### PR TITLE
Add panda_queryEntries rpc method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
-version = "0.6.3"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
+checksum = "7f200cbb1e856866d9eade941cf3aa0c5d7dd36f74311c4273b494f4ef036957"
 dependencies = [
  "getrandom 0.2.2",
  "once_cell",
@@ -154,19 +154,19 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+checksum = "fcb9af4888a70ad78ecb5efcb0ba95d66a3cf54a88b62ae81559954c7588c7a2"
 dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
  "libc",
  "log",
- "nb-connect",
  "once_cell",
  "parking",
  "polling",
+ "socket2 0.4.0",
  "vec-arena",
  "waker-fn",
  "winapi 0.3.9",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
 dependencies = [
  "event-listener",
 ]
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.1.8"
+version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c15b8ec3b5755a188c141c1f6a98e76de31b936209bf066b647979e2a84764a9"
+checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
 dependencies = [
  "nix",
  "winapi 0.3.9",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
+checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -732,6 +732,15 @@ name = "directories"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
 dependencies = [
  "dirs-sys",
 ]
@@ -1215,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1416,9 +1425,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.20.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
+checksum = "2f6332d94daa84478d55a6aa9dbb3b305ed6500fb0cb9400cb9e1525d0e0e188"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1566,16 +1575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19900e7eee95eb2b3c2e26d12a874cc80aaf750e31be6fcbe743ead369fa45d"
-dependencies = [
- "libc",
- "socket2 0.4.0",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,17 +1621,6 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg 1.0.1",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
@@ -1644,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d51546d704f52ef14b3c962b5776e53d5b862e5790e40a350d366c209bd7f7a"
+checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
 dependencies = [
  "autocfg 0.1.7",
  "byteorder",
@@ -1655,8 +1643,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.7.3",
- "serde",
+ "rand 0.8.3",
  "smallvec",
  "zeroize",
 ]
@@ -1689,6 +1676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
+ "libm",
 ]
 
 [[package]]
@@ -1728,7 +1716,7 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 [[package]]
 name = "p2panda-rs"
 version = "0.1.0"
-source = "git+https://github.com/p2panda/p2panda?branch=main#df79ec2db82e38979e0d50d9a9b07130e6e4e6a1"
+source = "git+https://github.com/p2panda/p2panda?branch=main#84a583eb58614e8c5ae76c80f2f04ee96db98713"
 dependencies = [
  "arrayvec",
  "bamboo-rs-core",
@@ -1791,7 +1779,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.6",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1815,18 +1803,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2059,9 +2047,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]
@@ -2111,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3648b669b10afeab18972c105e284a7b953a669b0be3514c27f9b17acab2f9cd"
+checksum = "68ef841a26fc5d040ced0417c6c6a64ee851f42489df11cdf0218e545b6f8d28"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -2123,11 +2111,9 @@ dependencies = [
  "num-iter",
  "num-traits",
  "pem",
- "rand 0.7.3",
- "sha2",
+ "rand 0.8.3",
  "simple_asn1",
  "subtle",
- "thiserror",
  "zeroize",
 ]
 
@@ -2315,13 +2301,14 @@ checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "simple_asn1"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
+checksum = "db8d597fce66eb0f19dd129b9956e4054cba21aeaf97d4116595027b670fac50"
 dependencies = [
  "chrono",
- "num-bigint 0.2.6",
+ "num-bigint",
  "num-traits",
+ "thiserror",
 ]
 
 [[package]]
@@ -2399,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2739d54a2ae9fdd0f545cb4e4b5574efb95e2ec71b7f921678e246fb20dcaaf"
+checksum = "d582b9bc04ec6c03084196efc42c2226b018e9941f03ee62bd88921d500917c0"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2409,11 +2396,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cad9cae4ca8947eba1a90e8ec7d3c59e7a768e2f120dc9013b669c34a90711"
+checksum = "de52d1d473cebb2abb79c886ef6a8023e965e34c0676a99cfeac2cc7f0fde4c1"
 dependencies = [
- "ahash 0.6.3",
+ "ahash 0.7.2",
  "atoi",
  "base64",
  "bitflags",
@@ -2424,6 +2411,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "digest 0.9.0",
+ "dirs",
  "either",
  "encoding_rs",
  "futures-channel",
@@ -2439,11 +2427,11 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "num-bigint 0.3.2",
+ "num-bigint",
  "once_cell",
  "parking_lot",
  "percent-encoding",
- "rand 0.7.3",
+ "rand 0.8.3",
  "regex",
  "rsa",
  "rustls",
@@ -2465,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01caee2b3935b4efe152f3262afbe51546ce3b1fc27ad61014e1b3cf5f55366e"
+checksum = "1a40f0be97e704d3fbf059e7e3333c3735639146a72d586c5534c70e79da88a4"
 dependencies = [
  "dotenv",
  "either",
@@ -2484,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.3.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce2e16b6774c671cc183e1d202386fdf9cde1e8468c1894a7f2a63eb671c4f4"
+checksum = "b6ae97ab05063ed515cdc23d90253213aa24dda0a288c5ec079af3d10f9771bc"
 dependencies = [
  "async-rustls",
  "async-std",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -30,7 +30,7 @@ openssl-probe = "0.1.2"
 rand = "0.8.3"
 serde = { version = "1.0.125", features = ["derive"] }
 sqlformat = "0.1.6"
-sqlx = { version = "0.5.1", features = ["runtime-async-std-rustls", "all-databases"] }
+sqlx = { version = "0.5.2", features = ["runtime-async-std-rustls", "all-databases"] }
 thiserror = "1.0.24"
 
 # @TODO: Change this as soon as `bamboo-rs` gets published

--- a/aquadoggo/src/db/models/entry.rs
+++ b/aquadoggo/src/db/models/entry.rs
@@ -118,17 +118,20 @@ impl Entry {
         let entries = query_as::<_, Entry>(
             "
             SELECT
-                author,
-                entry_bytes,
-                entry_hash,
-                log_id,
-                payload_bytes,
-                payload_hash,
-                seq_num
+                entries.author,
+                entries.entry_bytes,
+                entries.entry_hash,
+                entries.log_id,
+                entries.payload_bytes,
+                entries.payload_hash,
+                entries.seq_num
             FROM
                 entries
-            -- schema col does not exist yet
-            -- WHERE schema = ?1
+            INNER JOIN logs
+                ON (entries.log_id == logs.log_id
+                    AND entries.author == logs.author)
+            WHERE
+                logs.schema == ?1
             ",
         )
         .bind(schema)

--- a/aquadoggo/src/db/models/entry.rs
+++ b/aquadoggo/src/db/models/entry.rs
@@ -17,6 +17,7 @@ use crate::errors::Result;
 /// `author`, `payload_hash` etc. can be retrieved from `entry_bytes` but are separately stored in
 /// the database for faster querying.
 #[derive(FromRow, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Entry {
     /// Public key of the author.
     pub author: Author,

--- a/aquadoggo/src/rpc/methods/mod.rs
+++ b/aquadoggo/src/rpc/methods/mod.rs
@@ -1,5 +1,6 @@
 mod entry_args;
 mod publish_entry;
+mod query_entries;
 
 pub mod error {
     pub use super::publish_entry::PublishEntryError;
@@ -7,3 +8,4 @@ pub mod error {
 
 pub use entry_args::get_entry_args;
 pub use publish_entry::publish_entry;
+pub use query_entries::query_entries;

--- a/aquadoggo/src/rpc/methods/query_entries.rs
+++ b/aquadoggo/src/rpc/methods/query_entries.rs
@@ -1,0 +1,51 @@
+use crate::db::models::Entry;
+use crate::errors::Result;
+use crate::{
+    db::Pool,
+    rpc::{request::QueryEntriesRequest, response::QueryEntriesResponse},
+};
+
+pub async fn query_entries(
+    pool: Pool,
+    params: QueryEntriesRequest,
+) -> Result<QueryEntriesResponse> {
+    let entries = Entry::by_schema(&pool, &params.schema).await?;
+    Ok(QueryEntriesResponse { entries })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rpc::ApiService;
+    use crate::test_helpers::{initialize_db, rpc_request, rpc_response};
+    use p2panda_rs::atomic::Hash;
+
+    #[async_std::test]
+    async fn query_entries() {
+        // Prepare test database
+        let pool = initialize_db().await;
+        let io = ApiService::io_handler(pool);
+
+        let schema = Hash::new_from_bytes(vec![1, 2, 3]).unwrap();
+
+        // Prepare request to API
+        let request = rpc_request(
+            "panda_queryEntries",
+            &format!(
+                r#"{{
+                    "schema": "{}"
+                }}"#,
+                schema.as_hex(),
+            ),
+        );
+
+        // Prepare expected response result
+        let response = rpc_response(&format!(
+            r#"{{
+                "entries": []
+            }}"#,
+        ));
+
+        // Send request to API and compare response with expected result
+        assert_eq!(io.handle_request_sync(&request), Some(response));
+    }
+}

--- a/aquadoggo/src/rpc/request.rs
+++ b/aquadoggo/src/rpc/request.rs
@@ -16,3 +16,9 @@ pub struct PublishEntryRequest {
     pub entry_encoded: EntrySigned,
     pub message_encoded: MessageEncoded,
 }
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryEntriesRequest {
+    pub schema: Hash,
+}

--- a/aquadoggo/src/rpc/response.rs
+++ b/aquadoggo/src/rpc/response.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use crate::db::models::Entry;
 use p2panda_rs::atomic::{Hash, LogId, SeqNum};
 
 /// Response body of `panda_getEntryArguments`.
@@ -20,4 +21,10 @@ pub struct PublishEntryResponse {
     pub entry_hash_skiplink: Option<Hash>,
     pub last_seq_num: Option<SeqNum>,
     pub log_id: LogId,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryEntriesResponse {
+    pub entries: Vec<Entry>,
 }


### PR DESCRIPTION
This is very experimental of course

- provides an rpc method `panda_queryEntries` that returns all entry db records
- the return value follows the database layout quite closely to allow for experimentation in the frontend client while having access to all available db fields. Do we want to keep such an rpc method? Should entries be decoded before returning them? 

# Todo
- [x] Find a meaningful way to restrict querying all entries
~~Add test with a db fixture so that the test actually returns entries~~