### PR TITLE
Fix for breaking changes in p2panda-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,7 +1810,7 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 [[package]]
 name = "p2panda-rs"
 version = "0.1.0"
-source = "git+https://github.com/p2panda/p2panda?branch=main#84a583eb58614e8c5ae76c80f2f04ee96db98713"
+source = "git+https://github.com/p2panda/p2panda?branch=sam-refactor-entry#b7d659b290fff402df7a96bbcbefce1c3016b9b3"
 dependencies = [
  "arrayvec",
  "bamboo-rs-core",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -42,7 +42,7 @@ tag = "v0.1.0-pre-31"
 # crate via git. See: https://github.com/p2panda/p2panda/issues/38
 [dependencies.p2panda-rs]
 git = "https://github.com/p2panda/p2panda"
-branch = "main"
+branch = "sam-refactor-entry"
 features = ["db-sqlx"]
 
 [dev-dependencies]

--- a/aquadoggo/src/rpc/methods/entry_args.rs
+++ b/aquadoggo/src/rpc/methods/entry_args.rs
@@ -31,21 +31,21 @@ pub async fn get_entry_args(
     let entry_latest = Entry::latest(&pool, &params.author, &log_id).await?;
     
     match entry_latest {
-        Some(entry_backlink) => {
+        Some(mut entry_backlink) => {
             // Determine skiplink ("lipmaa"-link) entry in this log
             let entry_hash_skiplink = determine_skiplink(pool.clone(), &entry_backlink).await?;
 
             Ok(EntryArgsResponse {
                 entry_hash_backlink: Some(entry_backlink.entry_hash),
                 entry_hash_skiplink,
-                seq_num: entry_backlink.seq_num.next(),
+                seq_num: entry_backlink.seq_num.next().unwrap(),
                 log_id,
             })
         }
         None => Ok(EntryArgsResponse {
             entry_hash_backlink: None,
             entry_hash_skiplink: None,
-            seq_num: SeqNum::new(1),
+            seq_num: SeqNum::default(),
             log_id,
         }),
     }
@@ -130,8 +130,8 @@ mod tests {
             r#"{
                 "entryHashBacklink": null,
                 "entryHashSkiplink": null,
-                "lastSeqNum": null,
-                "logId": 1
+                "logId": 1,
+                "seqNum": 1
             }"#,
         );
 

--- a/aquadoggo/src/rpc/methods/entry_args.rs
+++ b/aquadoggo/src/rpc/methods/entry_args.rs
@@ -1,6 +1,6 @@
 use bamboo_rs_core::entry::is_lipmaa_required;
 use jsonrpc_v2::{Data, Params};
-use p2panda_rs::atomic::{Hash, Validation};
+use p2panda_rs::atomic::{Hash, SeqNum, Validation};
 
 use crate::db::models::{Entry, Log};
 use crate::db::Pool;
@@ -29,7 +29,7 @@ pub async fn get_entry_args(
 
     // Find latest entry in this log
     let entry_latest = Entry::latest(&pool, &params.author, &log_id).await?;
-
+    
     match entry_latest {
         Some(entry_backlink) => {
             // Determine skiplink ("lipmaa"-link) entry in this log
@@ -38,14 +38,14 @@ pub async fn get_entry_args(
             Ok(EntryArgsResponse {
                 entry_hash_backlink: Some(entry_backlink.entry_hash),
                 entry_hash_skiplink,
-                last_seq_num: Some(entry_backlink.seq_num),
+                seq_num: entry_backlink.seq_num.next(),
                 log_id,
             })
         }
         None => Ok(EntryArgsResponse {
             entry_hash_backlink: None,
             entry_hash_skiplink: None,
-            last_seq_num: None,
+            seq_num: SeqNum::new(1),
             log_id,
         }),
     }

--- a/aquadoggo/src/rpc/methods/publish_entry.rs
+++ b/aquadoggo/src/rpc/methods/publish_entry.rs
@@ -117,15 +117,17 @@ pub async fn publish_entry(
     .await?;
 
     // Already return arguments for next entry creation
-    let entry_latest = Entry::latest(&pool, &author, &entry.log_id())
+    let mut entry_latest = Entry::latest(&pool, &author, &entry.log_id())
         .await?
         .expect("Database does not contain any entries");
     let entry_hash_skiplink = super::entry_args::determine_skiplink(pool, &entry_latest).await?;
 
+    let next_seq_num = entry_latest.seq_num.next().unwrap();
+    
     Ok(PublishEntryResponse {
         entry_hash_backlink: Some(params.entry_encoded.hash()),
         entry_hash_skiplink,
-        seq_num: entry.seq_num().to_owned(),
+        seq_num: next_seq_num,
         log_id: entry.log_id().to_owned(),
     })
 }

--- a/aquadoggo/src/rpc/methods/publish_entry.rs
+++ b/aquadoggo/src/rpc/methods/publish_entry.rs
@@ -252,7 +252,7 @@ mod tests {
             &message_1,
             None,
             &log_id,
-            &SeqNum::new(1).unwrap(),
+            &SeqNum::new(2).unwrap(),
         )
         .await;
 
@@ -271,7 +271,7 @@ mod tests {
             &message_2,
             None,
             &log_id,
-            &SeqNum::new(2).unwrap(),
+            &SeqNum::new(3).unwrap(),
         )
         .await;
 
@@ -290,7 +290,7 @@ mod tests {
             &message_3,
             Some(&entry_1),
             &log_id,
-            &SeqNum::new(3).unwrap(),
+            &SeqNum::new(4).unwrap(),
         )
         .await;
 
@@ -310,7 +310,7 @@ mod tests {
             &message_4,
             None,
             &log_id,
-            &SeqNum::new(4).unwrap(),
+            &SeqNum::new(5).unwrap(),
         )
         .await;
 
@@ -330,7 +330,7 @@ mod tests {
             &message_5,
             None,
             &log_id,
-            &SeqNum::new(5).unwrap(),
+            &SeqNum::new(6).unwrap(),
         )
         .await;
     }
@@ -360,7 +360,7 @@ mod tests {
             &message_1,
             None,
             &log_id,
-            &SeqNum::new(1).unwrap(),
+            &SeqNum::new(2).unwrap(),
         )
         .await;
 
@@ -378,7 +378,7 @@ mod tests {
             &message_2,
             None,
             &log_id,
-            &SeqNum::new(2).unwrap(),
+            &SeqNum::new(3).unwrap(),
         )
         .await;
 

--- a/aquadoggo/src/rpc/methods/publish_entry.rs
+++ b/aquadoggo/src/rpc/methods/publish_entry.rs
@@ -125,7 +125,7 @@ pub async fn publish_entry(
     Ok(PublishEntryResponse {
         entry_hash_backlink: Some(params.entry_encoded.hash()),
         entry_hash_skiplink,
-        last_seq_num: Some(entry.seq_num().to_owned()),
+        seq_num: entry.seq_num().to_owned(),
         log_id: entry.log_id().to_owned(),
     })
 }
@@ -211,13 +211,13 @@ mod tests {
             r#"{{
                 "entryHashBacklink": "{}",
                 "entryHashSkiplink": {},
-                "lastSeqNum": {},
-                "logId": {}
+                "logId": {},
+                "seqNum": {}
             }}"#,
             entry_encoded.hash().as_hex(),
             skiplink_str,
-            seq_num.as_i64(),
             log_id.as_i64(),
+            seq_num.as_i64(),
         ));
 
         assert_eq!(handle_http(&app, request).await, response);

--- a/aquadoggo/src/rpc/response.rs
+++ b/aquadoggo/src/rpc/response.rs
@@ -9,7 +9,7 @@ use p2panda_rs::atomic::{Hash, LogId, SeqNum};
 pub struct EntryArgsResponse {
     pub entry_hash_backlink: Option<Hash>,
     pub entry_hash_skiplink: Option<Hash>,
-    pub last_seq_num: Option<SeqNum>,
+    pub seq_num: SeqNum,
     pub log_id: LogId,
 }
 
@@ -19,7 +19,7 @@ pub struct EntryArgsResponse {
 pub struct PublishEntryResponse {
     pub entry_hash_backlink: Option<Hash>,
     pub entry_hash_skiplink: Option<Hash>,
-    pub last_seq_num: Option<SeqNum>,
+    pub seq_num: SeqNum,
     pub log_id: LogId,
 }
 


### PR DESCRIPTION
Fixes for when we merge this: https://github.com/p2panda/p2panda/pull/62

- use new encoder module for signing and decoding entries
- SeqNum is no longer optional in Entry
- SeqNum is now current sequence number not previous in Entry
- Message in no longer optional in Entry