### PR TITLE
Event logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replace schema logs with document logs, changing the behavior the `nextEntryArgs` and `publishEntry` RPC methods, invalidating and deleting all previously published entries [#44](https://github.com/p2panda/aquadoggo/pull/44)
-- Rename `Message` to `Operation` everywhere [#48](https://github.com/p2panda/aquadoggo/pull/48)
-- Make JSON RPC methods compatible with new document logs flow [#47](https://github.com/p2panda/aquadoggo/pull/47)
-- Nicer looking `README.md` for crate [#42](https://github.com/p2panda/aquadoggo/42)
-- Support u64 integers [#54](https://github.com/p2panda/aquadoggo/pull/54)
+-   Replace schema logs with document logs, changing the behavior the `nextEntryArgs` and `publishEntry` RPC methods, invalidating and deleting all previously published entries [#44](https://github.com/p2panda/aquadoggo/pull/44)
+-   Rename `Message` to `Operation` everywhere [#48](https://github.com/p2panda/aquadoggo/pull/48)
+-   Make JSON RPC methods compatible with new document logs flow [#47](https://github.com/p2panda/aquadoggo/pull/47)
+-   Nicer looking `README.md` for crate [#42](https://github.com/p2panda/aquadoggo/42)
+-   Support u64 integers [#54](https://github.com/p2panda/aquadoggo/pull/54)
+-   Capture and print logs during tests [#62](https://github.com/p2panda/aquadoggo/pull/62)
 
 ## [0.1.0]
 
@@ -21,18 +22,18 @@ Released on 2021-10-25: :package: [`crate`](https://crates.io/crates/aquadoggo/0
 
 ### Added
 
-- `panda_queryEntries` RPC method [#23](https://github.com/p2panda/aquadoggo/pull/23)
-- Docker support [#22](https://github.com/p2panda/aquadoggo/pull/22)
-- `panda_publishEntry` RPC method [#21](https://github.com/p2panda/aquadoggo/pull/21)
-- `panda_getEntryArguments` RPC method [#11](https://github.com/p2panda/aquadoggo/pull/11)
-- SQL database persistence supporting PostgreSQL, MySQL and SQLite via `sqlx` [#9](https://github.com/p2panda/aquadoggo/pull/9)
-- Server configuration via environment variables [#7](https://github.com/p2panda/aquadoggo/pull/7)
-- JSON RPC HTTP and WebSocket API server via [#5](https://github.com/p2panda/aquadoggo/pull/5)
+-   `panda_queryEntries` RPC method [#23](https://github.com/p2panda/aquadoggo/pull/23)
+-   Docker support [#22](https://github.com/p2panda/aquadoggo/pull/22)
+-   `panda_publishEntry` RPC method [#21](https://github.com/p2panda/aquadoggo/pull/21)
+-   `panda_getEntryArguments` RPC method [#11](https://github.com/p2panda/aquadoggo/pull/11)
+-   SQL database persistence supporting PostgreSQL, MySQL and SQLite via `sqlx` [#9](https://github.com/p2panda/aquadoggo/pull/9)
+-   Server configuration via environment variables [#7](https://github.com/p2panda/aquadoggo/pull/7)
+-   JSON RPC HTTP and WebSocket API server via [#5](https://github.com/p2panda/aquadoggo/pull/5)
 
 ### Changed
 
-- Use p2panda-rs 0.2.1 with fixed linter setting [#41](https://github.com/p2panda/aquadoggo/41)
-- Use `tide` for HTTP server and `jsonrpc-v2` for JSON RPC [#29](https://github.com/p2panda/aquadoggo/29)
+-   Use p2panda-rs 0.2.1 with fixed linter setting [#41](https://github.com/p2panda/aquadoggo/41)
+-   Use `tide` for HTTP server and `jsonrpc-v2` for JSON RPC [#29](https://github.com/p2panda/aquadoggo/29)
 
-[Unreleased]: https://github.com/p2panda/aquadoggo/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/p2panda/aquadoggo/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/p2panda/aquadoggo/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "anyhow",
  "async-std",
  "bamboo-rs-core-ed25519-yasmf",
+ "ctor",
  "directories",
  "envy",
  "exit-future",
@@ -143,6 +144,7 @@ dependencies = [
  "log",
  "openssl-probe",
  "p2panda-rs",
+ "pretty_env_logger",
  "rand 0.8.4",
  "serde",
  "serde_json",
@@ -161,7 +163,7 @@ dependencies = [
  "aquadoggo",
  "async-ctrlc",
  "async-std",
- "env_logger",
+ "env_logger 0.9.0",
  "structopt",
 ]
 
@@ -1215,12 +1217,25 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -1746,6 +1761,15 @@ name = "httparse"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "humantime"
@@ -2407,6 +2431,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,6 +2478,12 @@ checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -44,3 +44,5 @@ tide-websockets = "0.4.0"
 
 [dev-dependencies]
 tide-testing = "0.1.3"
+ctor = "0.1.2"
+pretty_env_logger = "0.4"

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -25,3 +25,23 @@ mod test_helpers;
 
 pub use config::Configuration;
 pub use runtime::Runtime;
+
+/// Init pretty_env_logger before the test suite runs to handle logging outputs.
+///
+/// Several of our dependencies (`sqlx`, `p2panda_rs`, `tide`) emmit log messages
+/// which we can handle and print using `pretty_env_logger`. Logging ehaviour
+/// can be customised at runtime. With eg. `RUST_LOG=p2panda_rs=info cargo t` or
+/// `RUST_LOG=openmls=debug cargo t`.
+///
+/// The `ctor` crate is used to define a global constructor function. This method
+/// will be run before any of the test suites.
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+#[ctor::ctor]
+fn init() {
+    // If the `RUST_LOG` env var is not set skip initiation as we don't want
+    // to see any logs.
+    if std::env::var("RUST_LOG").is_ok() {
+        pretty_env_logger::init();
+    }
+}

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -31,7 +31,7 @@ pub use runtime::Runtime;
 /// Several of our dependencies (`sqlx`, `p2panda_rs`, `tide`) emmit log messages
 /// which we can handle and print using `pretty_env_logger`. Logging ehaviour
 /// can be customised at runtime. With eg. `RUST_LOG=p2panda_rs=info cargo t` or
-/// `RUST_LOG=openmls=debug cargo t`.
+/// `RUST_LOG=debug cargo t`.
 ///
 /// The `ctor` crate is used to define a global constructor function. This method
 /// will be run before any of the test suites.


### PR DESCRIPTION
Capture and print log messages emitted by our dependency libraries (`p2panda_rs`, `sqlx`, `tide` etc) during tests. Uses `pretty_env_logger`.

```bash
# print only p2panda info logs
RUST_LOG=p2panda_rs=info cargo t

# print all debug logs
RUST_LOG=debug cargo t
``` 

## 📋 Checklist

- [ ] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] ~Link this PR to any issues it closes~
- [ ] ~New files contain a SPDX license header~
