### PR TITLE
Dynamic GraphQL API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,10 +152,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
+name = "apollo-parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22f151e7fd55b164af009ae0e62893a40cf159ce73d23c11a6d708749030865"
+dependencies = [
+ "rowan",
+]
+
+[[package]]
 name = "aquadoggo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "apollo-parser",
  "async-graphql",
  "async-graphql-tide",
  "async-std",
@@ -171,6 +181,7 @@ dependencies = [
  "openssl-probe",
  "p2panda-rs",
  "rand 0.8.4",
+ "sea-query",
  "serde",
  "serde_json",
  "sqlformat",
@@ -1036,6 +1047,12 @@ dependencies = [
  "time 0.2.27",
  "version_check",
 ]
+
+[[package]]
+name = "countme"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328b822bdcba4d4e402be8d9adb6eebf269f969f8eadef977a553ff3c4fbcb58"
 
 [[package]]
 name = "cpufeatures"
@@ -3030,6 +3047,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56770675ebc04927ded3e60633437841581c285dc6236109ea25fbf3beb7b59e"
 
 [[package]]
+name = "rowan"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a938f42b9c73aeece236481f37adb3debb7dfe3ae347cd6a45b5797d9ce4250"
+dependencies = [
+ "countme",
+ "hashbrown",
+ "memoffset",
+ "rustc-hash",
+ "text-size",
+]
+
+[[package]]
 name = "rsa"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,6 +3107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3154,28 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sea-query"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83e4a0dd79545b61c6ca453a28d0a88829487869a8559a35a3192f1b6aacad8"
+dependencies = [
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cdc022b4f606353fe5dc85b09713a04e433323b70163e81513b141c6ae6eb5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
 ]
 
 [[package]]
@@ -3701,6 +3759,12 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288cb548dbe72b652243ea797201f3d481a0609a967980fcc5b2315ea811560a"
 
 [[package]]
 name = "textwrap"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.43"
+apollo-parser = "0.2.1"
 async-graphql = "3.0.25"
 async-graphql-tide = "3.0.25"
 async-std = { version = "1.10.0", features = ["attributes"] }
@@ -34,6 +35,7 @@ openssl-probe = "0.1.4"
 # @TODO: Move this back to crate as soon as upcoming changes have been published
 p2panda-rs = { git = "https://github.com/p2panda/p2panda", branch = "document" }
 rand = "0.8.4"
+sea-query = "0.20.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.67"
 sqlformat = "0.1.7"

--- a/aquadoggo/src/graphql/api.rs
+++ b/aquadoggo/src/graphql/api.rs
@@ -5,7 +5,7 @@ use async_graphql::{EmptyMutation, EmptySubscription, Schema};
 use tide::{http::mime, Body, Response, StatusCode};
 
 use crate::db::Pool;
-use crate::graphql::QueryRoot;
+use crate::graphql::{gql_to_sql, QueryRoot};
 use crate::server::{ApiRequest, ApiResult, ApiState};
 
 /// GraphQL Endpoint from `async_graphql` crate handling statically defined GraphQL queries.
@@ -56,7 +56,11 @@ impl tide::Endpoint<ApiState> for Endpoint {
     ///
     /// This handler resolves all incoming GraphQL requests and answers them both for dynamically
     /// and statically generated schemas.
-    async fn call(&self, request: ApiRequest) -> ApiResult {
+    async fn call(&self, mut request: ApiRequest) -> ApiResult {
+        let graphql_request = request.body_json::<async_graphql::Request>().await?;
+        let sql = gql_to_sql(&graphql_request.query).unwrap();
+        println!("{:?}", sql);
+
         // @TODO: Implement handling of dynamic GraphQL requests. Route all GraphQL requests to
         // static handler for now.
         self.static_endpoint.call(request).await

--- a/aquadoggo/src/graphql/api.rs
+++ b/aquadoggo/src/graphql/api.rs
@@ -5,7 +5,8 @@ use async_graphql::{EmptyMutation, EmptySubscription, Schema};
 use tide::{http::mime, Body, Response, StatusCode};
 
 use crate::db::Pool;
-use crate::graphql::{gql_to_sql, QueryRoot};
+use crate::graphql::convert::gql_to_sql;
+use crate::graphql::QueryRoot;
 use crate::server::{ApiRequest, ApiResult, ApiState};
 
 /// GraphQL Endpoint from `async_graphql` crate handling statically defined GraphQL queries.

--- a/aquadoggo/src/graphql/convert/mod.rs
+++ b/aquadoggo/src/graphql/convert/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+mod query;
+mod schema;
+mod sql;
+
+pub use query::{AbstractQuery, AbstractQueryError, Argument, Field, MetaField};
+pub use schema::{Schema, SchemaParseError};
+pub use sql::gql_to_sql;

--- a/aquadoggo/src/graphql/convert/mod.rs
+++ b/aquadoggo/src/graphql/convert/mod.rs
@@ -6,4 +6,39 @@ mod sql;
 
 pub use query::{AbstractQuery, AbstractQueryError, Argument, Field, MetaField};
 pub use schema::{Schema, SchemaParseError};
-pub use sql::gql_to_sql;
+pub use sql::query_to_sql;
+
+pub fn gql_to_sql(query: &str) -> anyhow::Result<String> {
+    // Convert GraphQL query to our own abstract query representation
+    let root = AbstractQuery::new(query)?;
+
+    // Convert to SQL query
+    let sql = query_to_sql(root).unwrap();
+
+    Ok(sql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gql_to_sql;
+
+    #[test]
+    fn parser() {
+        let query = "{
+            festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b(document: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\") {
+                document
+                fields {
+                    title
+                    description
+                }
+            }
+        }";
+
+        let sql = gql_to_sql(query).unwrap();
+
+        assert_eq!(
+            sql,
+            "SELECT \"title\", \"description\", \"document\" FROM \"festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b\" WHERE \"document\" = '0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543'"
+        );
+    }
+}

--- a/aquadoggo/src/graphql/convert/query.rs
+++ b/aquadoggo/src/graphql/convert/query.rs
@@ -383,13 +383,51 @@ mod tests {
     use super::AbstractQuery;
 
     #[test]
+    fn graphql_to_abstract() {
+        let query = "{
+            events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b(document: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\") {
+                document
+                fields {
+                    title
+                    content
+                    some_relation_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b {
+                        document
+                        fields {
+                            example
+                            url
+                            another_relation_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b {
+                                fields {
+                                    test
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }";
+        assert!(AbstractQuery::new(query).is_ok());
+    }
+
+    #[test]
+    fn invalid_schema() {
+        let query = "{ events { document } }";
+        assert!(AbstractQuery::new(query).is_err());
+
+        let query = "query {
+            events_ab46293111c48fc78b {
+                document
+            }
+        }";
+        assert!(AbstractQuery::new(query).is_err());
+    }
+
+    #[test]
     fn needs_shorthand_format() {
         let query = "query {
             events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b {
                 document
             }
         }";
-
         assert!(AbstractQuery::new(query).is_err());
 
         let query = "mutation {
@@ -397,7 +435,6 @@ mod tests {
                 document
             }
         }";
-
         assert!(AbstractQuery::new(query).is_err());
     }
 
@@ -411,7 +448,23 @@ mod tests {
                 }
             }
         }";
+        assert!(AbstractQuery::new(query).is_err());
+    }
 
+    #[test]
+    fn unsupported_alias_fields() {
+        let query = "{
+            alias: events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b {
+                document
+            }
+        }";
+        assert!(AbstractQuery::new(query).is_err());
+
+        let query = "{
+            events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b {
+                alias: document
+            }
+        }";
         assert!(AbstractQuery::new(query).is_err());
     }
 
@@ -422,7 +475,6 @@ mod tests {
                 document
             }
         }";
-
         assert!(AbstractQuery::new(query).is_err());
     }
 
@@ -434,7 +486,6 @@ mod tests {
                 random_meta_field
             }
         }";
-
         assert!(AbstractQuery::new(query).is_err());
 
         let query = "{
@@ -448,7 +499,6 @@ mod tests {
                 }
             }
         }";
-
         assert!(AbstractQuery::new(query).is_err());
     }
 
@@ -457,7 +507,6 @@ mod tests {
         let query = "{
             events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b {}
         }";
-
         assert!(AbstractQuery::new(query).is_err());
 
         let query = "{
@@ -465,7 +514,6 @@ mod tests {
                 fields {}
             }
         }";
-
         assert!(AbstractQuery::new(query).is_err());
 
         let query = "{
@@ -476,7 +524,6 @@ mod tests {
                 }
             }
         }";
-
         assert!(AbstractQuery::new(query).is_err());
     }
 }

--- a/aquadoggo/src/graphql/convert/query.rs
+++ b/aquadoggo/src/graphql/convert/query.rs
@@ -413,9 +413,12 @@ mod tests {
         let query = "{ events { document } }";
         assert!(AbstractQuery::new(query).is_err());
 
-        let query = "query {
-            events_ab46293111c48fc78b {
-                document
+        let query = "{ events_ab46293111c48fc78b { document } }";
+        assert!(AbstractQuery::new(query).is_err());
+
+        let query = "{
+            events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b {
+                document fields { invalid_relation_0020123 { document } }
             }
         }";
         assert!(AbstractQuery::new(query).is_err());

--- a/aquadoggo/src/graphql/convert/query.rs
+++ b/aquadoggo/src/graphql/convert/query.rs
@@ -5,6 +5,7 @@ use std::convert::TryInto;
 use apollo_parser::ast::{
     Argument as AstArgument, AstChildren, Definition, Document, Selection, Value,
 };
+use apollo_parser::Parser;
 use p2panda_rs::hash::Hash;
 use thiserror::Error;
 
@@ -263,8 +264,23 @@ impl AbstractQuery {
         Ok(arguments)
     }
 
-    /// Validates and converts an GraphQL document AST into an `AbstractQuery` instance which
-    /// represents a valid p2panda query to retreive document view data from the database.
+    /// Validates and converts a GraphQL query into an `AbstractQuery` instance.
+    ///
+    /// Abstract queries represent a valid p2panda query to retreive document-view data from the
+    /// database.
+    pub fn new(query: &str) -> Result<Self, AbstractQueryError> {
+        let parser = Parser::new(query);
+        let ast = parser.parse();
+
+        if ast.errors().len() > 0 {
+            // @TODO: Handle parsing errors
+            panic!("Parsing failed");
+        }
+
+        Self::new_from_document(ast.document())
+    }
+
+    /// Validates and converts a GraphQL document AST into an `AbstractQuery` instance.
     ///
     /// GraphQL is a fairly expressive query language and we do not need / support all of its
     /// features for p2panda queries: Directives, Variables, Mutations, Subscriptions, Alias Types

--- a/aquadoggo/src/graphql/convert/query.rs
+++ b/aquadoggo/src/graphql/convert/query.rs
@@ -2,47 +2,32 @@
 
 use std::convert::TryInto;
 
-use anyhow::Result;
 use apollo_parser::ast::{
     Argument as AstArgument, AstChildren, Definition, Document, Selection, Value,
 };
-use apollo_parser::Parser;
-use p2panda_rs::hash::{Hash, HASH_SIZE};
-use sea_query::{Alias, Expr, Query};
+use p2panda_rs::hash::Hash;
 use thiserror::Error;
 
-const MAX_SCHEMA_NAME: usize = 64;
-const SCHEMA_NAME_SEPARATOR: &str = "_";
-
-fn parse_graphql_query(query: &str) -> Result<Document> {
-    let parser = Parser::new(query);
-    let ast = parser.parse();
-
-    if ast.errors().len() > 0 {
-        panic!("Parsing failed");
-    }
-
-    Ok(ast.document())
-}
+use crate::graphql::convert::{Schema, SchemaParseError};
 
 type MetaFields = Option<Vec<MetaField>>;
 type Fields = Option<Vec<Field>>;
 type Arguments = Option<Vec<Argument>>;
 
 #[derive(Debug)]
-enum Argument {
+pub enum Argument {
     /// Filter document views by document hash.
     DocumentHash(Hash),
 }
 
 #[derive(Debug)]
-enum MetaField {
+pub enum MetaField {
     /// Hash of each document view.
     DocumentHash,
 }
 
 #[derive(Debug)]
-enum Field {
+pub enum Field {
     /// Name of the application data field to query.
     Name(String),
 
@@ -51,87 +36,22 @@ enum Field {
 }
 
 #[derive(Debug)]
-struct Relation {
+pub struct Relation {
     /// Schema hash of the related document view.
-    schema: Schema,
+    pub schema: Schema,
 
     /// Fields which give general information on the related document view.
-    meta_fields: MetaFields,
+    pub meta_fields: MetaFields,
 
     /// Materialized field values of the related document view.
-    fields: Fields,
-}
-
-/// Parsed reference of a schema.
-///
-/// As per specification a schema is referenced by its name and hash in a query.
-#[derive(Debug)]
-struct Schema {
-    /// Given name of this schema.
-    name: String,
-
-    /// Hash of the schema.
-    hash: Hash,
-}
-
-#[derive(Error, Debug)]
-#[allow(missing_copy_implementations)]
-pub enum ParseSchemaError {
-    #[error("Schema name is too long with {0} characters ({1} allowed)")]
-    TooLong(usize, usize),
-
-    #[error("Name and / or hash field is missing in string")]
-    MissingFields,
-
-    #[error(transparent)]
-    InvalidHash(#[from] p2panda_rs::hash::HashError),
-}
-
-impl Schema {
-    /// Parsing a schema string.
-    pub fn parse(str: &str) -> Result<Self, ParseSchemaError> {
-        // Allowed schema length is the maximum length of the schema name defined by the p2panda
-        // specification, the length of the separator and hash size times two because of its
-        // hexadecimal encoding.
-        let max_len = MAX_SCHEMA_NAME + SCHEMA_NAME_SEPARATOR.len() + (HASH_SIZE * 2);
-        if str.len() > max_len {
-            return Err(ParseSchemaError::TooLong(str.len(), max_len));
-        }
-
-        // Split the string by the separator and return the iterator in reversed form
-        let mut fields = str.rsplitn(2, SCHEMA_NAME_SEPARATOR);
-
-        // Since we start parsing the string from the back, we look at the hash first
-        let hash = fields
-            .next()
-            .ok_or(ParseSchemaError::MissingFields)?
-            .try_into()?;
-
-        // Finally parse the name of the given schema
-        let name = fields
-            .next()
-            .ok_or(ParseSchemaError::MissingFields)?
-            .to_string();
-
-        Ok(Self { name, hash })
-    }
-
-    /// Returns name of SQL table holding document views of this schema.
-    pub fn table_name(&self) -> String {
-        format!(
-            "{}{}{}",
-            self.name,
-            SCHEMA_NAME_SEPARATOR,
-            self.hash.as_str()
-        )
-    }
+    pub fields: Fields,
 }
 
 #[derive(Error, Debug)]
 #[allow(missing_copy_implementations)]
 pub enum AbstractQueryError {
     #[error(transparent)]
-    InvalidSchema(#[from] ParseSchemaError),
+    InvalidSchema(#[from] SchemaParseError),
 
     #[error("Query needs to contain a root operation definition")]
     OperationMissing,
@@ -174,18 +94,18 @@ pub enum AbstractQueryError {
 }
 
 #[derive(Debug)]
-struct AbstractQuery {
+pub struct AbstractQuery {
     /// Schema hash of the queried document view.
-    schema: Schema,
+    pub schema: Schema,
 
     /// Filter or sorting arguments which can be applied to the results.
-    arguments: Arguments,
+    pub arguments: Arguments,
 
     /// Fields which give general information on the given document view.
-    meta_fields: MetaFields,
+    pub meta_fields: MetaFields,
 
     /// Materialized field values of the document view.
-    fields: Fields,
+    pub fields: Fields,
 }
 
 impl AbstractQuery {
@@ -212,6 +132,7 @@ impl AbstractQuery {
                     let name = field
                         .name()
                         .ok_or(AbstractQueryError::ApplicationFieldInvalid)?
+                        .text()
                         .to_string();
 
                     match field.selection_set() {
@@ -268,10 +189,11 @@ impl AbstractQuery {
                     let name = field
                         .name()
                         .ok_or(AbstractQueryError::MetaFieldInvalid)?
+                        .text()
                         .to_string();
 
                     // No meta fields should have a selection set, except of "fields"
-                    if field.selection_set().is_some() && name.as_str() == "fields" {
+                    if field.selection_set().is_some() && name.as_str() != "fields" {
                         return Err(AbstractQueryError::MetaFieldInvalid);
                     }
 
@@ -314,6 +236,7 @@ impl AbstractQuery {
             let name = arg
                 .name()
                 .ok_or(AbstractQueryError::ArgumentInvalid)?
+                .text()
                 .to_string();
 
             // Expect arguments of known name and value type
@@ -428,135 +351,10 @@ impl AbstractQuery {
                     fields,
                 })
             } else {
-                return Err(AbstractQueryError::RootSelectionSetMissing);
+                Err(AbstractQueryError::RootSelectionSetMissing)
             }
         } else {
-            return Err(AbstractQueryError::OperationMissing);
+            Err(AbstractQueryError::OperationMissing)
         }
-    }
-}
-
-fn root_to_sql(root: AbstractQuery) -> Result<String> {
-    let mut query = Query::select();
-
-    if root.fields.is_some() {
-        for field in root.fields.unwrap() {
-            match field {
-                Field::Name(name) => {
-                    query.column(Alias::new(&name));
-                }
-                Field::Relation(_) => {
-                    panic!("Relations not supported yet");
-                }
-            }
-        }
-    }
-
-    if root.meta_fields.is_some() {
-        for meta in root.meta_fields.unwrap() {
-            match meta {
-                MetaField::DocumentHash => {
-                    query.column(Alias::new("document"));
-                }
-            }
-        }
-    }
-
-    query.from(Alias::new(&root.schema.table_name()));
-
-    if root.arguments.is_some() {
-        for arg in root.arguments.unwrap() {
-            match arg {
-                Argument::DocumentHash(value) => {
-                    query.and_where(Expr::col(Alias::new("document")).eq(value.as_str()));
-                }
-            }
-        }
-    }
-
-    let sql = query.to_string(sea_query::PostgresQueryBuilder);
-
-    Ok(sql)
-}
-
-pub fn gql_to_sql(query: &str) -> Result<String> {
-    // Parse GraphQL
-    let document = parse_graphql_query(query).unwrap();
-
-    // Convert GraphQL document to our own abstract query representation
-    let root = AbstractQuery::new_from_document(document)?;
-
-    // Convert to SQL query
-    let sql = root_to_sql(root).unwrap();
-
-    Ok(sql)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{gql_to_sql, Schema};
-
-    #[test]
-    fn parse_schema() {
-        let schema = Schema::parse(
-            "festivalevents_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
-        )
-        .unwrap();
-        assert_eq!(schema.name, "festivalevents");
-        assert_eq!(
-            schema.hash.as_str(),
-            "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
-        );
-
-        let schema = Schema::parse(
-            "mul_tiple_separators_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
-        )
-        .unwrap();
-        assert_eq!(schema.name, "mul_tiple_separators");
-        assert_eq!(
-            schema.hash.as_str(),
-            "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
-        );
-    }
-
-    #[test]
-    fn invalid_schema() {
-        // Missing name
-        assert!(Schema::parse("_0020c6f23dbdc3b5c7b9ab46293111c48fc78b").is_err());
-
-        // Invalid hash (wrong encoding)
-        assert!(Schema::parse("test_thisisnotahash").is_err());
-
-        // Separator missing
-        assert!(Schema::parse(
-            "withoutseparator0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
-        )
-        .is_err());
-
-        // Invalid hash (too short)
-        assert!(Schema::parse("invalid_hash_0020c6f23dbdc3b5c7b9ab46293111c48fc78b").is_err());
-
-        // Schema name exceeds limit
-        assert!(Schema::parse("too_long_name_with_many_characters_breaking_the_64_characters_limit_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b").is_err());
-    }
-
-    #[test]
-    fn parser() {
-        let query = "{
-            festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b(document: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\") {
-                document
-                fields {
-                    title
-                    description
-                }
-            }
-        }";
-
-        let sql = gql_to_sql(query).unwrap();
-
-        assert_eq!(
-            sql,
-            "SELECT \"title\", \"description\", \"document\" FROM \"festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b\" WHERE \"document\" = '0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543'"
-        );
     }
 }

--- a/aquadoggo/src/graphql/convert/schema.rs
+++ b/aquadoggo/src/graphql/convert/schema.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::convert::TryInto;
+
+use p2panda_rs::hash::{Hash, HASH_SIZE};
+use thiserror::Error;
+
+pub const MAX_SCHEMA_NAME: usize = 64;
+pub const SCHEMA_NAME_SEPARATOR: &str = "_";
+
+#[derive(Error, Debug)]
+#[allow(missing_copy_implementations)]
+pub enum SchemaParseError {
+    #[error("Schema name is too long with {0} characters ({1} allowed)")]
+    TooLong(usize, usize),
+
+    #[error("Name and / or hash field is missing in string")]
+    MissingFields,
+
+    #[error(transparent)]
+    InvalidHash(#[from] p2panda_rs::hash::HashError),
+}
+
+/// Parsed reference of a schema.
+///
+/// As per specification a schema is referenced by its name and hash in a query.
+#[derive(Debug)]
+pub struct Schema {
+    /// Given name of this schema.
+    name: String,
+
+    /// Hash of the schema.
+    hash: Hash,
+}
+
+impl Schema {
+    /// Parsing a schema string.
+    pub fn parse(str: &str) -> Result<Self, SchemaParseError> {
+        // Allowed schema length is the maximum length of the schema name defined by the p2panda
+        // specification, the length of the separator and hash size times two because of its
+        // hexadecimal encoding.
+        let max_len = MAX_SCHEMA_NAME + SCHEMA_NAME_SEPARATOR.len() + (HASH_SIZE * 2);
+        if str.len() > max_len {
+            return Err(SchemaParseError::TooLong(str.len(), max_len));
+        }
+
+        // Split the string by the separator and return the iterator in reversed form
+        let mut fields = str.rsplitn(2, SCHEMA_NAME_SEPARATOR);
+
+        // Since we start parsing the string from the back, we look at the hash first
+        let hash = fields
+            .next()
+            .ok_or(SchemaParseError::MissingFields)?
+            .try_into()?;
+
+        // Finally parse the name of the given schema
+        let name = fields
+            .next()
+            .ok_or(SchemaParseError::MissingFields)?
+            .to_string();
+
+        Ok(Self { name, hash })
+    }
+
+    /// Returns name of SQL table holding document views of this schema.
+    pub fn table_name(&self) -> String {
+        format!(
+            "{}{}{}",
+            self.name,
+            SCHEMA_NAME_SEPARATOR,
+            self.hash.as_str()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Schema;
+
+    #[test]
+    fn parse_schema() {
+        let schema = Schema::parse(
+            "festivalevents_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
+        )
+        .unwrap();
+        assert_eq!(schema.name, "festivalevents");
+        assert_eq!(
+            schema.hash.as_str(),
+            "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
+        );
+
+        let schema = Schema::parse(
+            "mul_tiple_separators_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b",
+        )
+        .unwrap();
+        assert_eq!(schema.name, "mul_tiple_separators");
+        assert_eq!(
+            schema.hash.as_str(),
+            "0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
+        );
+    }
+
+    #[test]
+    fn invalid_schema() {
+        // Missing name
+        assert!(Schema::parse("_0020c6f23dbdc3b5c7b9ab46293111c48fc78b").is_err());
+
+        // Invalid hash (wrong encoding)
+        assert!(Schema::parse("test_thisisnotahash").is_err());
+
+        // Separator missing
+        assert!(Schema::parse(
+            "withoutseparator0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
+        )
+        .is_err());
+
+        // Invalid hash (too short)
+        assert!(Schema::parse("invalid_hash_0020c6f23dbdc3b5c7b9ab46293111c48fc78b").is_err());
+
+        // Schema name exceeds limit
+        assert!(Schema::parse("too_long_name_with_many_characters_breaking_the_64_characters_limit_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b").is_err());
+    }
+}

--- a/aquadoggo/src/graphql/convert/sql.rs
+++ b/aquadoggo/src/graphql/convert/sql.rs
@@ -1,24 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use anyhow::Result;
-use apollo_parser::ast::Document;
-use apollo_parser::Parser;
 use sea_query::{Alias, Expr, Query};
 
 use crate::graphql::convert::{AbstractQuery, Argument, Field, MetaField};
 
-fn parse_graphql_query(query: &str) -> Result<Document> {
-    let parser = Parser::new(query);
-    let ast = parser.parse();
-
-    if ast.errors().len() > 0 {
-        panic!("Parsing failed");
-    }
-
-    Ok(ast.document())
-}
-
-fn query_to_sql(root: AbstractQuery) -> Result<String> {
+pub fn query_to_sql(root: AbstractQuery) -> Result<String> {
     let mut query = Query::select();
 
     if root.fields.is_some() {
@@ -59,42 +46,4 @@ fn query_to_sql(root: AbstractQuery) -> Result<String> {
     let sql = query.to_string(sea_query::PostgresQueryBuilder);
 
     Ok(sql)
-}
-
-pub fn gql_to_sql(query: &str) -> Result<String> {
-    // Parse GraphQL
-    let document = parse_graphql_query(query).unwrap();
-
-    // Convert GraphQL document to our own abstract query representation
-    let root = AbstractQuery::new_from_document(document)?;
-
-    // Convert to SQL query
-    let sql = query_to_sql(root).unwrap();
-
-    Ok(sql)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::gql_to_sql;
-
-    #[test]
-    fn parser() {
-        let query = "{
-            festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b(document: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\") {
-                document
-                fields {
-                    title
-                    description
-                }
-            }
-        }";
-
-        let sql = gql_to_sql(query).unwrap();
-
-        assert_eq!(
-            sql,
-            "SELECT \"title\", \"description\", \"document\" FROM \"festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b\" WHERE \"document\" = '0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543'"
-        );
-    }
 }

--- a/aquadoggo/src/graphql/convert/sql.rs
+++ b/aquadoggo/src/graphql/convert/sql.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use anyhow::Result;
+use apollo_parser::ast::Document;
+use apollo_parser::Parser;
+use sea_query::{Alias, Expr, Query};
+
+use crate::graphql::convert::{AbstractQuery, Argument, Field, MetaField};
+
+fn parse_graphql_query(query: &str) -> Result<Document> {
+    let parser = Parser::new(query);
+    let ast = parser.parse();
+
+    if ast.errors().len() > 0 {
+        panic!("Parsing failed");
+    }
+
+    Ok(ast.document())
+}
+
+fn query_to_sql(root: AbstractQuery) -> Result<String> {
+    let mut query = Query::select();
+
+    if root.fields.is_some() {
+        for field in root.fields.unwrap() {
+            match field {
+                Field::Name(name) => {
+                    query.column(Alias::new(&name));
+                }
+                Field::Relation(_) => {
+                    panic!("Relations not supported yet");
+                }
+            }
+        }
+    }
+
+    if root.meta_fields.is_some() {
+        for meta in root.meta_fields.unwrap() {
+            match meta {
+                MetaField::DocumentHash => {
+                    query.column(Alias::new("document"));
+                }
+            }
+        }
+    }
+
+    query.from(Alias::new(&root.schema.table_name()));
+
+    if root.arguments.is_some() {
+        for arg in root.arguments.unwrap() {
+            match arg {
+                Argument::DocumentHash(value) => {
+                    query.and_where(Expr::col(Alias::new("document")).eq(value.as_str()));
+                }
+            }
+        }
+    }
+
+    let sql = query.to_string(sea_query::PostgresQueryBuilder);
+
+    Ok(sql)
+}
+
+pub fn gql_to_sql(query: &str) -> Result<String> {
+    // Parse GraphQL
+    let document = parse_graphql_query(query).unwrap();
+
+    // Convert GraphQL document to our own abstract query representation
+    let root = AbstractQuery::new_from_document(document)?;
+
+    // Convert to SQL query
+    let sql = query_to_sql(root).unwrap();
+
+    Ok(sql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gql_to_sql;
+
+    #[test]
+    fn parser() {
+        let query = "{
+            festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b(document: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\") {
+                document
+                fields {
+                    title
+                    description
+                }
+            }
+        }";
+
+        let sql = gql_to_sql(query).unwrap();
+
+        assert_eq!(
+            sql,
+            "SELECT \"title\", \"description\", \"document\" FROM \"festival_events_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b\" WHERE \"document\" = '0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543'"
+        );
+    }
+}

--- a/aquadoggo/src/graphql/mod.rs
+++ b/aquadoggo/src/graphql/mod.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 mod api;
+mod convert;
 mod query;
-mod sql;
 
 pub use api::{Endpoint, StaticSchema};
 pub use query::QueryRoot;
-pub use sql::gql_to_sql;

--- a/aquadoggo/src/graphql/mod.rs
+++ b/aquadoggo/src/graphql/mod.rs
@@ -2,6 +2,8 @@
 
 mod api;
 mod query;
+mod sql;
 
 pub use api::{Endpoint, StaticSchema};
 pub use query::QueryRoot;
+pub use sql::gql_to_sql;

--- a/aquadoggo/src/graphql/sql.rs
+++ b/aquadoggo/src/graphql/sql.rs
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use apollo_parser::ast::{Argument as AstArgument, AstChildren, Definition, Document, Selection};
+use apollo_parser::Parser;
+use sea_query::{Alias, Query};
+
+use crate::errors::Result;
+
+#[derive(Debug)]
+struct Root {
+    /// Schema hash of the queried document view.
+    schema: String,
+
+    /// Filter or sorting arguments which can be applied to the results.
+    arguments: Option<Vec<Argument>>,
+
+    /// Fields which give general information on the given document view.
+    meta_fields: Option<Vec<MetaField>>,
+
+    /// Materialized field values of the document view.
+    fields: Option<Vec<Field>>,
+}
+
+#[derive(Debug)]
+enum Argument {
+    /// Filter document views by document hash.
+    DocumentHash(String),
+}
+
+#[derive(Debug)]
+enum MetaField {
+    /// Hash of each document view.
+    DocumentHash,
+}
+
+#[derive(Debug)]
+enum Field {
+    /// Materialized value of document view.
+    Value(String),
+
+    /// Values of another related document view.
+    Relation(Relation),
+}
+
+#[derive(Debug)]
+struct Relation {
+    /// Schema hash of the related document view.
+    schema: String,
+
+    /// Fields which give general information on the related document view.
+    meta_fields: Option<Vec<MetaField>>,
+
+    /// Materialized field values of the related document view.
+    fields: Option<Vec<Field>>,
+}
+
+fn parse_graphql_query(query: &str) -> Result<Document> {
+    let parser = Parser::new(query);
+    let ast = parser.parse();
+
+    if ast.errors().len() > 0 {
+        panic!("Parsing failed");
+    }
+
+    let document = ast.document();
+
+    Ok(document)
+}
+
+fn get_fields(selection_set: AstChildren<Selection>) -> Result<Vec<Field>> {
+    let mut fields = Vec::<Field>::new();
+
+    for selection in selection_set {
+        match selection {
+            Selection::Field(field) => {
+                let name = field.name().expect("Needs a name").text().to_string();
+
+                match field.selection_set() {
+                    Some(set) => {
+                        let (meta_fields, relation_fields) =
+                            get_meta_fields(set.selections()).unwrap();
+
+                        fields.push(Field::Relation(Relation {
+                            schema: name,
+                            meta_fields,
+                            fields: relation_fields,
+                        }));
+                    }
+                    None => {
+                        fields.push(Field::Value(name));
+                    }
+                };
+            }
+            _ => panic!("Needs a field"),
+        };
+    }
+
+    Ok(fields)
+}
+
+fn get_meta_fields(
+    selection_set: AstChildren<Selection>,
+) -> Result<(Option<Vec<MetaField>>, Option<Vec<Field>>)> {
+    let mut meta = Vec::<MetaField>::new();
+    let mut fields = None;
+
+    for selection in selection_set {
+        match selection {
+            Selection::Field(field) => {
+                let name = field.name().expect("Needs a name").text().to_string();
+
+                match name.as_str() {
+                    "fields" => {
+                        let set = field.selection_set().expect("Needs selection set");
+                        fields = Some(get_fields(set.selections()).unwrap());
+                    }
+                    "document" => {
+                        meta.push(MetaField::DocumentHash);
+                    }
+                    _ => panic!("Unknown meta field"),
+                };
+            }
+            _ => panic!("Needs a field"),
+        };
+    }
+
+    let meta_option = if meta.is_empty() { None } else { Some(meta) };
+
+    Ok((meta_option, fields))
+}
+
+fn get_root(document: Document) -> Result<Root> {
+    let definition = document
+        .definitions()
+        .nth(0)
+        .expect("Needs to contain at least one definition");
+
+    if let Definition::OperationDefinition(op_def) = definition {
+        let selection = op_def
+            .selection_set()
+            .expect("Needs to have a selection set")
+            .selections()
+            .nth(0)
+            .expect("Needs to have one selection");
+
+        println!("{:?}", selection);
+        if let Selection::Field(field) = selection {
+            let schema = field
+                .name()
+                .expect("Needs to have a name")
+                .text()
+                .to_string();
+
+            let arguments = match field.arguments() {
+                Some(args) => Some(get_arguments(args.arguments()).unwrap()),
+                None => None,
+            };
+
+            let (meta_fields, fields) = get_meta_fields(
+                field
+                    .selection_set()
+                    .expect("Needs to have a selection set")
+                    .selections(),
+            )
+            .unwrap();
+
+            return Ok(Root {
+                schema,
+                meta_fields,
+                arguments,
+                fields,
+            });
+        } else {
+            panic!("Needs to be a field");
+        }
+    } else {
+        panic!("Needs to be an operation definition");
+    }
+}
+
+fn get_arguments(args: AstChildren<AstArgument>) -> Result<Vec<Argument>> {
+    let mut arguments = Vec::<Argument>::new();
+
+    for arg in args {
+        let name = arg.name().expect("Needs a name").to_string();
+        let value = arg.value().expect("Needs a value").to_string();
+
+        let arg_value = match name.as_str() {
+            "document" => Argument::DocumentHash(value),
+            _ => panic!("Unknown argument"),
+        };
+
+        arguments.push(arg_value);
+    }
+
+    Ok(arguments)
+}
+
+pub fn gql_to_sql(query: &str) -> Result<String> {
+    let document = parse_graphql_query(query).unwrap();
+
+    let root = get_root(document).unwrap();
+
+    let mut query = Query::select();
+
+    if root.fields.is_some() {
+        for field in root.fields.unwrap() {
+            if let Field::Value(name) = field {
+                query.column(Alias::new(&name));
+            } else {
+                panic!("Relations not supported yet");
+            }
+        }
+    }
+
+    if root.meta_fields.is_some() {
+        for meta in root.meta_fields.unwrap() {
+            match meta {
+                MetaField::DocumentHash => {
+                    query.column(Alias::new("document"));
+                }
+            }
+        }
+    }
+
+    let sql = query
+        .from(Alias::new(&root.schema))
+        .to_string(sea_query::PostgresQueryBuilder);
+
+    Ok(sql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gql_to_sql;
+
+    #[test]
+    fn parser() {
+        let query = "{
+            festivalEvents(document: \"0x12\") {
+                document
+                fields {
+                    title
+                    description
+                }
+            }
+        }";
+
+        let sql = gql_to_sql(query).unwrap();
+
+        assert_eq!(
+            sql,
+            "SELECT \"title\", \"description\", \"document\" FROM \"festivalEvents\""
+        );
+    }
+}

--- a/aquadoggo/src/graphql/sql.rs
+++ b/aquadoggo/src/graphql/sql.rs
@@ -1,30 +1,40 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use apollo_parser::ast::{Argument as AstArgument, AstChildren, Definition, Document, Selection};
+use std::convert::TryInto;
+
+use apollo_parser::ast::{
+    Argument as AstArgument, AstChildren, Definition, Document, Selection, Value,
+};
 use apollo_parser::Parser;
+use p2panda_rs::hash::{Hash, HASH_SIZE};
 use sea_query::{Alias, Expr, Query};
 
 use crate::errors::Result;
 
-#[derive(Debug)]
-struct Root {
-    /// Schema hash of the queried document view.
-    schema: String,
+const MAX_SCHEMA_NAME: usize = 64;
+const SCHEMA_NAME_SEPARATOR: &str = "_";
 
-    /// Filter or sorting arguments which can be applied to the results.
-    arguments: Option<Vec<Argument>>,
+fn parse_graphql_query(query: &str) -> Result<Document> {
+    let parser = Parser::new(query);
+    let ast = parser.parse();
 
-    /// Fields which give general information on the given document view.
-    meta_fields: Option<Vec<MetaField>>,
+    if ast.errors().len() > 0 {
+        panic!("Parsing failed");
+    }
 
-    /// Materialized field values of the document view.
-    fields: Option<Vec<Field>>,
+    let document = ast.document();
+
+    Ok(document)
 }
+
+type MetaFields = Option<Vec<MetaField>>;
+type Fields = Option<Vec<Field>>;
+type Arguments = Option<Vec<Argument>>;
 
 #[derive(Debug)]
 enum Argument {
     /// Filter document views by document hash.
-    DocumentHash(String),
+    DocumentHash(Hash),
 }
 
 #[derive(Debug)]
@@ -45,7 +55,7 @@ enum Field {
 #[derive(Debug)]
 struct Relation {
     /// Schema hash of the related document view.
-    schema: String,
+    schema: Schema,
 
     /// Fields which give general information on the related document view.
     meta_fields: Option<Vec<MetaField>>,
@@ -54,166 +64,214 @@ struct Relation {
     fields: Option<Vec<Field>>,
 }
 
-fn parse_graphql_query(query: &str) -> Result<Document> {
-    let parser = Parser::new(query);
-    let ast = parser.parse();
+#[derive(Debug)]
+struct Schema {
+    /// Given name of this schema.
+    name: String,
 
-    if ast.errors().len() > 0 {
-        panic!("Parsing failed");
-    }
-
-    let document = ast.document();
-
-    Ok(document)
+    /// Hash of the schema.
+    hash: Hash,
 }
 
-fn get_fields(selection_set: AstChildren<Selection>) -> Result<Vec<Field>> {
-    let mut fields = Vec::<Field>::new();
+impl Schema {
+    pub fn parse(str: &str) -> Result<Self> {
+        if str.len() > MAX_SCHEMA_NAME + SCHEMA_NAME_SEPARATOR.len() + (HASH_SIZE * 2) {
+            panic!("Too long");
+        }
 
-    for selection in selection_set {
-        match selection {
-            Selection::Field(field) => {
-                let name = field.name().expect("Needs a name").text().to_string();
+        let mut separated = str.split(SCHEMA_NAME_SEPARATOR);
 
-                match field.selection_set() {
-                    Some(set) => {
-                        let (meta_fields, relation_fields) =
-                            get_meta_fields(set.selections()).unwrap();
+        let name = separated.next().expect("Could not parse name").into();
 
-                        fields.push(Field::Relation(Relation {
-                            schema: name,
-                            meta_fields,
-                            fields: relation_fields,
-                        }));
-                    }
-                    None => {
-                        fields.push(Field::Value(name));
-                    }
-                };
-            }
-            _ => panic!("Needs a field"),
-        };
+        let hash = separated
+            .next()
+            .expect("Could not parse hash")
+            .try_into()
+            .expect("Invalid hash");
+
+        Ok(Self { name, hash })
     }
 
-    Ok(fields)
+    pub fn table_name(&self) -> String {
+        format!(
+            "{}{}{}",
+            self.name,
+            SCHEMA_NAME_SEPARATOR,
+            self.hash.as_str()
+        )
+    }
 }
 
-fn get_meta_fields(
-    selection_set: AstChildren<Selection>,
-) -> Result<(Option<Vec<MetaField>>, Option<Vec<Field>>)> {
-    let mut meta = Vec::<MetaField>::new();
-    let mut fields = None;
+#[derive(Debug)]
+struct AbstractQuery {
+    /// Schema hash of the queried document view.
+    schema: Schema,
 
-    for selection in selection_set {
-        match selection {
-            Selection::Field(field) => {
-                let name = field.name().expect("Needs a name").text().to_string();
+    /// Filter or sorting arguments which can be applied to the results.
+    arguments: Arguments,
 
-                match name.as_str() {
-                    "fields" => {
-                        let set = field.selection_set().expect("Needs selection set");
-                        fields = Some(get_fields(set.selections()).unwrap());
-                    }
-                    "document" => {
-                        meta.push(MetaField::DocumentHash);
-                    }
-                    _ => panic!("Unknown meta field"),
-                };
-            }
-            _ => panic!("Needs a field"),
-        };
+    /// Fields which give general information on the given document view.
+    meta_fields: MetaFields,
+
+    /// Materialized field values of the document view.
+    fields: Fields,
+}
+
+impl AbstractQuery {
+    fn get_fields(selection_set: AstChildren<Selection>) -> Result<Vec<Field>> {
+        let mut fields = Vec::<Field>::new();
+
+        for selection in selection_set {
+            match selection {
+                Selection::Field(field) => {
+                    let field_name = field.name().expect("Needs a name").text().to_string();
+
+                    match field.selection_set() {
+                        Some(set) => {
+                            let (meta_fields, relation_fields) =
+                                Self::get_meta_fields(set.selections()).unwrap();
+
+                            fields.push(Field::Relation(Relation {
+                                schema: Schema::parse(&field_name).expect("Invalid schema"),
+                                meta_fields,
+                                fields: relation_fields,
+                            }));
+                        }
+                        None => {
+                            fields.push(Field::Value(field_name));
+                        }
+                    };
+                }
+                _ => panic!("Needs a field"),
+            };
+        }
+
+        Ok(fields)
     }
 
-    let meta_option = if meta.is_empty() { None } else { Some(meta) };
+    fn get_meta_fields(selection_set: AstChildren<Selection>) -> Result<(MetaFields, Fields)> {
+        let mut meta = Vec::<MetaField>::new();
+        let mut fields = None;
 
-    Ok((meta_option, fields))
-}
+        for selection in selection_set {
+            match selection {
+                Selection::Field(field) => {
+                    let name = field.name().expect("Needs a name").text().to_string();
 
-fn get_root(document: Document) -> Result<Root> {
-    let definition = document
-        .definitions()
-        .nth(0)
-        .expect("Needs to contain at least one definition");
+                    match name.as_str() {
+                        "fields" => {
+                            let set = field.selection_set().expect("Needs selection set");
+                            fields = Some(Self::get_fields(set.selections()).unwrap());
+                        }
+                        "document" => {
+                            meta.push(MetaField::DocumentHash);
+                        }
+                        _ => panic!("Unknown meta field"),
+                    };
+                }
+                _ => panic!("Needs a field"),
+            };
+        }
 
-    if let Definition::OperationDefinition(op_def) = definition {
-        let selection = op_def
-            .selection_set()
-            .expect("Needs to have a selection set")
-            .selections()
-            .nth(0)
-            .expect("Needs to have one selection");
+        let meta_option = if meta.is_empty() { None } else { Some(meta) };
 
-        if let Selection::Field(field) = selection {
-            let schema = field
-                .name()
-                .expect("Needs to have a name")
-                .text()
-                .to_string();
+        Ok((meta_option, fields))
+    }
 
-            let arguments = match field.arguments() {
-                Some(args) => Some(get_arguments(args.arguments()).unwrap()),
-                None => None,
+    fn get_arguments(args: AstChildren<AstArgument>) -> Result<Vec<Argument>> {
+        let mut arguments = Vec::<Argument>::new();
+
+        for arg in args {
+            let name = arg.name().expect("Needs a name").to_string();
+            let value = arg.value().expect("Needs a value");
+
+            let arg_value = match name.as_str() {
+                "document" => match value {
+                    Value::StringValue(str_value) => {
+                        let str: String = str_value.into();
+                        let hash = str.try_into().expect("Invalid hash");
+                        Argument::DocumentHash(hash)
+                    }
+                    _ => {
+                        panic!("Expected string");
+                    }
+                },
+                _ => panic!("Unknown argument"),
             };
 
-            let (meta_fields, fields) = get_meta_fields(
-                field
+            arguments.push(arg_value);
+        }
+
+        Ok(arguments)
+    }
+
+    pub fn new_from_query(query: &str) -> Result<Self> {
+        let document = parse_graphql_query(query).unwrap();
+        let root = Self::new_from_document(document).unwrap();
+        Ok(root)
+    }
+
+    pub fn new_from_document(document: Document) -> Result<Self> {
+        let definition = document
+            .definitions()
+            .next()
+            .expect("Needs to contain at least one definition");
+
+        if let Definition::OperationDefinition(op_def) = definition {
+            let selection = op_def
+                .selection_set()
+                .expect("Needs to have a selection set")
+                .selections()
+                .next()
+                .expect("Needs to have one selection");
+
+            if let Selection::Field(field) = selection {
+                let schema = field
+                    .name()
+                    .expect("Needs to have a name")
+                    .text()
+                    .to_string();
+
+                let arguments = field
+                    .arguments()
+                    .map(|args| Self::get_arguments(args.arguments()).unwrap());
+
+                let selections = field
                     .selection_set()
                     .expect("Needs to have a selection set")
-                    .selections(),
-            )
-            .unwrap();
+                    .selections();
 
-            return Ok(Root {
-                schema,
-                meta_fields,
-                arguments,
-                fields,
-            });
+                let (meta_fields, fields) = Self::get_meta_fields(selections).unwrap();
+
+                let schema = Schema::parse(&schema).expect("Invalid schema");
+
+                Ok(Self {
+                    schema,
+                    meta_fields,
+                    arguments,
+                    fields,
+                })
+            } else {
+                panic!("Needs to be a field");
+            }
         } else {
-            panic!("Needs to be a field");
+            panic!("Needs to be an operation definition");
         }
-    } else {
-        panic!("Needs to be an operation definition");
     }
 }
 
-fn get_arguments(args: AstChildren<AstArgument>) -> Result<Vec<Argument>> {
-    let mut arguments = Vec::<Argument>::new();
-
-    for arg in args {
-        let name = arg.name().expect("Needs a name").to_string();
-        let value = arg.value().expect("Needs a value").to_string();
-
-        let arg_value = match name.as_str() {
-            "document" => Argument::DocumentHash(value),
-            _ => panic!("Unknown argument"),
-        };
-
-        arguments.push(arg_value);
-    }
-
-    Ok(arguments)
-}
-
-fn parse(query: &str) -> Result<Root> {
-    let document = parse_graphql_query(query).unwrap();
-    let root = get_root(document).unwrap();
-    Ok(root)
-}
-
-fn validate(root: &Root, schema: u64) -> Result<()> {
-    Ok(())
-}
-
-fn root_to_sql(root: Root) -> Result<String> {
+fn root_to_sql(root: AbstractQuery) -> Result<String> {
     let mut query = Query::select();
 
     if root.fields.is_some() {
         for field in root.fields.unwrap() {
-            if let Field::Value(name) = field {
-                query.column(Alias::new(&name));
-            } else {
-                panic!("Relations not supported yet");
+            match field {
+                Field::Value(name) => {
+                    query.column(Alias::new(&name));
+                }
+                Field::Relation(_) => {
+                    panic!("Relations not supported yet");
+                }
             }
         }
     }
@@ -228,32 +286,26 @@ fn root_to_sql(root: Root) -> Result<String> {
         }
     }
 
+    query.from(Alias::new(&root.schema.table_name()));
+
     if root.arguments.is_some() {
         for arg in root.arguments.unwrap() {
             match arg {
                 Argument::DocumentHash(value) => {
-                    query.and_where(Expr::col(Alias::new("document")).eq(value));
+                    query.and_where(Expr::col(Alias::new("document")).eq(value.as_str()));
                 }
             }
         }
     }
 
-    let sql = query
-        .from(Alias::new(&root.schema))
-        .to_string(sea_query::PostgresQueryBuilder);
+    let sql = query.to_string(sea_query::PostgresQueryBuilder);
 
     Ok(sql)
 }
 
 pub fn gql_to_sql(query: &str) -> Result<String> {
-    // @TODO: We will pass in the schema later ..
-    let schema = 123;
-
     // Parse GraphQL to our own abstract query representation
-    let root = parse(query).unwrap();
-
-    // Validate query with application schema
-    validate(&root, schema).unwrap();
+    let root = AbstractQuery::new_from_query(query).unwrap();
 
     // Convert to SQL query
     let sql = root_to_sql(root).unwrap();
@@ -268,7 +320,7 @@ mod tests {
     #[test]
     fn parser() {
         let query = "{
-            festivalEvents(document: ABC123) {
+            festivalevents_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b(document: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\") {
                 document
                 fields {
                     title
@@ -281,7 +333,7 @@ mod tests {
 
         assert_eq!(
             sql,
-            "SELECT \"title\", \"description\", \"document\" FROM \"festivalEvents\" WHERE \"document\" = 'ABC123'"
+            "SELECT \"title\", \"description\", \"document\" FROM \"festivalevents_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b\" WHERE \"document\" = '0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543'"
         );
     }
 }

--- a/aquadoggo/src/rpc/methods/query_entries.rs
+++ b/aquadoggo/src/rpc/methods/query_entries.rs
@@ -28,7 +28,7 @@ pub async fn query_entries(
 mod tests {
     use p2panda_rs::hash::Hash;
 
-    use crate::server::{ApiState, build_server};
+    use crate::server::{build_server, ApiState};
     use crate::test_helpers::{handle_http, initialize_db, rpc_request, rpc_response};
 
     #[async_std::test]


### PR DESCRIPTION
This will be split into several PRs:

- [x] Parse GraphQL into abstract query representation
- [x] Convert abstract query representation into SELECT SQL query
  - [x] Filter by document hash
  - [ ] Sort ASC or DESC by any application data field
  - [ ] Get relation schema name + hash from application schema
  - [ ] JOINS for relation fields
    - [ ] Validate maximum depth
- [ ] Validate abstract query with registered Schema
- [ ] Run SQL query and return results in GraphQL response
- [ ] Handle errors correctly
  - [ ] Return them nicely in GraphQL API
- [ ] Support introspection

Closes: https://github.com/p2panda/aquadoggo/issues/64

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
