### PR TITLE
Introduce GraphQL endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduce GraphQL endpoint [#81](https://github.com/p2panda/aquadoggo/pull/81)
+
+### Changed
+
+- Move to `tokio` async runtime [#75](https://github.com/p2panda/aquadoggo/pull/75)
+
 ## [0.2.0]
 
 *Please note: `aquadoggo-rs` crate is not published yet, due to unpublished dependencies.*
@@ -18,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make JSON RPC methods compatible with new document logs flow [#47](https://github.com/p2panda/aquadoggo/pull/47)
 - Nicer looking `README.md` for crate [#42](https://github.com/p2panda/aquadoggo/42)
 - Support u64 integers [#54](https://github.com/p2panda/aquadoggo/pull/54)
-- Move to `tokio` async runtime [#75](https://github.com/p2panda/aquadoggo/pull/75)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,22 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -17,7 +27,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -40,7 +50,7 @@ dependencies = [
  "cfg-if",
  "cipher 0.3.0",
  "cpufeatures",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -78,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
  "cipher 0.2.5",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -88,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
  "cipher 0.2.5",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -131,6 +141,8 @@ name = "aquadoggo"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-graphql",
+ "async-graphql-axum",
  "axum",
  "bamboo-rs-core-ed25519-yasmf",
  "directories",
@@ -200,6 +212,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +256,95 @@ dependencies = [
  "futures-lite",
  "num_cpus",
  "once_cell",
+]
+
+[[package]]
+name = "async-graphql"
+version = "3.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b114d420084d89c434865778bf5e3ad210cc9ef5572e11c700f902b8f8cfe6"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-stream",
+ "async-trait",
+ "bytes 1.1.0",
+ "fast_chemail",
+ "fnv",
+ "futures-util",
+ "http",
+ "indexmap",
+ "mime",
+ "multer",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "static_assertions 1.1.0",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-axum"
+version = "3.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160dbbf81ce13c8dc6b66bf75699183b5ea2a2403a52ecba7266d68f4923a187"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "axum",
+ "bytes 1.1.0",
+ "futures-util",
+ "http-body",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio-util 0.6.9",
+ "tower-service",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "3.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b06e8b1cef822c6a8699a4ec75de140019a996d7c0e8ce3b021e5c2d036fd8"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "3.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863020a76049f6ac320a0e88350e0745e6392f73ed6fb08ebd6d56736abc28e7"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "3.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d435e9006dc82138249a64969d820a8d344357ded2075ca93d764d91f26999c9"
+dependencies = [
+ "bytes 1.1.0",
+ "indexmap",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -334,6 +441,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-task"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,9 +527,11 @@ checksum = "c9f346c92c1e9a71d14fe4aaf7c2a5d9932cc4e5e48d8fb6641524416eb79ddd"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64",
  "bitflags",
  "bytes 1.1.0",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -413,8 +543,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha-1 0.10.0",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tower-layer",
@@ -527,11 +659,23 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -540,7 +684,16 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -564,6 +717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +739,9 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cache-padded"
@@ -696,7 +858,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -705,7 +867,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -717,7 +879,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -908,7 +1070,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
@@ -920,7 +1082,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
@@ -932,7 +1094,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "typenum",
 ]
 
@@ -942,7 +1104,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -952,7 +1114,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -1011,6 +1173,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,11 +1228,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1160,7 +1366,7 @@ checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint 0.2.11",
  "ff 0.10.1",
- "generic-array",
+ "generic-array 0.14.5",
  "group 0.10.0",
  "pkcs8 0.7.6",
  "rand_core 0.6.3",
@@ -1178,7 +1384,7 @@ dependencies = [
  "crypto-bigint 0.3.2",
  "der 0.5.1",
  "ff 0.11.0",
- "generic-array",
+ "generic-array 0.14.5",
  "group 0.11.0",
  "rand_core 0.6.3",
  "sec1",
@@ -1248,6 +1454,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258f70bd2b060d448403a66d420e81dcac3e5247a4928a887404a5e03715e2e0"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
 ]
 
 [[package]]
@@ -1433,6 +1654,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
@@ -1473,7 +1703,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
- "opaque-debug",
+ "opaque-debug 0.3.0",
  "polyval 0.4.5",
 ]
 
@@ -1483,7 +1713,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
- "opaque-debug",
+ "opaque-debug 0.3.0",
  "polyval 0.5.3",
 ]
 
@@ -1573,6 +1803,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes 1.1.0",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha-1 0.10.0",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -1802,6 +2057,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1820,6 +2081,7 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1987,6 +2249,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2006,7 +2274,7 @@ checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
  "block-buffer 0.9.0",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2089,6 +2357,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "multer"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8f35e687561d5c1667590911e6698a8cb714a134a7505718a182e7bc9d3836"
+dependencies = [
+ "bytes 1.1.0",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.2",
+ "version_check",
 ]
 
 [[package]]
@@ -2186,6 +2472,12 @@ name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -2364,6 +2656,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,7 +2791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
- "opaque-debug",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
@@ -2467,7 +2802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
  "cpuid-bool",
- "opaque-debug",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
@@ -2479,7 +2814,7 @@ checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "opaque-debug",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
@@ -2488,6 +2823,16 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2670,6 +3015,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,7 +3175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
 dependencies = [
  "der 0.5.1",
- "generic-array",
+ "generic-array 0.14.5",
  "pkcs8 0.8.0",
  "subtle",
  "zeroize",
@@ -2940,6 +3294,18 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
@@ -2948,7 +3314,18 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -2976,7 +3353,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3152,7 +3529,7 @@ dependencies = [
  "futures-executor",
  "futures-intrusive",
  "futures-util",
- "generic-array",
+ "generic-array 0.14.5",
  "hashlink",
  "hex",
  "hmac 0.11.0",
@@ -3173,7 +3550,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha-1",
+ "sha-1 0.9.8",
  "sha2 0.9.9",
  "smallvec",
  "sqlformat",
@@ -3303,6 +3680,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3748,20 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -3523,6 +3920,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,6 +3939,7 @@ checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "log",
  "pin-project-lite",
@@ -3548,6 +3958,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3626,6 +4045,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "tungstenite"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes 1.1.0",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1 0.9.8",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +4092,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
@@ -3700,7 +4144,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.5",
  "subtle",
 ]
 
@@ -3732,6 +4176,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.43"
+async-graphql = "3.0.35"
+async-graphql-axum = "3.0.35"
 axum = "0.4.8"
 bamboo-rs-core-ed25519-yasmf = "0.1.0"
 directories = "3.0.2"

--- a/aquadoggo/src/graphql/api.rs
+++ b/aquadoggo/src/graphql/api.rs
@@ -15,5 +15,6 @@ pub async fn handle_graphql_query(
     request: GraphQLRequest,
     Extension(state): Extension<ApiState>,
 ) -> GraphQLResponse {
+    println!("{:?}", request.0);
     state.schema.execute(request.into_inner()).await.into()
 }

--- a/aquadoggo/src/graphql/api.rs
+++ b/aquadoggo/src/graphql/api.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use axum::extract::Extension;
+use axum::response::{self, IntoResponse};
+
+use crate::server::ApiState;
+
+pub async fn handle_graphql_playground() -> impl IntoResponse {
+    response::Html(playground_source(GraphQLPlaygroundConfig::new("/")))
+}
+
+pub async fn handle_graphql_query(
+    request: GraphQLRequest,
+    Extension(state): Extension<ApiState>,
+) -> GraphQLResponse {
+    state.schema.execute(request.into_inner()).await.into()
+}

--- a/aquadoggo/src/graphql/api.rs
+++ b/aquadoggo/src/graphql/api.rs
@@ -15,6 +15,5 @@ pub async fn handle_graphql_query(
     request: GraphQLRequest,
     Extension(state): Extension<ApiState>,
 ) -> GraphQLResponse {
-    println!("{:?}", request.0);
     state.schema.execute(request.into_inner()).await.into()
 }

--- a/aquadoggo/src/graphql/mod.rs
+++ b/aquadoggo/src/graphql/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+mod api;
+mod schema;
+
+pub use api::{handle_graphql_playground, handle_graphql_query};
+pub use schema::{build_static_schema, StaticSchema};

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::str::FromStr;
+
+use async_graphql::{EmptyMutation, EmptySubscription, Object, Schema};
+
+use crate::db::Pool;
+
+pub struct QueryRoot;
+
+#[Object]
+impl QueryRoot {
+    // @TODO: Remove this
+    async fn example<'a>(&self) -> String {
+        String::from_str("example").unwrap()
+    }
+}
+
+pub type StaticSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
+
+pub fn build_static_schema(pool: Pool) -> StaticSchema {
+    Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+        .data(pool)
+        .finish()
+}

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -10,9 +10,9 @@ pub struct QueryRoot;
 
 #[Object]
 impl QueryRoot {
-    // @TODO: Remove this
-    async fn example<'a>(&self) -> String {
-        String::from_str("example").unwrap()
+    // @TODO: Remove this example.
+    async fn ping(&self) -> String {
+        String::from_str("pong").unwrap()
     }
 }
 

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -16,6 +16,7 @@ impl QueryRoot {
     }
 }
 
+/// GraphQL schema for p2panda node.
 pub type StaticSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
 pub fn build_static_schema(pool: Pool) -> StaticSchema {

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -18,6 +18,7 @@ mod db;
 mod errors;
 mod rpc;
 mod runtime;
+mod server;
 mod task;
 
 #[cfg(test)]

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -16,6 +16,7 @@
 mod config;
 mod db;
 mod errors;
+mod graphql;
 mod rpc;
 mod runtime;
 mod server;

--- a/aquadoggo/src/rpc/methods/entry_args.rs
+++ b/aquadoggo/src/rpc/methods/entry_args.rs
@@ -91,8 +91,7 @@ pub async fn determine_skiplink(pool: Pool, entry: &Entry) -> Result<Option<Hash
 
 #[cfg(test)]
 mod tests {
-    use crate::rpc::api::build_rpc_api_service;
-    use crate::rpc::server::build_rpc_server;
+    use crate::server::{build_server, ApiState};
     use crate::test_helpers::{
         handle_http, initialize_db, random_entry_hash, rpc_error, rpc_request, rpc_response,
         TestClient,
@@ -103,8 +102,8 @@ mod tests {
     #[tokio::test]
     async fn respond_with_wrong_author_error() {
         let pool = initialize_db().await;
-        let rpc_api = build_rpc_api_service(pool.clone());
-        let app = build_rpc_server(rpc_api);
+        let state = ApiState::new(pool.clone());
+        let app = build_server(state);
         let client = TestClient::new(app);
 
         let request = rpc_request(
@@ -124,12 +123,9 @@ mod tests {
 
     #[tokio::test]
     async fn get_entry_arguments() {
-        // Prepare test database
         let pool = initialize_db().await;
-
-        // Create tide server with endpoints
-        let rpc_api = build_rpc_api_service(pool);
-        let app = build_rpc_server(rpc_api);
+        let state = ApiState::new(pool.clone());
+        let app = build_server(state);
         let client = TestClient::new(app);
 
         let request = rpc_request(

--- a/aquadoggo/src/rpc/methods/publish_entry.rs
+++ b/aquadoggo/src/rpc/methods/publish_entry.rs
@@ -181,8 +181,7 @@ mod tests {
     use p2panda_rs::identity::KeyPair;
     use p2panda_rs::operation::{Operation, OperationEncoded, OperationFields, OperationValue};
 
-    use crate::rpc::api::build_rpc_api_service;
-    use crate::rpc::server::build_rpc_server;
+    use crate::server::{build_server, ApiState};
     use crate::test_helpers::{
         handle_http, initialize_db, rpc_error, rpc_request, rpc_response, TestClient,
     };
@@ -283,8 +282,8 @@ mod tests {
         let pool = initialize_db().await;
 
         // Create tide server with endpoints
-        let rpc_api = build_rpc_api_service(pool);
-        let app = build_rpc_server(rpc_api);
+        let state = ApiState::new(pool.clone());
+        let app = build_server(state);
         let client = TestClient::new(app);
 
         // Define schema and log id for entries
@@ -401,8 +400,8 @@ mod tests {
         let pool = initialize_db().await;
 
         // Create tide server with endpoints
-        let rpc_api = build_rpc_api_service(pool);
-        let app = build_rpc_server(rpc_api);
+        let state = ApiState::new(pool.clone());
+        let app = build_server(state);
         let client = TestClient::new(app);
 
         // Define schema and log id for entries

--- a/aquadoggo/src/rpc/methods/query_entries.rs
+++ b/aquadoggo/src/rpc/methods/query_entries.rs
@@ -28,8 +28,7 @@ pub async fn query_entries(
 mod tests {
     use p2panda_rs::hash::Hash;
 
-    use crate::rpc::api::build_rpc_api_service;
-    use crate::rpc::server::build_rpc_server;
+    use crate::server::{build_server, ApiState};
     use crate::test_helpers::{handle_http, initialize_db, rpc_request, rpc_response, TestClient};
 
     #[tokio::test]
@@ -38,8 +37,8 @@ mod tests {
         let pool = initialize_db().await;
 
         // Create tide server with endpoints
-        let rpc_api = build_rpc_api_service(pool);
-        let app = build_rpc_server(rpc_api);
+        let state = ApiState::new(pool.clone());
+        let app = build_server(state);
         let client = TestClient::new(app);
 
         // Prepare request to API

--- a/aquadoggo/src/rpc/mod.rs
+++ b/aquadoggo/src/rpc/mod.rs
@@ -8,4 +8,4 @@ mod server;
 
 pub use api::{build_rpc_api_service, RpcApiService, RpcApiState};
 pub use methods::error::PublishEntryError;
-pub use server::{build_rpc_server, start_rpc_server};
+pub use server::{handle_get_http_request, handle_http_request};

--- a/aquadoggo/src/rpc/server.rs
+++ b/aquadoggo/src/rpc/server.rs
@@ -1,74 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
 use axum::extract::Extension;
-use axum::http::Method;
-use axum::routing::get;
-use axum::{Json, Router};
+use axum::Json;
 use jsonrpc_v2::{RequestObject, ResponseObjects};
-use tower_http::cors::{Any, CorsLayer};
 
-use crate::config::Configuration;
-use crate::rpc::RpcApiService;
+use crate::server::ApiState;
 
 /// Handle incoming HTTP JSON RPC requests.
-async fn handle_http_request(
+pub async fn handle_http_request(
     Json(rpc_request): Json<RequestObject>,
-    Extension(rpc_server): Extension<RpcApiService>,
+    Extension(state): Extension<ApiState>,
 ) -> Json<ResponseObjects> {
-    let response = rpc_server.handle(rpc_request).await;
+    let response = state.rpc_service.handle(rpc_request).await;
     Json(response)
 }
 
 /// Handle RPC requests with wrong HTTP method.
-async fn handle_get_http_request() -> &'static str {
+pub async fn handle_get_http_request() -> &'static str {
     "Used HTTP Method is not allowed. POST or OPTIONS is required"
-}
-
-/// Build HTTP server exposing a JSON RPC API.
-pub fn build_rpc_server(api: RpcApiService) -> Router {
-    // Configure CORS middleware
-    let cors = CorsLayer::new()
-        .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS])
-        .allow_credentials(false)
-        .allow_origin(Any);
-
-    // Prepare HTTP server with RPC route
-    Router::new()
-        .route("/", get(handle_get_http_request).post(handle_http_request))
-        .layer(cors)
-        .layer(Extension(api))
-}
-
-/// Start HTTP server.
-pub async fn start_rpc_server(config: &Configuration, api: RpcApiService) -> anyhow::Result<()> {
-    let http_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), config.http_port);
-    let server = build_rpc_server(api);
-    axum::Server::bind(&http_address)
-        .serve(server.into_make_service())
-        .await?;
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::rpc::api::build_rpc_api_service;
-    use crate::rpc::server::build_rpc_server;
-    use crate::test_helpers::{initialize_db, TestClient};
-
-    #[tokio::test]
-    async fn respond_with_method_not_allowed() {
-        let pool = initialize_db().await;
-        let rpc_api = build_rpc_api_service(pool.clone());
-        let app = build_rpc_server(rpc_api);
-
-        let client = TestClient::new(app);
-        let response = client.get("/").send().await;
-
-        assert_eq!(
-            response.text().await,
-            "Used HTTP Method is not allowed. POST or OPTIONS is required"
-        );
-    }
 }

--- a/aquadoggo/src/runtime.rs
+++ b/aquadoggo/src/runtime.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::config::Configuration;
 use crate::db::{connection_pool, create_database, run_pending_migrations, Pool};
-use crate::rpc::{build_rpc_api_service, start_rpc_server};
+use crate::server::{start_server, ApiState};
 use crate::task::TaskManager;
 
 /// Makes sure database is created and migrated before returning connection pool.
@@ -46,12 +46,12 @@ impl Runtime {
             .await
             .expect("Could not initialize database");
 
-        // Create RPC API handler with shared database connection pool
-        let rpc_api = build_rpc_api_service(pool.clone());
+        // Initialize API state with shared connection pool
+        let api_state = ApiState::new(pool.clone());
 
         // Start JSON RPC API server
-        task_manager.spawn("JSON RPC Server", async move {
-            start_rpc_server(&config, rpc_api).await?;
+        task_manager.spawn("API Server", async move {
+            start_server(&config, api_state).await?;
             Ok(())
         });
 

--- a/aquadoggo/src/server.rs
+++ b/aquadoggo/src/server.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use axum::extract::Extension;
+use axum::http::Method;
+use axum::routing::get;
+use axum::Router;
+use tower_http::cors::{Any, CorsLayer};
+
+use crate::config::Configuration;
+use crate::db::Pool;
+use crate::rpc::{
+    build_rpc_api_service, handle_get_http_request, handle_http_request, RpcApiService,
+};
+
+/// Shared state for incoming API requests.
+#[derive(Clone)]
+pub struct ApiState {
+    /// JSON RPC service with RPC handlers
+    // @TODO: This will be removed soon. See: https://github.com/p2panda/aquadoggo/issues/60
+    pub rpc_service: RpcApiService,
+
+    /// Database connection pool
+    pub pool: Pool,
+}
+
+impl ApiState {
+    /// Initialize new state with shared connection pool for API requests.
+    pub fn new(pool: Pool) -> Self {
+        let rpc_service = build_rpc_api_service(pool.clone());
+        Self { rpc_service, pool }
+    }
+}
+
+/// Build HTTP server exposing JSON RPC and GraphQL API.
+pub fn build_server(state: ApiState) -> Router {
+    // Configure CORS middleware
+    let cors = CorsLayer::new()
+        .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS])
+        .allow_credentials(false)
+        .allow_origin(Any);
+
+    Router::new()
+        // Add JSON RPC routes
+        // @TODO: The JSON RPC is deprecated and will be removed soon with GraphQL. See:
+        // https://github.com/p2panda/aquadoggo/issues/60
+        .route("/", get(handle_get_http_request).post(handle_http_request))
+        // Add GraphQL routes
+        // app.route("/graphql", get(Endpoint::handle_playground_request).post(handle_graphql_request))
+        // Add middlewares
+        .layer(cors)
+        // Add shared state
+        .layer(Extension(state))
+}
+
+/// Start HTTP server.
+pub async fn start_server(config: &Configuration, state: ApiState) -> anyhow::Result<()> {
+    let http_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), config.http_port);
+    let server = build_server(state);
+    axum::Server::bind(&http_address)
+        .serve(server.into_make_service())
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{initialize_db, TestClient};
+
+    use super::{build_server, ApiState};
+
+    #[tokio::test]
+    async fn respond_with_method_not_allowed() {
+        let pool = initialize_db().await;
+        let state = ApiState::new(pool.clone());
+        let client = TestClient::new(build_server(state));
+
+        let response = client.get("/").send().await;
+
+        assert_eq!(
+            response.text().await,
+            "Used HTTP Method is not allowed. POST or OPTIONS is required"
+        );
+    }
+}

--- a/aquadoggo/src/server.rs
+++ b/aquadoggo/src/server.rs
@@ -54,7 +54,7 @@ pub fn build_server(state: ApiState) -> Router {
 
     Router::new()
         // Add JSON RPC routes
-        // @TODO: The JSON RPC is deprecated and will be removed soon with GraphQL. See:
+        // @TODO: The JSON RPC is deprecated and will be replaced soon by GraphQL. See:
         // https://github.com/p2panda/aquadoggo/issues/60
         .route("/", get(handle_get_http_request).post(handle_http_request))
         // Add GraphQL routes


### PR DESCRIPTION
This PR just adds an GraphQL endpoint to the server, not doing anything yet.

* Refactor code-base to separate HTTP server functionality more clearly from JSON RPC
* Introduce `async_graphql` GraphQL framework
* Run an `/graphql` endpoint for `POST` (queries) and `GET` (playground) requests

Closes: #73 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
