### PR TITLE
Service manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduce GraphQL endpoint [#81](https://github.com/p2panda/aquadoggo/pull/81)
 - Generic task queue with worker pool [#82](https://github.com/p2panda/aquadoggo/pull/82)
+- Service manager [#90](https://github.com/p2panda/aquadoggo/pull/90)
 
 ### Changed
 

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -20,6 +20,7 @@ mod graphql;
 mod rpc;
 mod runtime;
 mod server;
+mod service_manager;
 mod task;
 mod worker;
 

--- a/aquadoggo/src/service_manager.rs
+++ b/aquadoggo/src/service_manager.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task;
-use tokio::task::JoinHandle;
 
 /// Sends messages through the communication bus between services.
 pub type Sender<T> = broadcast::Sender<T>;

--- a/aquadoggo/src/service_manager.rs
+++ b/aquadoggo/src/service_manager.rs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::future::Future;
+
+use tokio::task;
+
+#[async_trait::async_trait]
+pub trait Service {
+    async fn call(&self);
+}
+
+#[async_trait::async_trait]
+impl<FN, F> Service for FN
+where
+    FN: Fn() -> F + Sync,
+    F: Future<Output = ()> + Send + 'static,
+{
+    async fn call(&self) {
+        (self)().await
+    }
+}
+
+pub struct ServiceManager {
+    services: Vec<task::JoinHandle<()>>,
+}
+
+impl ServiceManager {
+    pub fn new() -> Self {
+        Self {
+            services: Vec::new(),
+        }
+    }
+
+    pub fn add<F: Service + Send + Sync + Copy + 'static>(&mut self, service: F) {
+        task::spawn(async move {
+            service.call().await;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServiceManager;
+
+    #[tokio::test]
+    async fn test() {
+        let mut manager = ServiceManager::new();
+
+        manager.add(|| async {});
+    }
+}

--- a/aquadoggo/src/service_manager.rs
+++ b/aquadoggo/src/service_manager.rs
@@ -2,50 +2,116 @@
 
 use std::future::Future;
 
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::{channel, Sender};
 use tokio::task;
 
 #[async_trait::async_trait]
 pub trait Service {
-    async fn call(&self);
+    async fn call(&self, tx: Sender<Message>);
 }
 
 #[async_trait::async_trait]
 impl<FN, F> Service for FN
 where
-    FN: Fn() -> F + Sync,
+    FN: Fn(Sender<Message>) -> F + Sync,
     F: Future<Output = ()> + Send + 'static,
 {
-    async fn call(&self) {
-        (self)().await
+    async fn call(&self, tx: Sender<Message>) {
+        (self)(tx).await
     }
+}
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    GracefulShutdown,
 }
 
 pub struct ServiceManager {
     services: Vec<task::JoinHandle<()>>,
+    tx: Box<Sender<Message>>,
 }
 
 impl ServiceManager {
-    pub fn new() -> Self {
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _) = channel(capacity);
+
         Self {
             services: Vec::new(),
+            tx: Box::new(tx),
         }
     }
 
     pub fn add<F: Service + Send + Sync + Copy + 'static>(&mut self, service: F) {
+        let tx = (*self.tx).clone();
+
         task::spawn(async move {
-            service.call().await;
+            service.call(tx).await;
         });
+    }
+
+    pub async fn shutdown(self) {
+        let mut rx = self.tx.subscribe();
+
+        // Broadcast graceful shutdown messages to all services
+        self.tx.send(Message::GracefulShutdown).unwrap();
+
+        // We drop our sender first to make sure _all_ senders get eventually closed, because the
+        // recv() call otherwise sleeps forever.
+        drop(self.tx);
+
+        // When every sender has gone out of scope, the recv call will return with a `Closed`
+        // error. This is our signal that all services have been finally shut down and we are done
+        // for good!
+        loop {
+            match rx.recv().await {
+                Err(RecvError::Closed) => break,
+                _ => (),
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ServiceManager;
+    use tokio::sync::broadcast::Sender;
+
+    use super::{Message, ServiceManager};
 
     #[tokio::test]
     async fn test() {
-        let mut manager = ServiceManager::new();
+        let mut manager = ServiceManager::new(1024);
 
-        manager.add(|| async {});
+        manager.add(|tx: Sender<Message>| async move {
+            let mut rx = tx.subscribe();
+
+            let handle = tokio::task::spawn(async {
+                loop {
+                    // Doing some very important work here
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            });
+
+            tokio::select! {
+                _ = handle => {
+                    println!("Important work finished");
+                }
+                Ok(Message::GracefulShutdown) = rx.recv() => {
+                    println!("Received shutdown signal");
+                }
+            }
+
+            println!("Exit ..");
+
+            // Some "work" we have to do before we can actually close this service
+            tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
+
+            println!("Done ..!");
+        });
+
+        // @TODO THIS MAKES IT ALL WORK. NOT SURE WHY.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        manager.shutdown().await;
     }
 }

--- a/aquadoggo/src/service_manager.rs
+++ b/aquadoggo/src/service_manager.rs
@@ -74,9 +74,6 @@ where
     /// Shared, thread-safe context between services.
     context: Context<D>,
 
-    /// List of all currently running services.
-    services: Vec<JoinHandle<()>>,
-
     /// Sender of our communication bus.
     ///
     /// This is a broadcast channel where any amount of senders and receivers can be derived from.
@@ -104,7 +101,6 @@ where
 
         Self {
             context: Context(Arc::new(context)),
-            services: Vec::new(),
             tx,
             shutdown,
         }

--- a/aquadoggo/src/service_manager.rs
+++ b/aquadoggo/src/service_manager.rs
@@ -50,7 +50,6 @@ impl ServiceManager {
 
     pub fn add<F: Service + Send + Sync + Copy + 'static>(&mut self, service: F) {
         let tx = self.tx.clone();
-        let rx = tx.subscribe();
         let shutdown_tx = self.shutdown.clone();
         let shutdown_rx = shutdown_tx.subscribe();
 
@@ -84,7 +83,7 @@ impl ServiceManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{Message, Sender, ServiceManager, Shutdown};
+    use super::{ServiceManager, Shutdown};
 
     #[tokio::test]
     async fn test() {


### PR DESCRIPTION
Introduces `ServiceManager` which orchestrates long-running concurrent services with a communication bus between them. Also it kindly informs all services about a shutdown and waits for them to stop before quitting the process for good.

The next step will be to a) remove `TaskManager` and replace it with this in the `Runtime` b) refactor the GraphQL API to fit the new "service" API and move it into the manager. c) Make use of the `axum` graceful shutdown feature.

Later we will also add the "Materializer" with the worker as a service here and use the communication bus to inform it about new, incoming entries from the GraphQL API. Much later the Replication service will also live here ..

Closes: #86 and #84 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
