### PR TITLE
Move `SqlStorage` into shared `Context`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor module structure, propagate errors in worker to service manager [#97](https://github.com/p2panda/aquadoggo/pull/97)
 - Restructure storage modules and remove JSON RPC [#101](https://github.com/p2panda/aquadoggo/pull/101)
 - Implement new methods required for replication defined by `EntryStore` trait [#102](https://github.com/p2panda/aquadoggo/pull/102)
-- Implement SQL `OperationStore` [103](https://github.com/p2panda/aquadoggo/pull/103)
+- Implement SQL `OperationStore` [#103](https://github.com/p2panda/aquadoggo/pull/103)
 - GraphQL client API with endpoint for retrieving next entry arguments [#119](https://github.com/p2panda/aquadoggo/pull/119)
 - GraphQL endpoint for publishing entries [#123](https://github.com/p2panda/aquadoggo/pull/132)
 
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve `Signal` efficiency in `ServiceManager` [#95](https://github.com/p2panda/aquadoggo/pull/95)
 - `EntryStore` improvements [#123](https://github.com/p2panda/aquadoggo/pull/123)
 - Improvements for log and entry table layout [#124](https://github.com/p2panda/aquadoggo/issues/122)
-- Update `StorageProvider` API after `p2panda-rs` changes [129](https://github.com/p2panda/aquadoggo/pull/129)
+- Update `StorageProvider` API after `p2panda-rs` changes [#129](https://github.com/p2panda/aquadoggo/pull/129)
+- Move `SqlStorage` into shared `Context` [#135](https://github.com/p2panda/aquadoggo/pull/135)
 
 ## [0.2.0]
 

--- a/aquadoggo/src/context.rs
+++ b/aquadoggo/src/context.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::config::Configuration;
-use crate::db::Pool;
+use crate::db::provider::SqlStorage;
 use crate::graphql::{build_root_schema, RootSchema};
 
 /// Inner data shared across all services.
@@ -12,8 +12,8 @@ pub struct Data {
     // Node configuration.
     pub config: Configuration,
 
-    /// Database connection pool.
-    pub pool: Pool,
+    /// Storage provider with database connection pool.
+    pub store: SqlStorage,
 
     /// Static GraphQL schema.
     pub schema: RootSchema,
@@ -21,12 +21,12 @@ pub struct Data {
 
 impl Data {
     /// Initialize new data instance with shared database connection pool.
-    pub fn new(pool: Pool, config: Configuration) -> Self {
-        let schema = build_root_schema(pool.clone());
+    pub fn new(store: SqlStorage, config: Configuration) -> Self {
+        let schema = build_root_schema(store.clone());
 
         Self {
             config,
-            pool,
+            store,
             schema,
         }
     }
@@ -37,8 +37,8 @@ pub struct Context(pub Arc<Data>);
 
 impl Context {
     /// Returns a new instance of `Context`.
-    pub fn new(pool: Pool, config: Configuration) -> Self {
-        Self(Arc::new(Data::new(pool, config)))
+    pub fn new(store: SqlStorage, config: Configuration) -> Self {
+        Self(Arc::new(Data::new(store, config)))
     }
 }
 

--- a/aquadoggo/src/db/provider.rs
+++ b/aquadoggo/src/db/provider.rs
@@ -14,8 +14,15 @@ use crate::graphql::client::{
     EntryArgsRequest, EntryArgsResponse, PublishEntryRequest, PublishEntryResponse,
 };
 
+#[derive(Clone)]
 pub struct SqlStorage {
     pub(crate) pool: Pool,
+}
+
+impl SqlStorage {
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
 }
 
 /// A `StorageProvider` implementation based on `sqlx` that supports SQLite and PostgreSQL databases.

--- a/aquadoggo/src/graphql/client/mutation.rs
+++ b/aquadoggo/src/graphql/client/mutation.rs
@@ -6,9 +6,7 @@ use p2panda_rs::operation::OperationEncoded;
 use p2panda_rs::storage_provider::traits::StorageProvider;
 
 use crate::db::provider::SqlStorage;
-use crate::db::Pool;
-
-use super::{PublishEntryRequest, PublishEntryResponse};
+use crate::graphql::client::{PublishEntryRequest, PublishEntryResponse};
 
 /// Mutations for use by p2panda clients.
 #[derive(Default, Debug, Copy, Clone)]
@@ -37,13 +35,9 @@ impl Mutation {
             operation_encoded: OperationEncoded::new(&operation_encoded_param)?,
         };
 
-        // Prepare database connection
-        let pool = ctx.data::<Pool>()?;
-        let provider = SqlStorage {
-            pool: pool.to_owned(),
-        };
-
-        provider
+        // Create entry in database
+        let store = ctx.data::<SqlStorage>()?;
+        store
             .publish_entry(&args)
             .await
             .map_err(|err| Error::from(err))
@@ -57,7 +51,7 @@ mod tests {
 
     use crate::context::Context;
     use crate::graphql::client::PublishEntryResponse;
-    use crate::test_helpers::initialize_db;
+    use crate::test_helpers::initialize_store;
     use crate::Configuration;
 
     const ENTRY_ENCODED: &str =
@@ -73,8 +67,8 @@ mod tests {
 
     #[tokio::test]
     async fn publish_entry() {
-        let pool = initialize_db().await;
-        let context = Context::new(pool.clone(), Configuration::default());
+        let store = initialize_store().await;
+        let context = Context::new(store, Configuration::default());
 
         let query = r#"
             mutation TestPublishEntry($entryEncoded: String!, $operationEncoded: String!) {
@@ -114,8 +108,8 @@ mod tests {
 
     #[tokio::test]
     async fn publish_entry_error_handling() {
-        let pool = initialize_db().await;
-        let context = Context::new(pool.clone(), Configuration::default());
+        let store = initialize_store().await;
+        let context = Context::new(store, Configuration::default());
 
         let query = r#"
             mutation TestPublishEntry($entryEncoded: String!, $operationEncoded: String!) {

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -2,17 +2,17 @@
 
 use async_graphql::{EmptySubscription, Schema};
 
-use crate::db::Pool;
+use crate::db::provider::SqlStorage;
 use crate::graphql::client::{Mutation, Query};
 
 /// GraphQL schema for p2panda node.
 pub type RootSchema = Schema<Query, Mutation, EmptySubscription>;
 
-pub fn build_root_schema(pool: Pool) -> RootSchema {
+pub fn build_root_schema(store: SqlStorage) -> RootSchema {
     let query = Query::default();
     let mutation = Mutation::default();
 
     Schema::build(query, mutation, EmptySubscription)
-        .data(pool)
+        .data(store)
         .finish()
 }

--- a/aquadoggo/src/node.rs
+++ b/aquadoggo/src/node.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use crate::bus::ServiceMessage;
 use crate::config::Configuration;
 use crate::context::Context;
+use crate::db::provider::SqlStorage;
 use crate::db::{connection_pool, create_database, run_pending_migrations, Pool};
 use crate::manager::ServiceManager;
 use crate::materializer::materializer_service;
@@ -47,8 +48,11 @@ impl Node {
             .await
             .expect("Could not initialize database");
 
+        // Prepare storage provider using connection pool
+        let store = SqlStorage::new(pool.clone());
+
         // Create service manager with shared data between services
-        let context = Context::new(pool.clone(), config);
+        let context = Context::new(store, config);
         let mut manager = ServiceManager::<Context, ServiceMessage>::new(1024, context);
 
         // Start materializer service

--- a/aquadoggo/src/server.rs
+++ b/aquadoggo/src/server.rs
@@ -55,14 +55,14 @@ mod tests {
 
     use crate::config::Configuration;
     use crate::context::Context;
-    use crate::test_helpers::{initialize_db, TestClient};
+    use crate::test_helpers::{initialize_store, TestClient};
 
     use super::build_server;
 
     #[tokio::test]
     async fn graphql_endpoint() {
-        let pool = initialize_db().await;
-        let context = Context::new(pool, Configuration::default());
+        let store = initialize_store().await;
+        let context = Context::new(store, Configuration::default());
         let client = TestClient::new(build_server(context));
 
         let response = client

--- a/aquadoggo/src/test_helpers.rs
+++ b/aquadoggo/src/test_helpers.rs
@@ -15,6 +15,7 @@ use sqlx::migrate::MigrateDatabase;
 use tower::make::Shared;
 use tower_service::Service;
 
+use crate::db::provider::SqlStorage;
 use crate::db::{connection_pool, create_database, run_pending_migrations, Pool};
 
 const DB_URL: &str = "sqlite::memory:";
@@ -137,6 +138,12 @@ pub async fn initialize_db() -> Pool {
     run_pending_migrations(&pool).await.unwrap();
 
     pool
+}
+
+// Create storage provider API around test database
+pub async fn initialize_store() -> SqlStorage {
+    let pool = initialize_db().await;
+    SqlStorage::new(pool)
 }
 
 // Delete test database


### PR DESCRIPTION
This moves the `SqlStorage` instance into the shared `Context`, so we don't need to create a new one on every GraphQL request (and other future methods).

Note: It is still possible to access the underlying connection pool object when needed as it is publicly exported inside the `SqlStorage`.

Closes: #134 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
