### PR TITLE
Fix high CPU usage of idle workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor module structure, propagate errors in worker to service manager [#97](https://github.com/p2panda/aquadoggo/pull/97)
 - Restructure storage modules and remove JSON RPC [#101](https://github.com/p2panda/aquadoggo/pull/101)
 - Implement new methods required for replication defined by `EntryStore` trait [#102](https://github.com/p2panda/aquadoggo/pull/102)
-- Implement SQL `OperationStore` [103](https://github.com/p2panda/aquadoggo/pull/103)
+- Implement SQL `OperationStore` [#103](https://github.com/p2panda/aquadoggo/pull/103)
 - GraphQL client API with endpoint for retrieving next entry arguments [#119](https://github.com/p2panda/aquadoggo/pull/119)
 - GraphQL endpoint for publishing entries [#123](https://github.com/p2panda/aquadoggo/pull/132)
 
@@ -27,7 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve `Signal` efficiency in `ServiceManager` [#95](https://github.com/p2panda/aquadoggo/pull/95)
 - `EntryStore` improvements [#123](https://github.com/p2panda/aquadoggo/pull/123)
 - Improvements for log and entry table layout [#124](https://github.com/p2panda/aquadoggo/issues/122)
-- Update `StorageProvider` API after `p2panda-rs` changes [129](https://github.com/p2panda/aquadoggo/pull/129)
+- Update `StorageProvider` API after `p2panda-rs` changes [#129](https://github.com/p2panda/aquadoggo/pull/129)
+
+### Fixed
+
+- Fix high CPU usage of idle workers [#136](https://github.com/p2panda/aquadoggo/pull/136)
 
 ## [0.2.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,6 @@ dependencies = [
  "async-trait",
  "axum",
  "bamboo-rs-core-ed25519-yasmf",
- "crossbeam-queue",
  "deadqueue",
  "directories",
  "envy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "axum",
  "bamboo-rs-core-ed25519-yasmf",
  "crossbeam-queue",
+ "deadqueue",
  "directories",
  "envy",
  "futures",
@@ -1009,6 +1010,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "deadqueue"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455d501abc72bae6432dbe500059887cab4700ba83303045db9ce2e824177d1c"
+dependencies = [
+ "crossbeam-queue",
+ "tokio",
 ]
 
 [[package]]

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -20,8 +20,7 @@ async-graphql = "3.0.35"
 async-graphql-axum = "3.0.35"
 axum = "0.5.1"
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
-crossbeam-queue = "0.3.5"
-deadqueue = { version = "0.2.2", default-feaatures = false, features = ["unlimited"] }
+deadqueue = { version = "0.2.2", default-features = false, features = ["unlimited"] }
 directories = "3.0.2"
 envy = "0.4.2"
 futures = "0.3.17"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -21,6 +21,7 @@ async-graphql-axum = "3.0.35"
 axum = "0.5.1"
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
 crossbeam-queue = "0.3.5"
+deadqueue = { version = "0.2.2", default-feaatures = false, features = ["unlimited"] }
 directories = "3.0.2"
 envy = "0.4.2"
 futures = "0.3.17"

--- a/aquadoggo/src/materializer/worker.rs
+++ b/aquadoggo/src/materializer/worker.rs
@@ -82,7 +82,7 @@ use std::hash::Hash;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crossbeam_queue::SegQueue;
+use deadqueue::unlimited::Queue;
 use log::{error, info};
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::{channel, Sender};
@@ -131,7 +131,7 @@ where
     input_index: Arc<Mutex<HashSet<IN>>>,
 
     /// FIFO queue of all tasks for this worker pool.
-    queue: Arc<SegQueue<QueueItem<IN>>>,
+    queue: Arc<Queue<QueueItem<IN>>>,
 }
 
 impl<IN> WorkerManager<IN>
@@ -142,7 +142,7 @@ where
     pub fn new() -> Self {
         Self {
             input_index: Arc::new(Mutex::new(HashSet::new())),
-            queue: Arc::new(SegQueue::new()),
+            queue: Arc::new(Queue::new()),
         }
     }
 }
@@ -409,50 +409,45 @@ where
             task::spawn(async move {
                 loop {
                     // Wait until there is a new task arriving in the queue
-                    match queue.pop() {
-                        Some(item) => {
-                            // Take this task and do work ..
-                            let result = work.call(context.clone(), item.input()).await;
+                    let item = queue.pop().await;
 
-                            // Remove input index from queue
-                            match input_index.lock() {
-                                Ok(mut index) => {
-                                    index.remove(&item.input());
-                                }
-                                Err(err) => {
-                                    error!("Error while locking input index: {}", err);
-                                    error_signal.trigger();
-                                }
-                            }
+                    // Take this task and do work ..
+                    let result = work.call(context.clone(), item.input()).await;
 
-                            // .. check the task result ..
-                            match result {
-                                Ok(Some(list)) => {
-                                    // Tasks succeeded and dispatches new, subsequent tasks
-                                    for task in list {
-                                        match tx.send(task) {
-                                            Err(err) => {
-                                                error!("Error while broadcasting task: {}", err);
-                                                error_signal.trigger();
-                                            }
-                                            _ => (),
-                                        }
+                    // Remove input index from queue
+                    match input_index.lock() {
+                        Ok(mut index) => {
+                            index.remove(&item.input());
+                        }
+                        Err(err) => {
+                            error!("Error while locking input index: {}", err);
+                            error_signal.trigger();
+                        }
+                    }
+
+                    // .. check the task result ..
+                    match result {
+                        Ok(Some(list)) => {
+                            // Tasks succeeded and dispatches new, subsequent tasks
+                            for task in list {
+                                match tx.send(task) {
+                                    Err(err) => {
+                                        error!("Error while broadcasting task: {}", err);
+                                        error_signal.trigger();
                                     }
+                                    _ => (),
                                 }
-                                Err(TaskError::Critical) => {
-                                    // Something really horrible happened, we need to crash!
-                                    error!("Critical error in task {:?}", item);
-                                    error_signal.trigger();
-                                }
-                                Err(TaskError::Failure) => {
-                                    // Silently fail .. maybe write something to the log or retry?
-                                }
-                                _ => (), // Task succeeded, but nothing to dispatch
                             }
                         }
-                        // Call the waker to avoid async runtime starvation when this loop runs
-                        // forever ..
-                        None => task::yield_now().await,
+                        Err(TaskError::Critical) => {
+                            // Something really horrible happened, we need to crash!
+                            error!("Critical error in task {:?}", item);
+                            error_signal.trigger();
+                        }
+                        Err(TaskError::Failure) => {
+                            // Silently fail .. maybe write something to the log or retry?
+                        }
+                        _ => (), // Task succeeded, but nothing to dispatch
                     }
                 }
             });


### PR DESCRIPTION
This uses [`deadqueue`](https://github.com/bikeshedder/deadqueue), a FIFO-queue implementation wrapping `crossbeam_queue::SegQueue`. It extends it with a future on `pop` which uses a nice [semaphore](https://github.com/bikeshedder/deadqueue/blob/master/src/unlimited.rs#L34) logic internally allowing us to `await` on it. This gives us exactly what we need to not naively unblock the async task and retry the queue manually on _every_ loop cycle, as there was otherwise no future to wait for before. This led originally to unnecessary waking of the runtime even when there was nothing to do, wasting CPU resources. With the new `await` / future on the queue we have a chance now to do something else in the async runtime and come back as soon as there is something to do again.

Closes: #127 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
