### PR TITLE
Fix in test db

### DIFF
--- a/aquadoggo/src/db/stores/test_utils.rs
+++ b/aquadoggo/src/db/stores/test_utils.rs
@@ -248,7 +248,7 @@ pub async fn test_db(
             let next_entry = Entry::new(
                 &next_entry_args.log_id,
                 Some(&next_operation),
-                next_entry_args.backlink.as_ref(),
+                next_entry_args.skiplink.as_ref(),
                 next_entry_args.backlink.as_ref(),
                 &next_entry_args.seq_num,
             )


### PR DESCRIPTION
:rofl: what a great mistake.

The reason it wasn't picked up is cos all validation of backlink & skiplinks happens in `publish_entry` and this is implemented (and tested) in `p2panda-rs`, so this didn't actually effect any of the tests in aquadoggo yet.

I'm going to move this test fixture across into `p2panda-rs` (which is where I caught this bug) so for now I think it's enough to just fix it here without adding tests as they will be in place when it moves.

lolz

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] ~Add this PR to the _Unreleased_ section in `CHANGELOG.md`~
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
