### PR TITLE
UPSERT documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix high CPU usage of idle workers [#136](https://github.com/p2panda/aquadoggo/pull/136)
 - Improve CI, track test coverage [#139](https://github.com/p2panda/aquadoggo/pull/139)
 - Fix compatibility with PostgreSQL, change sqlx runtime to `tokio` [#170](https://github.com/p2panda/aquadoggo/pull/170)
+- use UPSERT for inserting or updating documents [#173](https://github.com/p2panda/aquadoggo/pull/173)
 
 ## [0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix high CPU usage of idle workers [#136](https://github.com/p2panda/aquadoggo/pull/136)
 - Improve CI, track test coverage [#139](https://github.com/p2panda/aquadoggo/pull/139)
 - Fix compatibility with PostgreSQL, change sqlx runtime to `tokio` [#170](https://github.com/p2panda/aquadoggo/pull/170)
-- use UPSERT for inserting or updating documents [#173](https://github.com/p2panda/aquadoggo/pull/173)
+- Use UPSERT for inserting or updating documents [#173](https://github.com/p2panda/aquadoggo/pull/173)
 
 ## [0.2.0]
 

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -167,6 +167,9 @@ impl DocumentStore for SqlStorage {
                 )
             VALUES
                 ($1, $2, $3, $4)
+            ON CONFLICT(document_id) DO UPDATE SET
+                document_view_id=$2,
+                is_deleted=$3
             ",
         )
         .bind(document.id().as_str())
@@ -666,13 +669,15 @@ mod tests {
             let mut current_operations = Vec::new();
 
             for operation in document.operations() {
+                // For each operation in the db we insert a document, cumulatively adding the next operation
+                // each time. this should perform an "INSERT" first in the documents table, followed by 9 "UPDATES".
                 current_operations.push(operation.clone());
                 let document = DocumentBuilder::new(current_operations.clone())
                     .build()
                     .unwrap();
                 let result = db.store.insert_document(&document).await;
-                print!("{:#?}", result);
                 assert!(result.is_ok());
+
                 let document_view = db.store.get_document_by_id(document.id()).await.unwrap();
                 assert!(document_view.is_some());
             }

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -168,8 +168,8 @@ impl DocumentStore for SqlStorage {
             VALUES
                 ($1, $2, $3, $4)
             ON CONFLICT(document_id) DO UPDATE SET
-                document_view_id=$2,
-                is_deleted=$3
+                document_view_id = $2,
+                is_deleted = $3
             ",
         )
         .bind(document.id().as_str())

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -223,8 +223,11 @@ mod tests {
             let context = Context::new(db.store.clone(), Configuration::default());
             let input = TaskInput::new(Some(document_id.clone()), None);
 
+            // There is one CREATE operation for this document in the db, it should create a document
+            // in the documents table.
             assert!(reduce_task(context.clone(), input.clone()).await.is_ok());
 
+            // Now we create and insert an UPDATE operation for this document.
             let entry_args = db
                 .store
                 .get_entry_args(&EntryArgsRequest {
@@ -268,10 +271,12 @@ mod tests {
                 .await
                 .unwrap();
 
+            // This should now find the new UPDATE operation and perform an update on the document
+            // in the documents table.
             assert!(reduce_task(context.clone(), input).await.is_ok());
 
+            // The new view should exist and the document should refer to it.
             let document_view = context.store.get_document_by_id(document_id).await.unwrap();
-
             assert_eq!(
                 document_view.unwrap().get("username").unwrap().value(),
                 &OperationValue::Text("meeeeeee".to_string())

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -11,7 +11,7 @@ use crate::materializer::TaskInput;
 
 /// A reduce task is dispatched for every entry and operation pair which arrives at a node.
 ///
-/// They may also be dispatched from a dependency task when a pinned relations is present on an
+/// They may also be dispatched from a dependency task when a pinned relat&ions is present on an
 /// already materialised document view.
 ///
 /// After succesfully reducing and storing a document view an array of dependency tasks is returned.
@@ -153,16 +153,27 @@ async fn reduce_document(
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryFrom;
+
     use p2panda_rs::document::{DocumentBuilder, DocumentId, DocumentViewId};
-    use p2panda_rs::operation::{AsVerifiedOperation, OperationValue};
-    use p2panda_rs::storage_provider::traits::OperationStore;
+    use p2panda_rs::entry::{sign_and_encode, Entry};
+    use p2panda_rs::identity::Author;
+    use p2panda_rs::operation::{
+        AsVerifiedOperation, OperationEncoded, OperationValue, VerifiedOperation,
+    };
+    use p2panda_rs::storage_provider::traits::{
+        AsStorageEntry, EntryStore, OperationStore, StorageProvider,
+    };
     use p2panda_rs::test_utils::constants::TEST_SCHEMA_ID;
+    use p2panda_rs::test_utils::fixtures::{operation, operation_fields};
     use rstest::rstest;
 
     use crate::config::Configuration;
     use crate::context::Context;
     use crate::db::stores::test_utils::{test_db, TestDatabase, TestDatabaseRunner};
+    use crate::db::stores::StorageEntry;
     use crate::db::traits::DocumentStore;
+    use crate::graphql::client::EntryArgsRequest;
     use crate::materializer::tasks::reduce_task;
     use crate::materializer::TaskInput;
 
@@ -196,6 +207,76 @@ mod tests {
                 )
             }
         });
+    }
+
+    #[rstest]
+    fn updates_a_document(
+        #[from(test_db)]
+        #[with(1, 1)]
+        runner: TestDatabaseRunner,
+    ) {
+        runner.with_db_teardown(|db: TestDatabase| async move {
+            let document_id = db.documents.first().unwrap();
+            let key_pair = db.key_pairs.first().unwrap();
+            let author = Author::try_from(key_pair.public_key().to_owned()).unwrap();
+
+            let context = Context::new(db.store.clone(), Configuration::default());
+            let input = TaskInput::new(Some(document_id.clone()), None);
+
+            assert!(reduce_task(context.clone(), input.clone()).await.is_ok());
+
+            let entry_args = db
+                .store
+                .get_entry_args(&EntryArgsRequest {
+                    author,
+                    document: Some(document_id.clone()),
+                })
+                .await
+                .unwrap();
+
+            let operation = operation(
+                Some(operation_fields(vec![(
+                    "username",
+                    OperationValue::Text("meeeeeee".to_string()),
+                )])),
+                Some(document_id.as_str().parse().unwrap()),
+                None,
+            );
+
+            let entry = Entry::new(
+                &entry_args.log_id,
+                Some(&operation),
+                entry_args.skiplink.as_ref(),
+                entry_args.backlink.as_ref(),
+                &entry_args.seq_num,
+            )
+            .unwrap();
+
+            let entry_signed = sign_and_encode(&entry, key_pair).unwrap();
+            let operation_encoded = OperationEncoded::try_from(&operation).unwrap();
+
+            db.store
+                .insert_entry(StorageEntry::new(&entry_signed, &operation_encoded).unwrap())
+                .await
+                .unwrap();
+
+            let verified_operation =
+                VerifiedOperation::new_from_entry(&entry_signed, &operation_encoded).unwrap();
+
+            db.store
+                .insert_operation(&verified_operation, document_id)
+                .await
+                .unwrap();
+
+            assert!(reduce_task(context.clone(), input).await.is_ok());
+
+            let document_view = context.store.get_document_by_id(document_id).await.unwrap();
+
+            assert_eq!(
+                document_view.unwrap().get("username").unwrap().value(),
+                &OperationValue::Text("meeeeeee".to_string())
+            )
+        })
     }
 
     #[rstest]

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -11,7 +11,7 @@ use crate::materializer::TaskInput;
 
 /// A reduce task is dispatched for every entry and operation pair which arrives at a node.
 ///
-/// They may also be dispatched from a dependency task when a pinned relat&ions is present on an
+/// They may also be dispatched from a dependency task when a pinned relations is present on an
 /// already materialised document view.
 ///
 /// After succesfully reducing and storing a document view an array of dependency tasks is returned.


### PR DESCRIPTION
Following this bug: https://github.com/p2panda/aquadoggo/issues/172

We realised the SQL we have is not updating documents, only inserting.... So this is a fix for that and additional tests in the `reduce` task and `DocumentStore`.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
