### PR TITLE
Fix get documents by schema error on deleted doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor scalars and replication API, replace `graphql-client` with `gql_client` [#184](https://github.com/p2panda/aquadoggo/pull/184)
 
+### Fixed
+
+- Filter out deleted documents in `get_documents_by_schema` SQL query [193](https://github.com/p2panda/aquadoggo/pull/193)
+
 ## [0.3.0]
 
 Released on 2022-07-01: :package: [`crate`](https://crates.io/crates/aquadoggo/0.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Filter out deleted documents in `get_documents_by_schema` SQL query [193](https://github.com/p2panda/aquadoggo/pull/193)
+- Filter out deleted documents in `get_documents_by_schema` SQL query [#193](https://github.com/p2panda/aquadoggo/pull/193)
 
 ## [0.3.0]
 

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -652,6 +652,37 @@ mod tests {
     }
 
     #[rstest]
+    fn get_documents_by_schema_deleted_document(
+        #[from(test_db)]
+        #[with(10, 1, 1, true)]
+        runner: TestDatabaseRunner,
+    ) {
+        runner.with_db_teardown(|db: TestDatabase| async move {
+            let document_id = db.test_data.documents[0].clone();
+
+            let document_operations = db
+                .store
+                .get_operations_by_document_id(&document_id)
+                .await
+                .unwrap();
+
+            let document = DocumentBuilder::new(document_operations).build().unwrap();
+
+            let result = db.store.insert_document(&document).await;
+
+            assert!(result.is_ok());
+
+            let document_views = db
+                .store
+                .get_documents_by_schema(&TEST_SCHEMA_ID.parse().unwrap())
+                .await
+                .unwrap();
+
+            assert!(document_views.is_empty());
+        });
+    }
+
+    #[rstest]
     fn updates_a_document(
         #[from(test_db)]
         #[with(10, 1, 1)]


### PR DESCRIPTION
This was a simple fix, we were missing  `WHERE documents.is_deleted = false` in the SQL query.

Closing: #190 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
