### PR TITLE
Improve error logging in worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Refactor scalars and replication API, replace `graphql-client` with `gql_client` [#184](https://github.com/p2panda/aquadoggo/pull/184)
+- Give error types of worker a string for better debugging [#194](https://github.com/p2panda/aquadoggo/pull/194)
 
 ## [0.3.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,8 +123,8 @@ dependencies = [
  "p2panda-rs",
  "rand 0.8.5",
  "reqwest",
- "rstest 0.12.0",
- "rstest_reuse 0.1.3",
+ "rstest",
+ "rstest_reuse",
  "serde",
  "serde_json",
  "sqlx",
@@ -2059,8 +2059,8 @@ dependencies = [
  "openmls_traits",
  "rand 0.7.3",
  "regex",
- "rstest 0.15.0",
- "rstest_reuse 0.3.0",
+ "rstest",
+ "rstest_reuse",
  "serde",
  "serde-wasm-bindgen",
  "serde_repr",
@@ -2521,19 +2521,6 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.0",
- "syn",
-]
-
-[[package]]
-name = "rstest"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
@@ -2541,7 +2528,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros",
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2553,18 +2540,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "rustc_version 0.4.0",
- "syn",
-]
-
-[[package]]
-name = "rstest_reuse"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c6cfaae58c048728261723a72b80a0aa9f3768e9a7da3b302a24d262525219"
-dependencies = [
- "quote",
- "rustc_version 0.3.3",
+ "rustc_version",
  "syn",
 ]
 
@@ -2575,7 +2551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b29d3117bce27ea307d1fb7ce12c64ba11b3fd04311a42d32bc5f0072e6e3d4d"
 dependencies = [
  "quote",
- "rustc_version 0.4.0",
+ "rustc_version",
  "syn",
 ]
 
@@ -2587,20 +2563,11 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.12",
+ "semver",
 ]
 
 [[package]]
@@ -2700,27 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "serde"

--- a/aquadoggo/src/materializer/input.rs
+++ b/aquadoggo/src/materializer/input.rs
@@ -31,14 +31,16 @@ impl TaskInput {
 
 impl Display for TaskInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let doc_id = match &self.document_id {
+        let document_id = match &self.document_id {
             Some(id) => format!("{}", id),
             None => "-".to_string(),
         };
+
         let view_id = match &self.document_view_id {
             Some(view_id) => format!("{}", view_id),
             None => "-".to_string(),
         };
-        write!(f, "<TaskInput {}/{}>", doc_id, view_id)
+
+        write!(f, "<TaskInput {}/{}>", document_id, view_id)
     }
 }

--- a/aquadoggo/src/materializer/tasks/dependency.rs
+++ b/aquadoggo/src/materializer/tasks/dependency.rs
@@ -21,7 +21,7 @@ use crate::materializer::TaskInput;
 /// Expects a _reduce_ task to have completed successfully for the given document view itself and
 /// returns a critical error otherwise.
 pub async fn dependency_task(context: Context, input: TaskInput) -> TaskResult<TaskInput> {
-    debug!("Working on dependency task {:#?}", input);
+    debug!("Working on dependency task: {}", input);
 
     // Here we retrive the document view by document view id.
     let document_view = match &input.document_view_id {
@@ -61,14 +61,14 @@ pub async fn dependency_task(context: Context, input: TaskInput) -> TaskResult<T
     // We can think of these as "child" relations.
     for (_key, document_view_value) in document_view.fields().iter() {
         match document_view_value.value() {
-            p2panda_rs::operation::OperationValue::Relation(_relation) => {
+            p2panda_rs::operation::OperationValue::Relation(_) => {
                 // This is a relation to a document, if it doesn't exist in the db yet, then that
                 // means we either have no entries for this document, or we are not materialising
                 // it for some reason. We don't want to kick of a "reduce" or "dependency" task in
                 // either of these cases.
                 debug!("Relation field found, no action required.");
             }
-            p2panda_rs::operation::OperationValue::RelationList(_relation_list) => {
+            p2panda_rs::operation::OperationValue::RelationList(_) => {
                 // same as above...
                 debug!("Relation list field found, no action required.");
             }

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -18,7 +18,7 @@ use crate::materializer::TaskInput;
 /// After succesfully reducing and storing a document view an array of dependency tasks is returned.
 /// If invalid inputs were passed or a fatal db error occured a critical error is returned.
 pub async fn reduce_task(context: Context, input: TaskInput) -> TaskResult<TaskInput> {
-    debug!("Working on reduce task {:#?}", input);
+    debug!("Working on reduce task {}", input);
 
     // Find out which document we are handling
     let document_id = match resolve_document_id(&context, &input).await? {

--- a/aquadoggo/src/materializer/tasks/schema.rs
+++ b/aquadoggo/src/materializer/tasks/schema.rs
@@ -22,7 +22,7 @@ pub async fn schema_task(context: Context, input: TaskInput) -> TaskResult<TaskI
     let input_view_id = match (input.document_id, input.document_view_id) {
         (None, Some(view_id)) => Ok(view_id),
         // The task input must contain only a view id.
-        (_, _) => Err(TaskError::Critical),
+        (_, _) => Err(TaskError::Critical("Invalid task input".into())),
     }?;
 
     // Determine the schema of the updated view id.
@@ -37,13 +37,17 @@ pub async fn schema_task(context: Context, input: TaskInput) -> TaskResult<TaskI
         SchemaId::SchemaFieldDefinition(_) => {
             get_related_schema_definitions(&input_view_id, &context).await
         }
-        _ => Err(TaskError::Critical),
+        _ => Err(TaskError::Critical(format!(
+            "Unknown system schema id: {}",
+            schema
+        ))),
     }?;
 
-    // The affected schema definitions are not known yet to this node so we mark this task failed.
+    // The related schema definitions are not known yet to this node so we mark this task failed.
     if updated_schema_definitions.is_empty() {
-        debug!("Failed: Affected schema definition not found");
-        return Err(TaskError::Failure);
+        return Err(TaskError::Failure(
+            "Related schema definition not given (yet)".into(),
+        ));
     }
 
     for view_id in updated_schema_definitions.iter() {
@@ -51,7 +55,7 @@ pub async fn schema_task(context: Context, input: TaskInput) -> TaskResult<TaskI
             .store
             .get_schema_by_id(view_id)
             .await
-            .map_err(|_err| TaskError::Critical)?
+            .map_err(|err| TaskError::Critical(err.to_string()))?
         {
             // Updated schema was assembled successfully and is now passed to schema provider.
             Some(schema) => {
@@ -74,27 +78,31 @@ async fn get_schema_for_view(
 ) -> Result<SchemaId, TaskError> {
     let sample_operation_id = view_id.graph_tips().first().unwrap();
     let sample_operation = context.store.get_operation_by_id(sample_operation_id).await;
-    let sample_operation = sample_operation.map_err(|_| TaskError::Critical)?.unwrap();
+    let sample_operation = sample_operation
+        .map_err(|err| TaskError::Critical(err.to_string()))?
+        .unwrap();
     Ok(sample_operation.operation().schema())
 }
 
-/// Retrieve schema definitions that use the targetted schema field definition as one of their fields.
+/// Retrieve schema definitions that use the targeted schema field definition as one of their
+/// fields.
 async fn get_related_schema_definitions(
     target_field_definition: &DocumentViewId,
     context: &Context,
 ) -> Result<Vec<DocumentViewId>, TaskError> {
-    // Retrieve all schema definition documents from the store.
+    // Retrieve all schema definition documents from the store
     let schema_definitions = context
         .store
         .get_documents_by_schema(&SchemaId::SchemaDefinition(1))
         .await
-        .map_err(|_err| TaskError::Critical)
+        .map_err(|err| TaskError::Critical(err.to_string()))
         .unwrap();
 
-    // Collect all schema definitions that use the targetted field definition
+    // Collect all schema definitions that use the targeted field definition
     let mut related_schema_definitions = vec![];
     for schema in schema_definitions {
         let fields_value = schema.fields().get("fields").unwrap().value();
+
         if let OperationValue::PinnedRelationList(fields) = fields_value {
             if fields
                 .iter()
@@ -107,7 +115,9 @@ async fn get_related_schema_definitions(
         } else {
             // Abort if there are schema definitions in the store that don't match the schema
             // definition schema.
-            Err(TaskError::Critical)?
+            Err(TaskError::Critical(
+                "Schema definition operation does not have a 'fields' operation field".into(),
+            ))?
         }
     }
 

--- a/aquadoggo/src/materializer/tasks/schema.rs
+++ b/aquadoggo/src/materializer/tasks/schema.rs
@@ -17,7 +17,7 @@ use crate::materializer::TaskInput;
 /// has all its immediate dependencies available in the store. It collects all required views for
 /// the schema, instantiates it and adds it to the schema provider.
 pub async fn schema_task(context: Context, input: TaskInput) -> TaskResult<TaskInput> {
-    debug!("Working on schema task {}", input);
+    debug!("Working on schema task: {}", input);
 
     let input_view_id = match (input.document_id, input.document_view_id) {
         (None, Some(view_id)) => Ok(view_id),
@@ -81,6 +81,7 @@ async fn get_schema_for_view(
     let sample_operation = sample_operation
         .map_err(|err| TaskError::Critical(err.to_string()))?
         .unwrap();
+
     Ok(sample_operation.operation().schema())
 }
 

--- a/aquadoggo/src/materializer/worker.rs
+++ b/aquadoggo/src/materializer/worker.rs
@@ -537,6 +537,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::fmt::Display;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -651,6 +652,12 @@ mod tests {
         struct JigsawPiece {
             id: usize,
             relations: Vec<usize>,
+        }
+
+        impl Display for JigsawPiece {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{} {:?}", self.id, self.relations)
+            }
         }
 
         // This is a whole puzzle, which is simply a list of puzzle pieces. It has a "complete"

--- a/aquadoggo/src/materializer/worker.rs
+++ b/aquadoggo/src/materializer/worker.rs
@@ -76,7 +76,7 @@
 //! Task 1 results in "25", Task 2 in "64", Task 4 in "9".
 //! ```
 use std::collections::{HashMap, HashSet};
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::future::Future;
 use std::hash::Hash;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -143,7 +143,7 @@ pub type WorkerName = String;
 /// this registered work and an index of all current inputs in the task queue.
 struct WorkerManager<IN>
 where
-    IN: Send + Sync + Clone + Hash + Eq + 'static,
+    IN: Send + Sync + Clone + Hash + Eq + Display + 'static,
 {
     /// Index of all current inputs inside the task queue organized in a hash set.
     ///
@@ -157,7 +157,7 @@ where
 
 impl<IN> WorkerManager<IN>
 where
-    IN: Send + Sync + Clone + Hash + Eq + 'static,
+    IN: Send + Sync + Clone + Hash + Eq + Display + 'static,
 {
     /// Returns a new worker manager.
     pub fn new() -> Self {
@@ -209,7 +209,7 @@ where
 #[derive(Debug)]
 pub struct QueueItem<IN>
 where
-    IN: Send + Sync + Clone + 'static,
+    IN: Send + Sync + Clone + Display + 'static,
 {
     /// Unique task identifier.
     id: u64,
@@ -218,9 +218,18 @@ where
     input: IN,
 }
 
+impl<IN> Display for QueueItem<IN>
+where
+    IN: Send + Sync + Clone + Display + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<QueueItem {} w. {}>", self.id, self.input)
+    }
+}
+
 impl<IN> QueueItem<IN>
 where
-    IN: Send + Sync + Clone + 'static,
+    IN: Send + Sync + Clone + Display + 'static,
 {
     /// Returns a new queue item.
     pub fn new(id: u64, input: IN) -> Self {
@@ -242,7 +251,7 @@ where
 /// This factory serves as a main entry interface to dispatch, schedule and process tasks.
 pub struct Factory<IN, D>
 where
-    IN: Send + Sync + Clone + Hash + Eq + Debug + 'static,
+    IN: Send + Sync + Clone + Hash + Eq + Debug + Display + 'static,
     D: Send + Sync + Clone + 'static,
 {
     /// Shared context between all tasks.
@@ -268,7 +277,7 @@ where
 
 impl<IN, D> Factory<IN, D>
 where
-    IN: Send + Sync + Clone + Hash + Eq + Debug + 'static,
+    IN: Send + Sync + Clone + Hash + Eq + Debug + Display + 'static,
     D: Send + Sync + Clone + 'static,
 {
     /// Initialises a new factory.
@@ -505,7 +514,7 @@ where
                         Err(TaskError::Critical(err)) => {
                             // Something really horrible happened, we need to crash!
                             error!(
-                                "Critical error in worker {} with task {:?}: {}",
+                                "Critical error in worker {} with task {}: {}",
                                 name, item, err
                             );
 
@@ -513,7 +522,7 @@ where
                         }
                         Err(TaskError::Failure(err)) => {
                             debug!(
-                                "Silently failing worker {} with task {:?}: {}",
+                                "Silently failing worker {} with task {}: {}",
                                 name, item, err
                             );
                         }


### PR DESCRIPTION
This helps us to understand better what is going on when something fails inside the worker:

* Use `Display` for all logging of `TaskInput` and `QueueItem`
* Implement `Display` on `QueueItem`
* Add strings in `Failure` and `Critical` error types of worker

Closing: #189 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
