### PR TITLE
Add service ready signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GraphQL replication service gets and verifies new entries and inserts them into the db [#137](https://github.com/p2panda/aquadoggo/pull/137)
 - Add schema task and schema provider that update when new schema views are materialised [#166](https://github.com/p2panda/aquadoggo/pull/166)
+- Service ready signal [#218](https://github.com/p2panda/aquadoggo/pull/218)
 
 ### Changed
 

--- a/aquadoggo/src/http/service.rs
+++ b/aquadoggo/src/http/service.rs
@@ -8,14 +8,13 @@ use axum::http::Method;
 use axum::routing::get;
 use axum::Router;
 use log::{debug, warn};
-use tokio::sync::oneshot;
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::bus::ServiceSender;
 use crate::context::Context;
 use crate::http::api::{handle_graphql_playground, handle_graphql_query};
 use crate::http::context::HttpServiceContext;
-use crate::manager::Shutdown;
+use crate::manager::{ServiceReadySender, Shutdown};
 
 const GRAPHQL_ROUTE: &str = "/graphql";
 
@@ -44,7 +43,7 @@ pub async fn http_service(
     context: Context,
     signal: Shutdown,
     tx: ServiceSender,
-    tx_ready: oneshot::Sender<()>,
+    tx_ready: ServiceReadySender,
 ) -> Result<()> {
     let http_port = context.config.http_port;
     let http_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), http_port);

--- a/aquadoggo/src/http/service.rs
+++ b/aquadoggo/src/http/service.rs
@@ -40,7 +40,12 @@ pub fn build_server(http_context: HttpServiceContext) -> Router {
 }
 
 /// Start HTTP server.
-pub async fn http_service(context: Context, signal: Shutdown, tx: ServiceSender, tx_ready: oneshot::Sender<()>) -> Result<()> {
+pub async fn http_service(
+    context: Context,
+    signal: Shutdown,
+    tx: ServiceSender,
+    tx_ready: oneshot::Sender<()>,
+) -> Result<()> {
     let http_port = context.config.http_port;
     let http_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), http_port);
 

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -469,7 +469,7 @@ mod tests {
             });
 
             // Wait for service to be ready ..
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
 
             // Then straight away publish a CREATE operation and send it to the bus.
             let (entry_encoded, _) = send_to_store(&db.store, &operation, None, &key_pair).await;
@@ -481,7 +481,7 @@ mod tests {
             .unwrap();
 
             // Wait a little bit for work being done ..
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
 
             // Make sure the service did not crash and is still running
             assert_eq!(handle.is_finished(), false);

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use anyhow::Result;
-use log::debug;
+use log::{debug, warn};
 use p2panda_rs::storage_provider::traits::OperationStore;
+use tokio::sync::oneshot;
 use tokio::task;
 
 use crate::bus::{ServiceMessage, ServiceSender};
@@ -28,6 +29,7 @@ pub async fn materializer_service(
     context: Context,
     shutdown: Shutdown,
     tx: ServiceSender,
+    tx_ready: oneshot::Sender<()>,
 ) -> Result<()> {
     // Create worker factory with task queue
     let pool_size = context.config.worker_pool_size as usize;
@@ -114,6 +116,11 @@ pub async fn materializer_service(
         }
     });
 
+    debug!("Materialiser service is ready");
+    if tx_ready.send(()).is_err() {
+        warn!("No subscriber informed about materialiser service being ready");
+    };
+
     // Wait until we received the application shutdown signal or handle closed
     tokio::select! {
         _ = handle => (),
@@ -144,7 +151,7 @@ mod tests {
         key_pair, operation, operation_fields, random_document_id, random_operation_id,
     };
     use rstest::rstest;
-    use tokio::sync::broadcast;
+    use tokio::sync::{broadcast, oneshot};
     use tokio::task;
 
     use crate::context::Context;
@@ -196,17 +203,19 @@ mod tests {
                 }
             });
             let (tx, _) = broadcast::channel(1024);
+            let (tx_ready, rx_ready) = oneshot::channel::<()>();
 
             // Start materializer service
             let tx_clone = tx.clone();
             let handle = tokio::spawn(async move {
-                materializer_service(context, shutdown, tx_clone)
+                materializer_service(context, shutdown, tx_clone, tx_ready)
                     .await
                     .unwrap();
             });
 
-            // Wait for service to be ready ..
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            if rx_ready.await.is_err() {
+                panic!("Service dropped");
+            }
 
             // Send a message over the bus which kicks in materialization
             tx.send(crate::bus::ServiceMessage::NewOperation(
@@ -269,18 +278,23 @@ mod tests {
                 }
             });
             let (tx, _) = broadcast::channel(1024);
+            let (tx_ready, rx_ready) = oneshot::channel::<()>();
 
             // Start materializer service
             let tx_clone = tx.clone();
             let handle = tokio::spawn(async move {
-                materializer_service(context, shutdown, tx_clone)
+                materializer_service(context, shutdown, tx_clone, tx_ready)
                     .await
                     .unwrap();
             });
 
+            if rx_ready.await.is_err() {
+                panic!("Service dropped");
+            }
+
             // Wait for service to be done .. it should materialize the document since it was waiting
             // as a "pending" task in the database
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
 
             // Make sure the service did not crash and is still running
             assert_eq!(handle.is_finished(), false);
@@ -333,17 +347,19 @@ mod tests {
                 }
             });
             let (tx, _) = broadcast::channel(1024);
+            let (tx_ready, rx_ready) = oneshot::channel::<()>();
 
             // Start materializer service
             let tx_clone = tx.clone();
             let handle = tokio::spawn(async move {
-                materializer_service(context, shutdown, tx_clone)
+                materializer_service(context, shutdown, tx_clone, tx_ready)
                     .await
                     .unwrap();
             });
 
-            // Wait for service to be ready ..
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            if rx_ready.await.is_err() {
+                panic!("Service dropped");
+            }
 
             // Send a message over the bus which kicks in materialization
             tx.send(crate::bus::ServiceMessage::NewOperation(
@@ -462,14 +478,17 @@ mod tests {
 
             // Start materializer service
             let tx_clone = tx.clone();
+            let (tx_ready, rx_ready) = oneshot::channel::<()>();
+
             let handle = tokio::spawn(async move {
-                materializer_service(context, shutdown, tx_clone)
+                materializer_service(context, shutdown, tx_clone, tx_ready)
                     .await
                     .unwrap();
             });
 
-            // Wait for service to be ready ..
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            if rx_ready.await.is_err() {
+                panic!("Service dropped");
+            }
 
             // Then straight away publish a CREATE operation and send it to the bus.
             let (entry_encoded, _) = send_to_store(&db.store, &operation, None, &key_pair).await;

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -3,12 +3,11 @@
 use anyhow::Result;
 use log::{debug, warn};
 use p2panda_rs::storage_provider::traits::OperationStore;
-use tokio::sync::oneshot;
 use tokio::task;
 
 use crate::bus::{ServiceMessage, ServiceSender};
 use crate::context::Context;
-use crate::manager::Shutdown;
+use crate::manager::{ServiceReadySender, Shutdown};
 use crate::materializer::tasks::{dependency_task, reduce_task, schema_task};
 use crate::materializer::worker::{Factory, Task, TaskStatus};
 use crate::materializer::TaskInput;
@@ -29,7 +28,7 @@ pub async fn materializer_service(
     context: Context,
     shutdown: Shutdown,
     tx: ServiceSender,
-    tx_ready: oneshot::Sender<()>,
+    tx_ready: ServiceReadySender,
 ) -> Result<()> {
     // Create worker factory with task queue
     let pool_size = context.config.worker_pool_size as usize;

--- a/aquadoggo/src/node.rs
+++ b/aquadoggo/src/node.rs
@@ -60,13 +60,18 @@ impl Node {
         let mut manager = ServiceManager::<Context, ServiceMessage>::new(1024, context);
 
         // Start materializer service.
-        manager.add("materializer", materializer_service);
-
+        if manager.add("materializer", materializer_service).await.is_err() {
+            panic!("Failed starting materialiser service");
+        }
         // Start replication service
-        manager.add("replication", replication_service);
+        if manager.add("replication", replication_service).await.is_err() {
+            panic!("Failed starting replication service");
+        }
 
         // Start HTTP server with GraphQL API
-        manager.add("http", http_service);
+        if manager.add("http", http_service).await.is_err() {
+            panic!("Failed starting HTTP service");
+        }
 
         Self { pool, manager }
     }

--- a/aquadoggo/src/node.rs
+++ b/aquadoggo/src/node.rs
@@ -60,11 +60,19 @@ impl Node {
         let mut manager = ServiceManager::<Context, ServiceMessage>::new(1024, context);
 
         // Start materializer service.
-        if manager.add("materializer", materializer_service).await.is_err() {
+        if manager
+            .add("materializer", materializer_service)
+            .await
+            .is_err()
+        {
             panic!("Failed starting materialiser service");
         }
         // Start replication service
-        if manager.add("replication", replication_service).await.is_err() {
+        if manager
+            .add("replication", replication_service)
+            .await
+            .is_err()
+        {
             panic!("Failed starting replication service");
         }
 

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -14,7 +14,6 @@ use p2panda_rs::operation::{AsVerifiedOperation, VerifiedOperation};
 use p2panda_rs::storage_provider::traits::{
     AsStorageEntry, EntryStore, OperationStore, StorageProvider,
 };
-use tokio::sync::oneshot;
 use tokio::task;
 
 use crate::bus::{ServiceMessage, ServiceSender};
@@ -22,7 +21,7 @@ use crate::context::Context;
 use crate::db::request::PublishEntryRequest;
 use crate::db::stores::StorageEntry;
 use crate::graphql::replication::client;
-use crate::manager::Shutdown;
+use crate::manager::{ServiceReadySender, Shutdown};
 
 /// Replication service polling other nodes frequently to ask them about new entries from a defined
 /// set of authors and log ids.
@@ -30,7 +29,7 @@ pub async fn replication_service(
     context: Context,
     shutdown: Shutdown,
     tx: ServiceSender,
-    tx_ready: oneshot::Sender<()>,
+    tx_ready: ServiceReadySender,
 ) -> Result<()> {
     // Prepare replication configuration
     let config = &context.config.replication;


### PR DESCRIPTION
Services receive an additional parameter with a oneshot channel to which they send a unit value once they are ready to process messages on the communication bus. This allows us to understand when a service becomes ready from outside the service. Previously there were a couple of tests that waited for some arbitrary time to allow services to become available.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
