### PR TITLE
Refactor `get_expected_skiplink()`

### DIFF
--- a/aquadoggo/src/domain.rs
+++ b/aquadoggo/src/domain.rs
@@ -503,7 +503,7 @@ mod tests {
     #[rstest]
     #[case::ok(&[(0, 8)], (0, 8))]
     #[should_panic(
-        expected = "Expected skiplink target for <Author 53fc96> at log id 0 and seq num 4 not found in database"
+        expected = "Expected skiplink target not found in store: <Author 53fc96>, log id 0, seq num 4"
     )]
     #[case::skiplink_missing(&[(0, 4), (0, 8)], (0, 8))]
     #[should_panic(
@@ -523,7 +523,7 @@ mod tests {
     )]
     #[case::seq_num_occupied_(&[], (0, 7))]
     #[should_panic(
-        expected = "Expected skiplink target for <Author 53fc96> at log id 0 and seq num 4 not found in database"
+        expected = "Expected skiplink target not found in store: <Author 53fc96>, log id 0, seq num 4"
     )]
     #[case::next_args_skiplink_missing(&[(0, 4), (0, 7), (0, 8)], (0, 7))]
     #[should_panic(
@@ -862,7 +862,7 @@ mod tests {
         let result = next_args(&db.store, &public_key, Some(&document_view_id)).await;
         assert_eq!(
             result.unwrap_err().message.as_str(),
-            "Expected skiplink target for <Author 53fc96> at log id 0 and seq num 4 not found in database"
+            "Expected skiplink target not found in store: <Author 53fc96>, log id 0, seq num 4"
         );
     }
 

--- a/aquadoggo/src/validation.rs
+++ b/aquadoggo/src/validation.rs
@@ -6,7 +6,7 @@ use p2panda_rs::entry::{LogId, SeqNum};
 use p2panda_rs::identity::Author;
 use p2panda_rs::operation::AsOperation;
 use p2panda_rs::storage_provider::traits::StorageProvider;
-use p2panda_rs::{Human, Validate};
+use p2panda_rs::Human;
 
 /// Verify that a claimed seq num is the next sequence number following the latest.
 ///

--- a/aquadoggo/src/validation.rs
+++ b/aquadoggo/src/validation.rs
@@ -95,7 +95,6 @@ pub async fn get_expected_skiplink<S: StorageProvider>(
     log_id: &LogId,
     seq_num: &SeqNum,
 ) -> Result<S::StorageEntry> {
-    // Ensure
     ensure!(
         !seq_num.is_first(),
         anyhow!("Entry with seq num 1 can not have skiplink")

--- a/aquadoggo/src/validation.rs
+++ b/aquadoggo/src/validation.rs
@@ -110,7 +110,7 @@ pub async fn get_expected_skiplink<S: StorageProvider>(
     match skiplink_entry {
         Some(entry) => Ok(entry),
         None => Err(anyhow!(
-            "Skiplink target not found in store: {} log id {} seq num {}",
+            "Expected skiplink target not found in store: {}, log id {}, seq num {}",
             author.display(),
             log_id.as_u64(),
             skiplink_seq_num.as_u64()
@@ -274,14 +274,12 @@ mod tests {
     #[rstest]
     #[case::expected_skiplink_is_in_store_and_is_same_as_backlink(KeyPair::from_private_key_str(PRIVATE_KEY).unwrap(), LogId::default(), SeqNum::new(4).unwrap())]
     #[should_panic(
-        expected = "Expected skiplink target for <Author 53fc96> at log id 0 and seq num 19 not found in database"
+        expected = "Expected skiplink target not found in store: <Author 53fc96>, log id 0, seq num 19"
     )]
     #[case::skiplink_not_in_store(KeyPair::from_private_key_str(PRIVATE_KEY).unwrap(), LogId::default(), SeqNum::new(20).unwrap())]
-    #[should_panic(expected = "at log id 0 and seq num 4 not found in database")]
+    #[should_panic(expected = "Expected skiplink target not found in store")]
     #[case::author_does_not_exist(KeyPair::new(), LogId::default(), SeqNum::new(5).unwrap())]
-    #[should_panic(
-        expected = "Expected skiplink target for <Author 53fc96> at log id 4 and seq num 6 not found in database"
-    )]
+    #[should_panic(expected = "<Author 53fc96>, log id 4, seq num 6")]
     #[case::log_id_is_wrong(KeyPair::from_private_key_str(PRIVATE_KEY).unwrap(), LogId::new(4), SeqNum::new(7).unwrap())]
     #[should_panic(expected = "Entry with seq num 1 can not have skiplink")]
     #[case::seq_num_is_one(KeyPair::from_private_key_str(PRIVATE_KEY).unwrap(), LogId::new(0), SeqNum::new(1).unwrap())]


### PR DESCRIPTION
Matches current behavior of `skiplink_seq_num()` method

Describe your changes here.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
