### PR TITLE
Remove unused field from operations data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor scalars and replication API, replace `graphql-client` with `gql_client` [#184](https://github.com/p2panda/aquadoggo/pull/184)
 - Give error types of worker a string for better debugging [#194](https://github.com/p2panda/aquadoggo/pull/194)
 - Bump `p2panda-rs` which now supports log id's starting from `0` [#207](https://github.com/p2panda/aquadoggo/pull/207)
+- Removed unused field `entry_hash` from operation data model [#221](https://github.com/p2panda/aquadoggo/pull/221)
 
 ### Fixed
 

--- a/aquadoggo/migrations/20220509090252_create-operations.sql
+++ b/aquadoggo/migrations/20220509090252_create-operations.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS operations_v1 (
     author                  TEXT            NOT NULL,
     document_id             TEXT            NOT NULL,
     operation_id            TEXT            NOT NULL UNIQUE,
-    entry_hash              TEXT            NOT NULL UNIQUE,
     action                  TEXT            NOT NULL,
     schema_id               TEXT            NOT NULL,
     previous_operations     TEXT            NULL,

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -12,13 +12,12 @@ pub struct OperationRow {
     pub document_id: String,
 
     /// The id of this operation.
+    ///
+    /// Also, the hash of the entry this operation is associated with.
     pub operation_id: String,
 
     /// The action type this operation is performing.
     pub action: String,
-
-    /// The hash of the entry this operation is associated with.
-    pub entry_hash: String,
 
     /// The id of the schema this operation follows.
     pub schema_id: String,
@@ -64,9 +63,6 @@ pub struct OperationFieldsJoinedRow {
 
     /// The action type this operation is performing.
     pub action: String,
-
-    /// The hash of the entry this operation is associated with.
-    pub entry_hash: String,
 
     /// The id of the schema this operation follows.
     pub schema_id: String,

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -86,19 +86,17 @@ impl OperationStore<VerifiedOperation> for SqlStorage {
                     author,
                     document_id,
                     operation_id,
-                    entry_hash,
                     action,
                     schema_id,
                     previous_operations
                 )
             VALUES
-                ($1, $2, $3, $4, $5, $6, $7)
+                ($1, $2, $3, $4, $5, $6)
             ",
         )
         .bind(operation.public_key().as_str())
         .bind(document_id.as_str())
         .bind(operation.operation_id().as_str())
-        .bind(operation.operation_id().as_hash().as_str())
         .bind(operation.action().as_str())
         .bind(operation.schema().as_str())
         .bind(
@@ -193,7 +191,6 @@ impl OperationStore<VerifiedOperation> for SqlStorage {
                 operations_v1.author,
                 operations_v1.document_id,
                 operations_v1.operation_id,
-                operations_v1.entry_hash,
                 operations_v1.action,
                 operations_v1.schema_id,
                 operations_v1.previous_operations,
@@ -232,7 +229,6 @@ impl OperationStore<VerifiedOperation> for SqlStorage {
                 operations_v1.author,
                 operations_v1.document_id,
                 operations_v1.operation_id,
-                operations_v1.entry_hash,
                 operations_v1.action,
                 operations_v1.schema_id,
                 operations_v1.previous_operations,

--- a/aquadoggo/src/db/utils.rs
+++ b/aquadoggo/src/db/utils.rs
@@ -371,8 +371,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -390,8 +388,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -409,8 +405,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -428,8 +422,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -450,8 +442,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -472,8 +462,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -494,8 +482,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -516,8 +502,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -538,8 +522,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -560,8 +542,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -582,8 +562,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
@@ -604,8 +582,6 @@ mod tests {
                     "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
                         .to_string(),
                 action: "create".to_string(),
-                entry_hash: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
-                    .to_string(),
                 schema_id:
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),


### PR DESCRIPTION
The same information is stored in `operation_id` on that model and
`entry_hash` is also not used anywhere afaict.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
