### PR TITLE
The monster refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,24 +538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
-name = "cddl-cat"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259c8f43c4c804869941ba6869864ccd8283fd23beb13b328a65dd77ff780cf6"
-dependencies = [
- "base64",
- "escape8259",
- "float-ord",
- "hex",
- "nom",
- "regex",
- "serde",
- "serde_cbor",
- "strum_macros",
- "thiserror",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,15 +1040,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "escape8259"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edd65c008c6e97290e463c336e0c3fe109a91accb0e6b3e9e353d1605bd58b8"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "event-listener"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,12 +1078,6 @@ dependencies = [
  "rand_core 0.6.3",
  "subtle",
 ]
-
-[[package]]
-name = "float-ord"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
 
 [[package]]
 name = "flume"
@@ -1456,6 +1423,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hkdf"
@@ -2051,12 +2021,11 @@ dependencies = [
 [[package]]
 name = "p2panda-rs"
 version = "0.4.0"
-source = "git+https://github.com/p2panda/p2panda?rev=5d6508d5a9b4b766621c3bd14879cc568fbac02d#5d6508d5a9b4b766621c3bd14879cc568fbac02d"
+source = "git+https://github.com/p2panda/p2panda?rev=467540ed9fa575f32af5b0e5e02f9185c354c880#467540ed9fa575f32af5b0e5e02f9185c354c880"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",
  "bamboo-rs-core-ed25519-yasmf",
- "cddl-cat",
  "ciborium",
  "console_error_panic_hook",
  "ed25519",
@@ -2606,12 +2575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
-
-[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2711,16 +2674,6 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
  "serde",
 ]
 
@@ -3064,19 +3017,6 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
  "syn",
 ]
 

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -33,7 +33,7 @@ lipmaa-link = "^0.2.2"
 log = "^0.4.17"
 once_cell = "^1.12.0"
 openssl-probe = "^0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "5d6508d5a9b4b766621c3bd14879cc568fbac02d" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "467540ed9fa575f32af5b0e5e02f9185c354c880" }
 serde = { version = "^1.0.137", features = ["derive"] }
 sqlx = { version = "^0.6.0", features = [
     "any",
@@ -63,7 +63,7 @@ hex = "0.4.3"
 http = "^0.2.8"
 hyper = "^0.14.19"
 once_cell = "^1.12.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "5d6508d5a9b4b766621c3bd14879cc568fbac02d", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "467540ed9fa575f32af5b0e5e02f9185c354c880", features = [
     "testing",
 ] }
 rand = "^0.8.5"

--- a/aquadoggo/src/db/errors.rs
+++ b/aquadoggo/src/db/errors.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use p2panda_rs::document::{DocumentId, DocumentViewId};
+use p2panda_rs::schema::error::{SchemaError, SchemaIdError};
 use p2panda_rs::schema::system::SystemSchemaError;
-use p2panda_rs::schema::{SchemaError, SchemaIdError};
 
 /// `SQLStorage` errors.
 #[derive(thiserror::Error, Debug)]

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -324,7 +324,8 @@ mod tests {
     };
     use p2panda_rs::entry::{LogId, SeqNum};
     use p2panda_rs::identity::Author;
-    use p2panda_rs::operation::{AsOperation, Operation, OperationId, OperationValue};
+    use p2panda_rs::operation::traits::AsOperation;
+    use p2panda_rs::operation::{Operation, OperationId, OperationValue};
     use p2panda_rs::schema::SchemaId;
     use p2panda_rs::storage_provider::traits::{AsStorageEntry, EntryStore, OperationStore};
     use p2panda_rs::test_utils::constants::SCHEMA_ID;
@@ -374,8 +375,7 @@ mod tests {
         runner: TestDatabaseRunner,
     ) {
         runner.with_db_teardown(|db: TestDatabase| async move {
-            let author =
-                Author::try_from(db.test_data.key_pairs[0].public_key().to_owned()).unwrap();
+            let author = Author::from(db.test_data.key_pairs[0].public_key());
 
             // Get one entry from the pre-polulated db
             let entry = db
@@ -449,12 +449,11 @@ mod tests {
     #[rstest]
     fn inserts_gets_many_document_views(
         #[from(test_db)]
-        #[with(10, 1, 1, false, SCHEMA_ID.parse().unwrap(), vec![("username", OperationValue::Text("panda".into()))], vec![("username", OperationValue::Text("PANDA".into()))])]
+        #[with(10, 1, 1, false, SCHEMA_ID.parse().unwrap(), vec![("username", OperationValue::String("panda".into()))], vec![("username", OperationValue::String("PANDA".into()))])]
         runner: TestDatabaseRunner,
     ) {
         runner.with_db_teardown(|db: TestDatabase| async move {
-            let author =
-                Author::try_from(db.test_data.key_pairs[0].public_key().to_owned()).unwrap();
+            let author = Author::from(db.test_data.key_pairs[0].public_key());
             let schema_id = SchemaId::from_str(SCHEMA_ID).unwrap();
 
             let log_id = LogId::default();
@@ -490,12 +489,12 @@ mod tests {
                 let expected_username = if count == 0 {
                     DocumentViewValue::new(
                         &entry.hash().into(),
-                        &OperationValue::Text("panda".to_string()),
+                        &OperationValue::String("panda".to_string()),
                     )
                 } else {
                     DocumentViewValue::new(
                         &entry.hash().into(),
-                        &OperationValue::Text("PANDA".to_string()),
+                        &OperationValue::String("PANDA".to_string()),
                     )
                 };
                 assert_eq!(document_view.get("username").unwrap(), &expected_username);

--- a/aquadoggo/src/errors.rs
+++ b/aquadoggo/src/errors.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use p2panda_rs::schema::{SchemaId, SchemaIdError};
+use p2panda_rs::schema::error::SchemaIdError;
+use p2panda_rs::schema::SchemaId;
 use thiserror::Error;
 
 /// A result type used in aquadoggo modules.

--- a/aquadoggo/src/graphql/client/dynamic_query.rs
+++ b/aquadoggo/src/graphql/client/dynamic_query.rs
@@ -318,14 +318,24 @@ impl DynamicQuery {
 
                 // Recurse into view lists.
                 OperationValue::RelationList(rel) => {
-                    let queries = rel.clone().into_iter().map(|doc_id| {
-                        self.get_by_document_id(doc_id, ctx, next_selection.clone(), None)
+                    let queries = rel.iter().map(|doc_id| {
+                        self.get_by_document_id(
+                            doc_id.to_owned(),
+                            ctx,
+                            next_selection.clone(),
+                            None,
+                        )
                     });
                     Value::List(future::try_join_all(queries).await?)
                 }
                 OperationValue::PinnedRelationList(rel) => {
-                    let queries = rel.clone().into_iter().map(|view_id| {
-                        self.get_by_document_view_id(view_id, ctx, next_selection.clone(), None)
+                    let queries = rel.iter().map(|view_id| {
+                        self.get_by_document_view_id(
+                            view_id.to_owned(),
+                            ctx,
+                            next_selection.clone(),
+                            None,
+                        )
                     });
                     Value::List(future::try_join_all(queries).await?)
                 }
@@ -354,7 +364,7 @@ fn gql_scalar(operation_value: &OperationValue) -> Value {
         OperationValue::Boolean(value) => value.to_owned().into(),
         OperationValue::Integer(value) => value.to_owned().into(),
         OperationValue::Float(value) => value.to_owned().into(),
-        OperationValue::Text(value) => value.to_owned().into(),
+        OperationValue::String(value) => value.to_owned().into(),
         // only use for scalars
         _ => panic!("can only return scalar values"),
     }
@@ -383,7 +393,7 @@ mod test {
 
             // Add schema to node.
             let schema = db
-                .add_schema("schema_name", vec![("bool", FieldType::Bool)], &key_pair)
+                .add_schema("schema_name", vec![("bool", FieldType::Boolean)], &key_pair)
                 .await;
 
             // Publish document on node.
@@ -513,7 +523,7 @@ mod test {
 
             // Add schema to node.
             let schema = db
-                .add_schema("schema_name", vec![("bool", FieldType::Bool)], &key_pair)
+                .add_schema("schema_name", vec![("bool", FieldType::Boolean)], &key_pair)
                 .await;
 
             // Publish document on node.

--- a/aquadoggo/src/graphql/client/dynamic_types/utils.rs
+++ b/aquadoggo/src/graphql/client/dynamic_types/utils.rs
@@ -10,8 +10,8 @@ use p2panda_rs::schema::FieldType;
 pub fn graphql_typename(operation_field_type: &FieldType) -> String {
     match operation_field_type {
         // Scalars
-        FieldType::Bool => "Boolean".to_string(),
-        FieldType::Int => "Int".to_string(),
+        FieldType::Boolean => "Boolean".to_string(),
+        FieldType::Integer => "Int".to_string(),
         FieldType::Float => "Float".to_string(),
         FieldType::String => "String".to_string(),
 

--- a/aquadoggo/src/graphql/client/static_query.rs
+++ b/aquadoggo/src/graphql/client/static_query.rs
@@ -131,7 +131,7 @@ mod tests {
 
             let document_id = db.test_data.documents.get(0).unwrap();
             let author =
-                Author::try_from(db.test_data.key_pairs[0].public_key().to_owned()).unwrap();
+                Author::from(db.test_data.key_pairs[0].public_key());
 
             // Selected fields need to be alphabetically sorted because that's what the `json`
             // macro that is used in the assert below produces.

--- a/aquadoggo/src/graphql/replication/query.rs
+++ b/aquadoggo/src/graphql/replication/query.rs
@@ -248,15 +248,7 @@ mod tests {
 
             // The test runner creates a test entry for us, we can retreive the public key from the
             // author
-            let public_key: Author = db
-                .test_data
-                .key_pairs
-                .first()
-                .unwrap()
-                .public_key()
-                .to_owned()
-                .try_into()
-                .unwrap();
+            let public_key: Author = db.test_data.key_pairs.first().unwrap().public_key().into();
 
             // Construct the query
             let gql_query = format!(
@@ -348,15 +340,9 @@ mod tests {
 
             // Get public key from author of generated test data
             let public_key: String = {
-                let key_from_db = billie_db
-                    .test_data
-                    .key_pairs
-                    .first()
-                    .unwrap()
-                    .public_key()
-                    .to_owned();
+                let key_from_db = billie_db.test_data.key_pairs.first().unwrap().public_key();
 
-                let author = Author::try_from(key_from_db).unwrap();
+                let author = Author::from(key_from_db);
                 author.as_str().into()
             };
 

--- a/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
@@ -35,8 +35,7 @@ impl From<&DocumentViewId> for DocumentViewIdScalar {
 
 impl From<&DocumentViewIdScalar> for DocumentViewId {
     fn from(value: &DocumentViewIdScalar) -> Self {
-        // Unwrap because `DocumentViewIdScalar` is always safely intialised.
-        DocumentViewId::new(value.0.graph_tips()).unwrap()
+        DocumentViewId::new(value.0.graph_tips())
     }
 }
 

--- a/aquadoggo/src/graphql/scalars/encoded_operation_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/encoded_operation_scalar.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use async_graphql::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
-use p2panda_rs::operation::OperationEncoded;
+use p2panda_rs::operation::EncodedOperation;
 use serde::{Deserialize, Serialize};
 
 /// Entry payload and p2panda operation, CBOR bytes encoded as a hexadecimal string.
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
-pub struct EncodedOperationScalar(OperationEncoded);
+pub struct EncodedOperationScalar(EncodedOperation);
 
 #[Scalar]
 impl ScalarType for EncodedOperationScalar {
     fn parse(value: Value) -> InputValueResult<Self> {
         match &value {
             Value::String(str_value) => {
-                let panda_value = OperationEncoded::new(str_value)?;
+                let panda_value = EncodedOperation::new(str_value.as_bytes());
                 Ok(EncodedOperationScalar(panda_value))
             }
             _ => Err(InputValueError::expected_type(value)),
@@ -21,18 +21,18 @@ impl ScalarType for EncodedOperationScalar {
     }
 
     fn to_value(&self) -> Value {
-        Value::String(self.0.as_str().to_string())
+        Value::String(self.0.to_string())
     }
 }
 
-impl From<OperationEncoded> for EncodedOperationScalar {
-    fn from(operation: OperationEncoded) -> Self {
+impl From<EncodedOperation> for EncodedOperationScalar {
+    fn from(operation: EncodedOperation) -> Self {
         Self(operation)
     }
 }
 
-impl From<EncodedOperationScalar> for OperationEncoded {
-    fn from(operation: EncodedOperationScalar) -> OperationEncoded {
+impl From<EncodedOperationScalar> for EncodedOperation {
+    fn from(operation: EncodedOperationScalar) -> EncodedOperation {
         operation.0
     }
 }

--- a/aquadoggo/src/graphql/scalars/entry_signed_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/entry_signed_scalar.rs
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use async_graphql::{InputValueError, Scalar, ScalarType, Value};
-use p2panda_rs::entry::EntrySigned;
+use p2panda_rs::entry::EncodedEntry;
 use serde::{Deserialize, Serialize};
 
 /// Signed bamboo entry, encoded as a hexadecimal string.
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
-pub struct EntrySignedScalar(EntrySigned);
+pub struct EntrySignedScalar(EncodedEntry);
 
 #[Scalar]
 impl ScalarType for EntrySignedScalar {
     fn parse(value: Value) -> async_graphql::InputValueResult<Self> {
         match &value {
             Value::String(str_value) => {
-                let panda_value = EntrySigned::new(str_value)?;
+                let panda_value = EncodedEntry::new(str_value.as_bytes());
                 Ok(EntrySignedScalar(panda_value))
             }
             _ => Err(InputValueError::expected_type(value)),
@@ -21,18 +21,18 @@ impl ScalarType for EntrySignedScalar {
     }
 
     fn to_value(&self) -> Value {
-        Value::String(self.0.as_str().to_string())
+        Value::String(self.0.to_string())
     }
 }
 
-impl From<EntrySigned> for EntrySignedScalar {
-    fn from(entry: EntrySigned) -> Self {
+impl From<EncodedEntry> for EntrySignedScalar {
+    fn from(entry: EncodedEntry) -> Self {
         Self(entry)
     }
 }
 
-impl From<EntrySignedScalar> for EntrySigned {
-    fn from(entry: EntrySignedScalar) -> EntrySigned {
+impl From<EntrySignedScalar> for EncodedEntry {
+    fn from(entry: EntrySignedScalar) -> EncodedEntry {
         entry.0
     }
 }

--- a/aquadoggo/src/graphql/scalars/seq_num_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/seq_num_scalar.rs
@@ -6,7 +6,8 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use async_graphql::scalar;
-use p2panda_rs::entry::{SeqNum, SeqNumError};
+use p2panda_rs::entry::error::SeqNumError;
+use p2panda_rs::entry::SeqNum;
 use serde::{Deserialize, Serialize};
 
 /// Sequence number of an entry.

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -140,9 +140,9 @@ mod tests {
 
     use p2panda_rs::document::DocumentViewId;
     use p2panda_rs::identity::KeyPair;
+    use p2panda_rs::operation::traits::AsOperation;
     use p2panda_rs::operation::{
-        AsVerifiedOperation, Operation, OperationValue, PinnedRelation, PinnedRelationList,
-        Relation, RelationList,
+        Operation, OperationValue, PinnedRelation, PinnedRelationList, Relation, RelationList,
     };
     use p2panda_rs::storage_provider::traits::OperationStore;
     use p2panda_rs::test_utils::constants::SCHEMA_ID;

--- a/aquadoggo/src/materializer/tasks/dependency.rs
+++ b/aquadoggo/src/materializer/tasks/dependency.rs
@@ -176,9 +176,9 @@ mod tests {
 
     use p2panda_rs::document::{DocumentId, DocumentViewId};
     use p2panda_rs::identity::KeyPair;
+    use p2panda_rs::operation::traits::AsVerifiedOperation;
     use p2panda_rs::operation::{
-        AsVerifiedOperation, Operation, OperationValue, PinnedRelation, PinnedRelationList,
-        Relation, RelationList,
+        Operation, OperationValue, PinnedRelation, PinnedRelationList, Relation, RelationList,
     };
     use p2panda_rs::schema::{FieldType, SchemaId};
     use p2panda_rs::storage_provider::traits::OperationStore;

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -92,11 +92,11 @@ async fn resolve_document_id<S: StorageProvider>(
             // https://github.com/p2panda/aquadoggo/issues/148
             debug!("Find document for view with id: {}", document_view_id);
 
-            let operation_id = document_view_id.clone().into_iter().next().unwrap();
+            let operation_id = document_view_id.iter().next().unwrap();
 
             context
                 .store
-                .get_document_by_operation_id(&operation_id)
+                .get_document_by_operation_id(operation_id)
                 .await
                 .map_err(|err| TaskError::Critical(err.to_string()))
         }
@@ -197,7 +197,8 @@ async fn reduce_document(
 #[cfg(test)]
 mod tests {
     use p2panda_rs::document::{DocumentBuilder, DocumentId, DocumentViewId};
-    use p2panda_rs::operation::{AsVerifiedOperation, OperationValue};
+    use p2panda_rs::operation::traits::AsVerifiedOperation;
+    use p2panda_rs::operation::OperationValue;
     use p2panda_rs::storage_provider::traits::OperationStore;
     use p2panda_rs::test_utils::constants::SCHEMA_ID;
     use p2panda_rs::test_utils::fixtures::{

--- a/aquadoggo/src/materializer/tasks/schema.rs
+++ b/aquadoggo/src/materializer/tasks/schema.rs
@@ -97,7 +97,7 @@ async fn get_related_schema_definitions(
         if let OperationValue::PinnedRelationList(fields) = fields_value {
             if fields
                 .iter()
-                .any(|field_view_id| &field_view_id == target_field_definition)
+                .any(|field_view_id| field_view_id == target_field_definition)
             {
                 related_schema_definitions.push(schema.id().clone())
             } else {
@@ -144,7 +144,7 @@ mod tests {
         let create_field_definition = Operation::new_create(
             SchemaId::SchemaFieldDefinition(1),
             operation_fields(vec![
-                ("name", OperationValue::Text("field_name".to_string())),
+                ("name", OperationValue::String("field_name".to_string())),
                 ("type", FieldType::String.into()),
             ]),
         )
@@ -170,10 +170,10 @@ mod tests {
         let create_schema_definition = Operation::new_create(
             SchemaId::SchemaDefinition(1),
             operation_fields(vec![
-                ("name", OperationValue::Text("schema_name".to_string())),
+                ("name", OperationValue::String("schema_name".to_string())),
                 (
                     "description",
-                    OperationValue::Text("description".to_string()),
+                    OperationValue::String("description".to_string()),
                 ),
                 (
                     "fields",

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -169,7 +169,7 @@ async fn insert_new_entries(
 
         publish(
             &context.0.store,
-            entry.entry_signed(),
+            &entry.entry_signed(),
             entry
                 .operation_encoded()
                 .expect("All stored entries contain an operation"),

--- a/aquadoggo/src/validation.rs
+++ b/aquadoggo/src/validation.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, ensure, Result};
 use p2panda_rs::document::DocumentId;
 use p2panda_rs::entry::{LogId, SeqNum};
 use p2panda_rs::identity::Author;
-use p2panda_rs::operation::AsOperation;
+use p2panda_rs::operation::traits::AsOperation;
 use p2panda_rs::storage_provider::traits::StorageProvider;
 use p2panda_rs::Human;
 


### PR DESCRIPTION
Integrate new API for the "monster" https://github.com/p2panda/p2panda/pull/415

- new validation methods
  - introduce validating operations against schema 
  - rewrite all validation in GraphQL / `publish()` / `next_args()`
  - replace bamboo verify with new validation methods
- `StorageEntry`
  - no longer contains it's payload `EncodedOperation`, need to refactor in many places where this is expected
  - rework constructor so it can't fail 
- `ValidatedOperation`
  - we can no longer directly construct this so we need an own type in `aquadoggo` representing operations coming from the db
- `Operation`
  - constructors now accept fields as vec (introduce conversion trait for `OperatoinFields`?)
  - `::new_create()`, `::new_update()`, `::new_delete()` no longer exist, use `OperationBuilder()` instead
- `EntryEncoded` -> `Operation` decoding difficult now but we rely on this in some testing patterns
- `EncodedEntryAndOperation` replication needs operation from store

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
