### PR TITLE
Wrap document insertion methods in transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement new API for untagged operations [#245](https://github.com/p2panda/aquadoggo/pull/235)
 - Use `DocumentStore` trait from `p2panda_rs` [#249](https://github.com/p2panda/aquadoggo/pull/249)
 - Increase broadcast channel sizes [#257](https://github.com/p2panda/aquadoggo/pull/257)
+- Use transaction in `insert_document()` [#259](https://github.com/p2panda/aquadoggo/pull/259)
 
 ### Fixed
 


### PR DESCRIPTION
In `insert_document` perform two db insertions, these should be wrapped in a transaction.

Fix for: #254  and _hopefully_ #247 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
