### PR TITLE
Replication by schema

### DIFF
--- a/aquadoggo/src/Test.js
+++ b/aquadoggo/src/Test.js
@@ -1,4 +1,0 @@
-function test() {
-  // This function prints console hello fiona
-  return console.log("hello fiona");
-}

--- a/aquadoggo/src/Test.js
+++ b/aquadoggo/src/Test.js
@@ -1,0 +1,4 @@
+function test() {
+  // This function prints console hello fiona
+  return console.log("hello fiona");
+}

--- a/aquadoggo/src/graphql/pagination.rs
+++ b/aquadoggo/src/graphql/pagination.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Generic pagination response of GraphQL connection API.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Paginated<T, C> {
+pub struct  Paginated<T, C> {
     pub edges: Vec<PaginatedEdges<T, C>>,
     pub page_info: PaginatedInfo,
 }

--- a/aquadoggo/src/graphql/replication/client.rs
+++ b/aquadoggo/src/graphql/replication/client.rs
@@ -6,12 +6,14 @@ use anyhow::{anyhow, Result};
 use gql_client::Client;
 use p2panda_rs::entry::{LogId, SeqNum};
 use p2panda_rs::identity::Author;
+use p2panda_rs::schema::SchemaId;
 use serde::{Deserialize, Serialize};
 
+use crate::AuthorToReplicate;
 use crate::db::stores::StorageEntry;
-use crate::graphql::pagination::Paginated;
+use crate::graphql::pagination::{Paginated, PaginatedInfo};
 use crate::graphql::replication::response::EncodedEntryAndOperation;
-use crate::graphql::scalars;
+use crate::graphql::scalars::{self, PublicKeyScalar};
 
 /// Response type of `entries_newer_than_seq_num` query.
 #[derive(Serialize, Deserialize)]
@@ -20,15 +22,64 @@ struct Response {
     entries_newer_than_seq_num: Paginated<EncodedEntryAndOperation, scalars::SeqNumScalar>,
 }
 
+pub async fn logs_by_schema(remote_peer: &str, schema_id: &SchemaId) -> Paginated<AuthorToReplicate, PublicKeyScalar> {
+    // @TODO: Currently this method does not use pagination, we will need to call this multiple
+    // times and eventually we will get up to date.
+    let query = format!(
+        r#"
+            query {{
+                entriesNewerThanSeqNum(
+                    logId: "{}",
+                    publicKey: "{}",
+                    seqNum: {}
+                ) {{
+                    edges {{
+                        cursor
+                        node {{
+                            public_key
+                            log_id
+                        }}
+                    }}
+                    pageInfo {{
+                        hasNextPage
+                    }}
+                }}
+            }}
+        "#,
+        log_id.as_u64(),
+        public_key.as_str(),
+        latest_seq_num
+            .map(|num| num.as_u64().to_string())
+            .unwrap_or_else(|| "null".into()),
+    );
+
+    // Make GraphQL request
+    let client = Client::new(endpoint);
+    let response: Response = client
+        .query_unwrap(&query)
+        .await
+        .map_err(|err| anyhow!("Replication query failed with error {}", err))?;
+
+    // Convert results to correct return type
+    let entries = response
+        .entries_newer_than_seq_num
+        .edges
+        .into_iter()
+        .map(|edge| edge.node.try_into())
+        .collect::<Result<Vec<StorageEntry>>>()?;
+
+    Ok((response.entries_newer_than_seq_num.page_info, entries))
+}
+
 /// Attempts to get entries newer than the given sequence number for a public key and log id.
 pub async fn entries_newer_than_seq_num(
     endpoint: &str,
     log_id: &LogId,
     public_key: &Author,
     latest_seq_num: Option<&SeqNum>,
-) -> Result<Vec<StorageEntry>> {
-    // @TODO: Currently this method does not use pagination, you will need to call this multiple
-    // times and eventually you we will get up to date.
+) -> Result<(PaginatedInfo, Vec<StorageEntry>)> {
+    // @TODO: Currently this method does not use pagination, we will need to call this multiple
+    // times and eventually we will get up to date.
     let query = format!(
         r#"
             query {{
@@ -72,5 +123,5 @@ pub async fn entries_newer_than_seq_num(
         .map(|edge| edge.node.try_into())
         .collect::<Result<Vec<StorageEntry>>>()?;
 
-    Ok(entries)
+    Ok((response.entries_newer_than_seq_num.page_info, entries))
 }

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -32,7 +32,7 @@ mod validation;
 mod test_helpers;
 
 pub use crate::config::Configuration;
-pub use crate::replication::ReplicationConfiguration;
+pub use crate::replication::{ReplicationConfiguration, AuthorToReplicate, SchemaToReplicate};
 pub use node::Node;
 pub use schema::SchemaProvider;
 

--- a/aquadoggo/src/replication/config.rs
+++ b/aquadoggo/src/replication/config.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 use anyhow::{Error, Result};
 use p2panda_rs::entry::LogId;
 use p2panda_rs::identity::Author;
+use p2panda_rs::schema::SchemaId;
 use serde::Deserialize;
 
 /// Configuration for the replication service.
@@ -18,7 +19,10 @@ pub struct ReplicationConfiguration {
     pub remote_peers: Vec<String>,
 
     /// The authors to replicate and their log ids.
-    pub authors_to_replicate: Vec<AuthorToReplicate>,
+    pub replicate_by_author: Option<Vec<AuthorToReplicate>>,
+
+    /// The schema ids of schemas to replicate.
+    pub replicate_by_schema: Option<Vec<SchemaId>>,
 }
 
 impl Default for ReplicationConfiguration {
@@ -26,7 +30,8 @@ impl Default for ReplicationConfiguration {
         Self {
             connection_interval_seconds: 30,
             remote_peers: Vec::new(),
-            authors_to_replicate: Vec::new(),
+            replicate_by_author: Some(Vec::new()),
+            replicate_by_schema: Some(Vec::new()),
         }
     }
 }

--- a/aquadoggo/src/replication/config.rs
+++ b/aquadoggo/src/replication/config.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::convert::TryFrom;
+use std::str::FromStr;
 
 use anyhow::{Error, Result};
 use p2panda_rs::entry::LogId;
@@ -22,7 +23,7 @@ pub struct ReplicationConfiguration {
     pub replicate_by_author: Option<Vec<AuthorToReplicate>>,
 
     /// The schema ids of schemas to replicate.
-    pub replicate_by_schema: Option<Vec<SchemaId>>,
+    pub replicate_by_schema: Option<Vec<SchemaToReplicate>>,
 }
 
 impl Default for ReplicationConfiguration {
@@ -60,5 +61,28 @@ impl TryFrom<(String, Vec<u64>)> for AuthorToReplicate {
         let log_ids = value.1.into_iter().map(LogId::new).collect();
 
         Ok(Self(author, log_ids))
+    }
+}
+
+/// Replication configuration for a single schema.
+///
+/// Currently only contains the schema's id.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SchemaToReplicate(SchemaId);
+
+impl SchemaToReplicate {
+    /// Access the configured schema id.
+    pub fn schema_id(&self) -> &SchemaId {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for SchemaToReplicate {
+    type Error = Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let schema_id = SchemaId::from_str(&value)?;
+
+        Ok(Self(schema_id))
     }
 }

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -3,6 +3,7 @@
 mod config;
 mod service;
 mod replicate_authors;
+mod replicate_schemas;
 
 pub use config::{ReplicationConfiguration, AuthorToReplicate, SchemaToReplicate};
 pub use service::replication_service;

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod service;
+mod replicate_authors;
 
 pub use config::ReplicationConfiguration;
 pub use service::replication_service;

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -4,5 +4,5 @@ mod config;
 mod service;
 mod replicate_authors;
 
-pub use config::ReplicationConfiguration;
+pub use config::{ReplicationConfiguration, AuthorToReplicate, SchemaToReplicate};
 pub use service::replication_service;

--- a/aquadoggo/src/replication/replicate_authors.rs
+++ b/aquadoggo/src/replication/replicate_authors.rs
@@ -1,0 +1,81 @@
+use std::sync::Arc;
+
+use log::{debug, warn, error};
+use p2panda_rs::entry::{LogId, SeqNum};
+use p2panda_rs::identity::Author;
+use p2panda_rs::storage_provider::traits::EntryStore;
+
+use crate::bus::ServiceMessage;
+use crate::context::Context;
+use crate::graphql::replication::client;
+use crate::replication::service::{insert_new_entries, verify_entries};
+
+pub async fn replicate_authors(
+    authors_to_replicate: Arc<Vec<super::config::AuthorToReplicate>>,
+    context: &Context,
+    remote_peer: &String,
+    tx: &tokio::sync::broadcast::Sender<ServiceMessage>,
+) {
+    for author_to_replicate in authors_to_replicate.clone().iter() {
+        let author = author_to_replicate.author().clone();
+        let log_ids = author_to_replicate.log_ids().clone();
+
+        for log_id in log_ids {
+            // Get the latest sequence number we have for this log and author
+            let latest_seq_num = get_latest_seq_num(context, &log_id, &author).await;
+            debug!(
+                "Latest entry sequence number of {} and {}: {:?}",
+                log_id.as_u64(),
+                author,
+                latest_seq_num
+            );
+
+            // Make our replication request to the remote peer
+            let response = client::entries_newer_than_seq_num(
+                remote_peer,
+                &log_id,
+                &author,
+                latest_seq_num.as_ref(),
+            )
+            .await;
+
+            match response {
+                Ok(entries) => {
+                    debug!(
+                        "Received {} new entries from peer {}",
+                        entries.len(),
+                        remote_peer
+                    );
+
+                    if let Err(err) = verify_entries(&entries, &context).await {
+                        warn!("Couldn't verify entries: {}", err);
+                        continue;
+                    }
+
+                    insert_new_entries(&entries, &context, tx.clone())
+                        .await
+                        .unwrap_or_else(|err| error!("{:?}", err));
+                }
+                Err(err) => {
+                    warn!(
+                        "Replication request to peer {} failed: {}",
+                        remote_peer, err
+                    );
+                }
+            }
+        }
+    }
+}
+
+
+
+/// Helper method to get the latest sequence number of a log and author.
+async fn get_latest_seq_num(context: &Context, log_id: &LogId, author: &Author) -> Option<SeqNum> {
+    context
+        .store
+        .get_latest_entry(author, log_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|entry| *entry.entry_decoded().seq_num())
+}

--- a/aquadoggo/src/replication/replicate_schemas.rs
+++ b/aquadoggo/src/replication/replicate_schemas.rs
@@ -1,28 +1,55 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::error::Error;
 use std::sync::Arc;
+use std::time::Duration;
 
-use log::{debug, warn, error};
+use async_graphql::connection::PageInfo;
+use log::{debug, error, warn};
 use p2panda_rs::entry::{LogId, SeqNum};
 use p2panda_rs::identity::Author;
+use p2panda_rs::schema::SchemaId;
 use p2panda_rs::storage_provider::traits::EntryStore;
 
 use crate::bus::ServiceMessage;
 use crate::context::Context;
+use crate::graphql::pagination::PaginatedInfo;
 use crate::graphql::replication::client;
 use crate::replication::service::{insert_new_entries, verify_entries};
 
-pub async fn replicate_authors(
-    authors_to_replicate: Arc<Vec<super::config::AuthorToReplicate>>,
+/// Fully replicate a set of schemas from a local peer.
+pub async fn replicate_schemas(
+    schemas_to_replicate: Arc<Vec<super::config::SchemaToReplicate>>,
     context: &Context,
     remote_peer: &String,
     tx: &tokio::sync::broadcast::Sender<ServiceMessage>,
 ) {
-    for author_to_replicate in authors_to_replicate.clone().iter() {
-        let author = author_to_replicate.author().clone();
-        let log_ids = author_to_replicate.log_ids().clone();
+    let mut has_next_page=true;
 
-        for log_id in log_ids {
+    for schema_to_replicate in schemas_to_replicate.clone().iter() {
+        let schema_id = schema_to_replicate.schema_id();
+
+        while has_next_page {
+            let result = client::logs_by_schema(remote_peer, schema_id).await;
+            for edge in result.edges {
+                let author = edge.node.author().clone();
+
+                let log_ids = edge.node.log_ids().clone();
+                replicate_author(author, log_ids, context, remote_peer, tx).await;
+            }
+        }
+    }
+}
+
+pub async fn replicate_author(
+    author: Author,
+    log_ids: Vec<LogId>,
+    context: &Context,
+    remote_peer: &String,
+    tx: &tokio::sync::broadcast::Sender<ServiceMessage>,
+) {
+    for log_id in log_ids {
+        loop {
             // Get the latest sequence number we have for this log and author
             let latest_seq_num = get_latest_seq_num(context, &log_id, &author).await;
             debug!(
@@ -42,7 +69,7 @@ pub async fn replicate_authors(
             .await;
 
             match response {
-                Ok((_, entries)) => {
+                Ok((info, entries)) => {
                     debug!(
                         "Received {} new entries from peer {}",
                         entries.len(),
@@ -51,25 +78,31 @@ pub async fn replicate_authors(
 
                     if let Err(err) = verify_entries(&entries, context).await {
                         warn!("Couldn't verify entries: {}", err);
-                        continue;
+                        break;
                     }
 
                     insert_new_entries(&entries, context, tx.clone())
                         .await
                         .unwrap_or_else(|err| error!("{:?}", err));
+
+                    if !info.has_next_page {
+                        break;
+                    }
+
+                    // Wait a couple of seconds before we attempt next replication requests
+                    tokio::time::sleep(Duration::from_secs(1)).await;
                 }
                 Err(err) => {
                     warn!(
                         "Replication request to peer {} failed: {}",
                         remote_peer, err
                     );
+                    break;
                 }
             }
         }
     }
 }
-
-
 
 /// Helper method to get the latest sequence number of a log and author.
 async fn get_latest_seq_num(context: &Context, log_id: &LogId, author: &Author) -> Option<SeqNum> {

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -63,7 +63,7 @@ impl TryFrom<Opt> for Configuration {
 
         config.replication = ReplicationConfiguration {
             remote_peers: opt.remote_node_addresses,
-            authors_to_replicate,
+            replicate_by_author: authors_to_replicate,
             ..ReplicationConfiguration::default()
         };
 


### PR DESCRIPTION
# Overview

This PR enables configuring a node to replicate all documents from connected remote nodes that belong to a given schema. This is achieved by querying for logs that belong to this schema and then using the existing replication-mechanism to replicate these logs.

## Todo

- [x] Add config option `replicate_by_schema`
- [ ] Request and handle logs for configured schemas
- [ ] Add endpoint for requesting logs by schema

## Changes and remarks

- The config option `authors_to_replicate` has bee renamed to `replicate_by_author`


## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
