### PR TITLE
Fix test-runner race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix pollution of mutably shared schema store during testing
+
 ## [0.4.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix pollution of mutably shared schema store during testing
+- Fix race-condition of mutably shared static schema store during testing [#269](https://github.com/p2panda/aquadoggo/pull/269)
 
 ## [0.4.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "rstest_reuse",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlx",
  "thiserror",
  "tokio",
@@ -658,6 +659,18 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -2155,6 +2168,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538c30747ae860d6fb88330addbbd3e0ddbe46d662d032855596d8a8ca260611"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079a83df15f85d89a68d64ae1238f142f172b1fa915d0d76b26a7cba1b659a69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -78,5 +78,6 @@ reqwest = { version = "^0.11.11", default-features = false, features = [
 rstest = "^0.15.0"
 rstest_reuse = "^0.3.0"
 serde_json = "^1.0.85"
+serial_test = "1.0.0"
 tower = "^0.4.13"
 tower-service = "^0.3.2"

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -336,7 +336,7 @@ mod tests {
     use p2panda_rs::operation::traits::AsOperation;
     use p2panda_rs::operation::{Operation, OperationId};
     use p2panda_rs::storage_provider::traits::StorageProvider;
-    use p2panda_rs::test_utils::constants::{self};
+    use p2panda_rs::test_utils::constants;
     use p2panda_rs::test_utils::fixtures::{
         operation, random_document_view_id, random_operation_id,
     };

--- a/aquadoggo/src/graphql/client/dynamic_query.rs
+++ b/aquadoggo/src/graphql/client/dynamic_query.rs
@@ -419,6 +419,7 @@ mod test {
     use p2panda_rs::test_utils::fixtures::random_key_pair;
     use rstest::rstest;
     use serde_json::json;
+    use serial_test::serial;
 
     use crate::db::stores::test_utils::{
         add_document, add_schema, test_db, TestDatabase, TestDatabaseRunner,
@@ -426,6 +427,12 @@ mod test {
     use crate::test_helpers::graphql_test_client;
 
     #[rstest]
+    // Note: This and more tests in this file use the underlying static schema provider which is a
+    // static mutable data store, accessible across all test runner threads in parallel mode. To
+    // prevent overwriting data across threads we have to run this test in serial.
+    //
+    // Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
+    #[serial]
     fn single_query(#[from(test_db)] runner: TestDatabaseRunner) {
         // Test single query parameter variations.
 
@@ -482,6 +489,7 @@ mod test {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     #[case::unknown_document_id(
         "id: \"00208f7492d6eb01360a886dac93da88982029484d8c04a0bd2ac0607101b80a6634\"",
         value!({
@@ -555,6 +563,7 @@ mod test {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     fn collection_query(#[from(test_db)] runner: TestDatabaseRunner) {
         // Test collection query parameter variations.
 
@@ -602,6 +611,7 @@ mod test {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     fn type_name(#[from(test_db)] runner: TestDatabaseRunner) {
         // Test availability of `__typename` on all objects.
 

--- a/aquadoggo/src/graphql/client/dynamic_types/tests.rs
+++ b/aquadoggo/src/graphql/client/dynamic_types/tests.rs
@@ -6,11 +6,18 @@ use p2panda_rs::schema::{FieldType, SchemaId, SYSTEM_SCHEMAS};
 use p2panda_rs::test_utils::fixtures::random_key_pair;
 use rstest::rstest;
 use serde_json::json;
+use serial_test::serial;
 
 use crate::db::stores::test_utils::{add_schema, test_db, TestDatabase, TestDatabaseRunner};
 use crate::test_helpers::graphql_test_client;
 
 #[rstest]
+// Note: This and more tests in this file use the underlying static schema provider which is a
+// static mutable data store, accessible across all test runner threads in parallel mode. To
+// prevent overwriting data across threads we have to run this test in serial.
+//
+// Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
+#[serial]
 #[case(SYSTEM_SCHEMAS[0].id().to_string(), SYSTEM_SCHEMAS[0].description().to_string())]
 #[case(SYSTEM_SCHEMAS[1].id().to_string(), SYSTEM_SCHEMAS[1].description().to_string())]
 fn system_schema_container_type(
@@ -71,6 +78,7 @@ fn system_schema_container_type(
 }
 
 #[rstest]
+#[serial] // See note above on why we execute this test in series
 fn application_schema_container_type(#[from(test_db)] runner: TestDatabaseRunner) {
     runner.with_db_teardown(move |mut db: TestDatabase| async move {
         let key_pair = random_key_pair();
@@ -137,6 +145,7 @@ fn application_schema_container_type(#[from(test_db)] runner: TestDatabaseRunner
 }
 
 #[rstest]
+#[serial] // See note above on why we execute this test in series
 fn application_schema_fields_type(#[from(test_db)] runner: TestDatabaseRunner) {
     runner.with_db_teardown(move |mut db: TestDatabase| async move {
         let key_pair = random_key_pair();
@@ -220,6 +229,7 @@ fn application_schema_fields_type(#[from(test_db)] runner: TestDatabaseRunner) {
 }
 
 #[rstest]
+#[serial] // See note above on why we execute this test in series
 fn metadata_type(#[from(test_db)] runner: TestDatabaseRunner) {
     runner.with_db_teardown(move |db: TestDatabase| async move {
         let client = graphql_test_client(&db).await;

--- a/aquadoggo/src/graphql/client/mutation.rs
+++ b/aquadoggo/src/graphql/client/mutation.rs
@@ -106,6 +106,7 @@ mod tests {
     };
     use rstest::{fixture, rstest};
     use serde_json::json;
+    use serial_test::serial;
     use tokio::sync::broadcast;
 
     use crate::bus::ServiceMessage;
@@ -198,6 +199,12 @@ mod tests {
     }
 
     #[rstest]
+    // Note: This and more tests in this file use the underlying static schema provider which is a
+    // static mutable data store, accessible across all test runner threads in parallel mode. To
+    // prevent overwriting data across threads we have to run this test in serial.
+    //
+    // Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
+    #[serial]
     fn publish_entry(
         #[from(test_db)]
         #[with(0, 0, 0, false, test_schema())]
@@ -226,6 +233,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     fn sends_message_on_communication_bus(
         #[from(test_db)]
         #[with(0, 0, 0, false, test_schema())]
@@ -253,6 +261,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     fn post_gql_mutation(
         #[from(test_db)]
         #[with(0, 0, 0, false, test_schema())]
@@ -291,6 +300,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     #[case::invalid_entry_bytes(
         "AB01",
         &OPERATION_ENCODED,
@@ -507,6 +517,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     #[case::backlink_and_skiplink_not_in_db(
         &entry_signed_encoded_unvalidated(
             8,
@@ -637,6 +648,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     fn publish_many_entries(
         #[from(test_db)]
         #[with(0, 0, 0, false, doggo_schema())]
@@ -726,6 +738,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     fn duplicate_publishing_of_entries(
         #[from(test_db)]
         #[with(1, 1, 1, false, doggo_schema())]
@@ -770,6 +783,7 @@ mod tests {
     }
 
     #[rstest]
+    #[serial] // See note above on why we execute this test in series
     fn publish_unsupported_schema(
         #[from(encoded_entry)] entry_with_unsupported_schema: EncodedEntry,
         #[from(encoded_operation)] operation_with_unsupported_schema: EncodedOperation,

--- a/aquadoggo/src/graphql/client/tests.rs
+++ b/aquadoggo/src/graphql/client/tests.rs
@@ -9,6 +9,7 @@ use p2panda_rs::schema::FieldType;
 use p2panda_rs::test_utils::fixtures::random_key_pair;
 use rstest::rstest;
 use serde_json::json;
+use serial_test::serial;
 
 use crate::db::stores::test_utils::{
     add_document, add_schema, test_db, TestDatabase, TestDatabaseRunner,
@@ -18,6 +19,12 @@ use crate::test_helpers::graphql_test_client;
 // Test querying application documents with scalar fields (no relations) by document id and by view
 // id.
 #[rstest]
+// Note: This and more tests in this file use the underlying static schema provider which is a
+// static mutable data store, accessible across all test runner threads in parallel mode. To
+// prevent overwriting data across threads we have to run this test in serial.
+//
+// Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
+#[serial]
 fn scalar_fields(#[from(test_db)] runner: TestDatabaseRunner) {
     runner.with_db_teardown(&|mut db: TestDatabase| async move {
         let key_pair = random_key_pair();
@@ -91,6 +98,7 @@ fn scalar_fields(#[from(test_db)] runner: TestDatabaseRunner) {
 // Test querying application documents across a parent-child relation using different kinds of
 // relation fields.
 #[rstest]
+#[serial] // See note above on why we execute this test in series
 fn relation_fields(#[from(test_db)] runner: TestDatabaseRunner) {
     runner.with_db_teardown(&|mut db: TestDatabase| async move {
         let key_pair = random_key_pair();

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -206,11 +206,18 @@ mod test {
     use p2panda_rs::test_utils::fixtures::key_pair;
     use rstest::rstest;
     use serde_json::{json, Value};
+    use serial_test::serial;
 
     use crate::db::stores::test_utils::{add_schema, test_db, TestDatabase, TestDatabaseRunner};
     use crate::test_helpers::graphql_test_client;
 
     #[rstest]
+    // Note: This and more tests in this file use the underlying static schema provider which is a
+    // static mutable data store, accessible across all test runner threads in parallel mode. To
+    // prevent overwriting data across threads we have to run this test in serial.
+    //
+    // Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
+    #[serial]
     fn schema_updates(#[from(test_db)] runner: TestDatabaseRunner) {
         runner.with_db_teardown(move |mut db: TestDatabase| async move {
             // Create test client in the beginning so it is initialised with just the system

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -212,9 +212,9 @@ mod test {
     use crate::test_helpers::graphql_test_client;
 
     #[rstest]
-    // Note: This and more tests in this file use the underlying static schema provider which is a
-    // static mutable data store, accessible across all test runner threads in parallel mode. To
-    // prevent overwriting data across threads we have to run this test in serial.
+    // Note: This test uses the underlying static schema provider which is a static mutable data
+    // store, accessible across all test runner threads in parallel mode. To prevent overwriting
+    // data across threads we have to run this test in serial.
     //
     // Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
     #[serial]

--- a/aquadoggo/src/tests.rs
+++ b/aquadoggo/src/tests.rs
@@ -17,10 +17,17 @@ use p2panda_rs::operation::{Operation, OperationAction, OperationBuilder};
 use p2panda_rs::schema::{FieldType, Schema, SchemaId};
 use reqwest::Client;
 use serde_json::{json, Map, Value};
+use serial_test::serial;
 
 use crate::{Configuration, Node};
 
 #[tokio::test]
+// Note: This and more tests in this file use the underlying static schema provider which is a
+// static mutable data store, accessible across all test runner threads in parallel mode. To
+// prevent overwriting data across threads we have to run this test in serial.
+//
+// Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
+#[serial]
 async fn e2e() {
     // This is an aquadoggo E2E test.
     //

--- a/aquadoggo/src/tests.rs
+++ b/aquadoggo/src/tests.rs
@@ -22,9 +22,9 @@ use serial_test::serial;
 use crate::{Configuration, Node};
 
 #[tokio::test]
-// Note: This and more tests in this file use the underlying static schema provider which is a
-// static mutable data store, accessible across all test runner threads in parallel mode. To
-// prevent overwriting data across threads we have to run this test in serial.
+// Note: This test uses the underlying static schema provider which is a static mutable data store,
+// accessible across all test runner threads in parallel mode. To prevent overwriting data across
+// threads we have to run this test in serial.
 //
 // Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321
 #[serial]


### PR DESCRIPTION
Some of our tests use the underlying static schema provider which is a static mutable data store (due to a workaround for `async-graphql`). This mutable store is accessible across all test runner threads in parallel mode as they all run in the same process. To prevent overwriting data across threads (race condition) we have to run these test in serial.

Read more: https://users.rust-lang.org/t/static-mutables-in-tests/49321

## Background

This PR is blantantly stolen from https://github.com/p2panda/aquadoggo/pull/266 which is the in-depth research of @sandreae to find out where the race-conditions came from.

The following changes have been made in comparison to PR #266:

1. Added comments around the places where we add `[#serial]`. It's fairly special-case and I can see how that same problem will come up in the future when we (and others) add new tests and forget to make them execute in serial. These comments will not necessarily prevent that but it's better than nothing maybe.
2. Removed all code which was somewhat _optional_ around solving these kinds of race conditions. #266 adds a feature to reliably inform about if an async task (like building a new schema) was finished. There is more race conditions to tackle, but they are more unlikely to happen (for now we can naively bump the waiting times).

I'm wondering if there's another way to tackle the issue in the future. We could have a mocked static schema store only for test environments which puts the data behind a randomized key which is set once per thread. Then all parallelly-running tests would have the schema store behind the same memory address, but access different areas _inside_ of it.

Closes: #247

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
