### PR TITLE
Perform "quick commit" in materializer service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move GraphQL `types` into separate modules [#343](https://github.com/p2panda/aquadoggo/pull/343)
 - Set default order for root queries to document id [#352](https://github.com/p2panda/aquadoggo/pull/352)
 - Remove property tests again because of concurrency bug [#347](https://github.com/p2panda/aquadoggo/pull/347)
+- Incrementally update documents in materializer [#280](https://github.com/p2panda/aquadoggo/pull/280)
 
 ### Fixed
 

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -284,7 +284,10 @@ impl SqlStore {
     ///
     /// Note: "out-of-date" document views will remain in storage when a document already existed
     /// and is updated. If they are not needed for anything else they can be garbage collected.
-    pub async fn insert_document(&self, document: &Document) -> Result<(), DocumentStorageError> {
+    pub async fn insert_document(
+        &self,
+        document: &impl AsDocument,
+    ) -> Result<(), DocumentStorageError> {
         // Start a transaction, any db insertions after this point, and before the `commit()`
         // can be rolled back in the event of an error.
         let mut tx = self
@@ -473,7 +476,7 @@ async fn insert_document_view(
 // `documents`, `document_views` and `document_view_fields` tables.
 async fn insert_document(
     tx: &mut Transaction<'_, Any>,
-    document: &Document,
+    document: &impl AsDocument,
 ) -> Result<(), DocumentStorageError> {
     // Insert or update the document to the `documents` table.
     query(

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -31,7 +31,7 @@
 //! explicitly wish to keep.
 use async_trait::async_trait;
 use p2panda_rs::document::traits::AsDocument;
-use p2panda_rs::document::{Document, DocumentId, DocumentView, DocumentViewId};
+use p2panda_rs::document::{DocumentId, DocumentView, DocumentViewId};
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::storage_provider::error::DocumentStorageError;
 use p2panda_rs::storage_provider::traits::DocumentStore;

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -568,7 +568,6 @@ mod tests {
         config: PopulateStoreConfig,
     ) {
         test_runner(move |mut node: TestNode| async move {
-            // Populate the store with some entries and operations but DON'T materialise any resulting documents.
             let (key_pairs, document_ids) = populate_and_materialize(&mut node, &config).await;
             let document_id = document_ids[0].clone();
             let key_pair = &key_pairs[0];
@@ -617,7 +616,6 @@ mod tests {
         config: PopulateStoreConfig,
     ) {
         test_runner(move |mut node: TestNode| async move {
-            // Populate the store with some entries and operations but DON'T materialise any resulting documents.
             let (key_pairs, document_ids) = populate_and_materialize(&mut node, &config).await;
             let document_id = document_ids[0].clone();
             let key_pair = &key_pairs[0];

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -177,7 +177,7 @@ async fn quick_commit(
 ) -> bool {
     let operation = context
         .store
-        .get_operation(&operation_id)
+        .get_operation(operation_id)
         .await
         .unwrap_or_else(|_| {
             panic!(


### PR DESCRIPTION
Uses https://github.com/p2panda/p2panda/pull/485 to perform a quick commit on a document instead of materializing from scratch.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
