### PR TITLE
Introduce requeue flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Correct use of `sqlx` transactions [#285](https://github.com/p2panda/aquadoggo/pull/285) `rs`
+- Correct use of `sqlx` transactions [#285](https://github.com/p2panda/aquadoggo/pull/285)
 - Fix race-condition of mutably shared static schema store during testing [#269](https://github.com/p2panda/aquadoggo/pull/269)
+- Introduce flag to requeue tasks in worker queue, fixes race-condition in materialization logic [#286](https://github.com/p2panda/aquadoggo/pull/286)
 
 ## [0.4.0]
 

--- a/aquadoggo/src/materializer/worker.rs
+++ b/aquadoggo/src/materializer/worker.rs
@@ -506,9 +506,6 @@ where
                     // Take this task and do work ..
                     let result = work.call(context.clone(), item.input()).await;
 
-                    // Trigger removing the task from the task store
-                    on_complete(item.input());
-
                     // Check the result
                     match result {
                         Ok(Some(list)) => {
@@ -565,6 +562,9 @@ where
                             error!("Error while broadcasting task during requeue: {}", err);
                             error_signal.trigger();
                         }
+                    } else {
+                        // Trigger removing the task from the task store
+                        on_complete(item.input());
                     }
                 }
             });

--- a/aquadoggo/src/materializer/worker.rs
+++ b/aquadoggo/src/materializer/worker.rs
@@ -434,6 +434,7 @@ where
                                         on_pending(task.clone());
 
                                         // Generate a unique id for this new task and add it to queue
+                                        debug!("Sending materializer {} task with input {} to the task queue.", task.worker_name(), task.input());
                                         let next_id = counter.fetch_add(1, Ordering::Relaxed);
                                         queue.push(QueueItem::new(next_id, task.1.clone()));
                                         index.insert(task.1, PostAction::Idle);
@@ -442,11 +443,13 @@ where
                                         // 2. This is the first duplicate coming in, let's set the
                                         // requeue flag to indicate that more work needs to be done
                                         // when the current task completes
+                                        debug!("Duplicate materializer {} task already in progress, setting re-queue flag for task with input {} and not adding this task to the queue.", task.worker_name(), task.input());
                                         index.insert(task.1, PostAction::Requeue);
                                     }
                                     Some(PostAction::Requeue) => {
                                         // 3. We observed already one duplicate task coming in, let's
                                         // ignore this one
+                                        debug!("Materializer {} task with input {} not sent to queue as a task for this document has already been re-queued.", task.worker_name(), task.input());
                                         continue;
                                     }
                                 }


### PR DESCRIPTION
Introduces a `requeue` boolean-flag in the input index of our `Factory` implementation (task worker queue) which allows tasks to get re-scheduled after completion.

This fixes a nasty bug which can be only reproduced on very fast machines: https://github.com/p2panda/aquadoggo/issues/281

This branches off Sam's work on https://github.com/p2panda/aquadoggo/pull/285 which surely made the bug easier to track down.

## Problem

Let's say we have operations arriving in the following order at the node: `C1 [D1]`, `U2 [D1]`, `C1 [D2]`, `U3 [D1]` and `U2 [D2]`. That's an CREATE, UPDATE and another UPDATE operation for a "Document 1" and another CREATE and UPDATE operation for a "Document 2", they arrive at the same time at the GraphQL API and get put in this order on the service bus where they get broadcasted.

The current factory implementation would now look at each of these operations arriving through the service bus and queue them up IF we don't handle that document yet. In the "dispatcher" this would look like that:

1. `C1 [D1]` arrives. Do we already work on `D1`? No, let's queue it!
2. `U2 [D1]` arrives. Do we already work on `D1`? Yes. Ignore.
3. `C1 [D2]` arrives. Do we already work on `D2`? No, let's queue it!
4. `U3 [D1]` arrives. Do we already work on `D1`? Yes. Ignore.
5. `U2 [D2]` arrives. Do we already work on `D2`? Yes. Ignore.

.. concurrently we're already running a whole worker pool eagerly waiting to look at the queue, taking the tasks off it. So depending on how the "dispatcher" races with the "workers" the outcome might always look a little bit different. For example, if we finished working on `C1 [D1]` _before_ the dispatcher looks at `U3 [D1]`, it might actually get queued as well.

That design of "looking at duplicates" had one purpose: Avoid working on the same document twice, aka "we're already working on it, why do it a second time". This is a nice optimization, but it also assumes that we have all possible operations in the database _already_ in the moment _before_ `C1 [D1]` or a later D1-related task kicks in.

Funnily, this worked quite well so far, we never noticed a problem. Most of the time the requests were slow enough for the factory to queue _every_ operation and ignore nothing:

1. `C1 [D1]` arrives. Do we already work on `D1`? No, let's queue it!
... (the worker happily crunches that operation in the background, seeing C1 in the database)
... some short fraction of time later ..
2. `U2 [D1]` arrives. Do we already work on `D1`? No, let's queue it!
... (the worker happily crunches that operation in the background, seeing U2 in the database)
... and so on ..

Since our requests get faster now (due to client-side caching in `shirokuma`) we observed the following problem:

1. `C1 [D1]` arrives. Do we already work on `D1`? No, let's queue it!
... (the worker happily crunches that operation in the background, seeing C1 in the database)
... some short fraction of time later ..
2. `U2 [D1]` arrives! Woah. FAST! Surprise!! Do we already work on `D1`? Yes. Ignore.
... and so on ..

The new operations `U2` etc. arrived in the database _after_ the worker looked at them but _before_ it finished working on `C1`! Thus, we lost `U2` ..

## Solution

After some analysis I realized that the system makes still sense in its basic assumption: We don't need to work on documents more than we have to! `aquadoggo` is an event-sourcing system where "events" kick-in work, independent of the amount of data arriving. Here is an example:

```
D: [U U U] [U U U U U U U] U U U U U U U U ...
          Work!           Work! 
```

Note how the brackets `[...]` "group" the operations in work units. They simply get loaded from the database as they already were there before the work started.

There is an ongoing stream of incoming UPDATE operations and every time we kick in the worker for that document it takes the "fresh" ones and materializes them. We don't need to have a worker for _each_ operation, we just have to make sure that we consider them all exactly _once_ - and this is where the previous system failed, as operations just got lost ..

In this PR a "re-queue" flag got introduced which restarts a task for a document D when operations have been observed which came in while the worker was already running on D. It works like this:

1. `C1 [D1]` arrives. Do we already work on `D1`? No, let's queue it!
2. `U2 [D1]` arrives. Do we already work on `D1`? Yes. Set requeue flag for `D1` to `true` 
3. `C1 [D2]` arrives. Do we already work on `D2`? No, let's queue it!
4. `U3 [D1]` arrives. Do we already work on `D1`? Yes, and the requeue flag is set. Ignore.
5. `U2 [D2]` arrives. Do we already work on `D2`? Yes. Set requeue flag for `D2` to `true` 

This scenario assumes that the worker for `D1` and the other worker for `D2` are still running while all other operations get dispatched, that's the "worst-case scenario" in terms of maximum pressure on the dispatcher which made the previous implementation fail.

What this does now is quite nice: As soon as the work on `C1` finished and the requeue flag was detected, it will just add a new task to the queue to continue working on `D1`, making sure to also account for all these operations which arrived a little bit later (`U2` and `U3`).

What we get from this is:

1. Some sort of "batching" of operations for the same document when they arrive _very_ fast
2. The queue does not get "blocked" by waiting operations, we can still continue looking at other operations for other documents and assigning them to different workers
3. Accounting for moments of very high pressure on the dispatcher without losing any information
4. Still making sure that we only working on a document _once_ at a time, to avoid concurrent work overwriting each other

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
