### PR TITLE
Migrate CLI from `structopt` to `clap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Migrate CLI from `structopt` to `clap` [#289](https://github.com/p2panda/aquadoggo/pull/289)
 - Introduce libp2p networking service and configuration [#282](https://github.com/p2panda/aquadoggo/pull/282)
 - Rework test runner and test node population patterns and refactor test_utils [#277](https://github.com/p2panda/aquadoggo/pull/277)
 - Implement API changes to p2panda-rs storage traits, new and breaking db migration [#268](https://github.com/p2panda/aquadoggo/pull/268)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,15 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,8 +200,8 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "aquadoggo",
+ "clap",
  "env_logger",
- "structopt",
  "tokio",
 ]
 
@@ -841,17 +832,39 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1111,7 +1124,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1125,7 +1138,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1429,7 +1442,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1846,15 +1859,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -1879,6 +1883,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "hex"
@@ -2144,6 +2154,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,7 +2411,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fba456131824ab6acd4c7bf61e9c0f0a3014b5fc9868ccb8e10d344594cdc4f"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "quote",
  "syn",
 ]
@@ -2925,6 +2947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "p256"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,7 +3353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
@@ -4270,7 +4298,7 @@ checksum = "b850fa514dc11f2ee85be9d055c512aa866746adfacd1cb42d867d68e6a5b0d9"
 dependencies = [
  "dotenvy",
  "either",
- "heck 0.4.1",
+ "heck",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -4316,39 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "stun"
@@ -4454,15 +4452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -4867,12 +4856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4966,12 +4949,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -22,7 +22,7 @@ doc = false
 anyhow = "^1.0.62"
 tokio = { version = "^1.20.1", features = ["full"] }
 env_logger = "^0.9.0"
-structopt = "^0.3.26"
+clap = { version = "^4.1.8", features = ["derive"] }
 
 [dependencies.aquadoggo]
 version = "~0.4.0"

--- a/aquadoggo_cli/README.md
+++ b/aquadoggo_cli/README.md
@@ -5,26 +5,42 @@ Node server with GraphQL API for the p2panda network.
 ## Usage
 
 ```
-FLAGS:
-    -h, --help
-            Prints help information
+Options:
+  -d, --data-dir <DATA_DIR>
+          Path to data folder, $HOME/.local/share/aquadoggo by default on Linux
 
-    -V, --version
-            Prints version information
+  -P, --http-port <HTTP_PORT>
+          Port for the http server, 2020 by default
 
-OPTIONS:
-    -A <authors-to-replicate>...
-            A collection of authors and their logs to replicate.
+  -q, --quic-port <QUIC_PORT>
+          Port for the QUIC transport, 2022 by default
 
-            eg. -A 123abc="1 2 345" -A 456def="6 7" .. adds the authors:
-            - "123abc" with log_ids 1, 2, 345
-            - "456def" with log_ids 6 7
+  -r, --remote-node-addresses <REMOTE_NODE_ADDRESSES>
+          URLs of remote nodes to replicate with
 
-    -d, --data-dir <data-dir>
-            Path to data folder, $HOME/.local/share/aquadoggo by default on Linux
+  -A <PUBLIC_KEYS_TO_REPLICATE>
+          A collection of authors and their logs to replicate.
 
-    -r, --remote-node-addresses <remote-node-addresses>...
-            URLs of remote nodes to replicate with
+          eg. -A 123abc="1 2 345" -A 456def="6 7"
+          .. adds the authors:
+          - "123abc" with log_ids 1, 2, 345
+          - "456def" with log_ids 6 7
+
+  -m, --mdns <MDNS>
+          Enable mDNS for peer discovery over LAN (using port 5353), true by default
+
+          [possible values: true, false]
+
+      --ping <PING>
+          Enable ping for connected peers (send and receive ping packets), true by default
+
+          [possible values: true, false]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```
 
 ## Environment variables

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -30,7 +30,8 @@ where
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "aquadoggo Node", about = "Node server for the p2panda network")]
+#[command(name = "aquadoggo Node", version)]
+/// Node server for the p2panda network.
 struct Cli {
     /// Path to data folder, $HOME/.local/share/aquadoggo by default on Linux.
     #[arg(short, long)]

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -6,15 +6,15 @@ use std::error::Error;
 
 use anyhow::Result;
 use aquadoggo::{Configuration, NetworkConfiguration, Node, ReplicationConfiguration};
-use structopt::StructOpt;
+use clap::Parser;
 
 /// Helper method to parse a single key-value pair.
-fn parse_key_val<T, U>(s: &str) -> Result<(T, Vec<U>), Box<dyn Error>>
+fn parse_key_val<T, U>(s: &str) -> Result<(T, Vec<U>), Box<dyn Error + Send + Sync + 'static>>
 where
     T: std::str::FromStr,
-    T::Err: Error + 'static,
+    T::Err: Error + Send + Sync + 'static,
     U: std::str::FromStr,
-    U::Err: Error + 'static,
+    U::Err: Error + Send + Sync + 'static,
 {
     let pos = s
         .find('=')
@@ -29,23 +29,23 @@ where
     Ok((key, values))
 }
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "aquadoggo Node", about = "Node server for the p2panda network")]
-struct Opt {
+#[derive(Parser, Debug)]
+#[command(name = "aquadoggo Node", about = "Node server for the p2panda network")]
+struct Cli {
     /// Path to data folder, $HOME/.local/share/aquadoggo by default on Linux.
-    #[structopt(short, long, parse(from_os_str))]
+    #[arg(short, long)]
     data_dir: Option<std::path::PathBuf>,
 
     /// Port for the http server, 2020 by default.
-    #[structopt(short = "P", long)]
+    #[arg(short = 'P', long)]
     http_port: Option<u16>,
 
     /// Port for the QUIC transport, 2022 by default.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     quic_port: Option<u16>,
 
     /// URLs of remote nodes to replicate with.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     remote_node_addresses: Vec<String>,
 
     /// A collection of authors and their logs to replicate.
@@ -54,41 +54,41 @@ struct Opt {
     /// .. adds the authors:
     /// - "123abc" with log_ids 1, 2, 345
     /// - "456def" with log_ids 6 7
-    #[structopt(short = "A", parse(try_from_str = parse_key_val), number_of_values = 1)]
+    #[arg(short = 'A', value_parser = parse_key_val::<String, u64>, number_of_values = 1)]
     public_keys_to_replicate: Vec<(String, Vec<u64>)>,
 
     /// Enable mDNS for peer discovery over LAN (using port 5353), true by default.
-    #[structopt(short, long)]
+    #[arg(short, long)]
     mdns: Option<bool>,
 
     /// Enable ping for connected peers (send and receive ping packets), true by default.
-    #[structopt(long)]
+    #[arg(long)]
     ping: Option<bool>,
 }
 
-impl TryFrom<Opt> for Configuration {
+impl TryFrom<Cli> for Configuration {
     type Error = anyhow::Error;
 
-    fn try_from(opt: Opt) -> Result<Self, Self::Error> {
-        let mut config = Configuration::new(opt.data_dir)?;
-        config.http_port = opt.http_port.unwrap_or(2020);
+    fn try_from(cli: Cli) -> Result<Self, Self::Error> {
+        let mut config = Configuration::new(cli.data_dir)?;
+        config.http_port = cli.http_port.unwrap_or(2020);
 
-        let public_keys_to_replicate = opt
+        let public_keys_to_replicate = cli
             .public_keys_to_replicate
             .into_iter()
             .map(|elem| elem.try_into())
             .collect::<Result<_>>()?;
 
         config.replication = ReplicationConfiguration {
-            remote_peers: opt.remote_node_addresses,
+            remote_peers: cli.remote_node_addresses,
             public_keys_to_replicate,
             ..ReplicationConfiguration::default()
         };
 
         config.network = NetworkConfiguration {
-            mdns: opt.mdns.unwrap_or(true),
-            ping: opt.ping.unwrap_or(true),
-            quic_port: opt.quic_port.unwrap_or(2022),
+            mdns: cli.mdns.unwrap_or(true),
+            ping: cli.ping.unwrap_or(true),
+            quic_port: cli.quic_port.unwrap_or(2022),
             ..NetworkConfiguration::default()
         };
 
@@ -101,8 +101,8 @@ async fn main() {
     env_logger::init();
 
     // Parse command line arguments and load configuration
-    let opt = Opt::from_args();
-    let config = opt.try_into().expect("Could not load configuration");
+    let cli = Cli::parse();
+    let config = cli.try_into().expect("Could not load configuration");
 
     // Start p2panda node in async runtime
     let node = Node::start(config).await;

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -55,7 +55,7 @@ struct Cli {
     /// .. adds the authors:
     /// - "123abc" with log_ids 1, 2, 345
     /// - "456def" with log_ids 6 7
-    #[arg(short = 'A', value_parser = parse_key_val::<String, u64>, number_of_values = 1)]
+    #[arg(short = 'A', value_parser = parse_key_val::<String, u64>, number_of_values = 1, verbatim_doc_comment)]
     public_keys_to_replicate: Vec<(String, Vec<u64>)>,
 
     /// Enable mDNS for peer discovery over LAN (using port 5353), true by default.


### PR DESCRIPTION
This is a drop-in replacement (more or less) of `structopt` with `clap`. See https://github.com/p2panda/aquadoggo/issues/288 for additional context.

- [x] Replace `structopt` dependency with `clap`
- [x] Rename `struct` from `Opt` to `Cli`
- [x] Update `README` with latest usage

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
