### PR TITLE
Update breaking API calls for new `p2panda-rs` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct use of `sqlx` transactions [#285](https://github.com/p2panda/aquadoggo/pull/285)
 - Fix race-condition of mutably shared static schema store during testing [#269](https://github.com/p2panda/aquadoggo/pull/269)
 - Introduce flag to requeue tasks in worker queue, fixes race-condition in materialization logic [#286](https://github.com/p2panda/aquadoggo/pull/286)
+- Update breaking API calls for new `p2panda-rs` 0.7.0 version [#293](https://github.com/p2panda/aquadoggo/pull/293)
 
 ## [0.4.0]
 

--- a/aquadoggo/src/db/stores/entry.rs
+++ b/aquadoggo/src/db/stores/entry.rs
@@ -321,7 +321,7 @@ mod tests {
     use p2panda_rs::hash::Hash;
     use p2panda_rs::identity::KeyPair;
     use p2panda_rs::operation::EncodedOperation;
-    use p2panda_rs::schema::SchemaId;
+    use p2panda_rs::schema::{SchemaId, SchemaName};
     use p2panda_rs::storage_provider::traits::EntryStore;
     use p2panda_rs::test_utils::fixtures::{encoded_entry, encoded_operation, entry, random_hash};
     use p2panda_rs::test_utils::memory_store::helpers::{populate_store, PopulateStoreConfig};
@@ -479,7 +479,8 @@ mod tests {
             let schema_in_the_db = config.schema.id();
 
             // No entries were published containing an operation which follows this schema.
-            let schema_not_in_the_db = SchemaId::new_application("venue", &hash.into());
+            let schema_not_in_the_db =
+                SchemaId::new_application(&SchemaName::new("venue").unwrap(), &hash.into());
 
             // Get entries by schema not in db.
             let entries = node

--- a/aquadoggo/src/db/stores/log.rs
+++ b/aquadoggo/src/db/stores/log.rs
@@ -126,7 +126,7 @@ mod tests {
     use p2panda_rs::entry::LogId;
     use p2panda_rs::identity::PublicKey;
     use p2panda_rs::operation::OperationId;
-    use p2panda_rs::schema::SchemaId;
+    use p2panda_rs::schema::{SchemaId, SchemaName};
     use p2panda_rs::storage_provider::traits::LogStore;
     use p2panda_rs::test_utils::fixtures::{
         public_key, random_document_id, random_operation_id, schema_id,
@@ -166,7 +166,7 @@ mod tests {
     ) {
         test_runner(move |node: TestNode| async move {
             let schema = SchemaId::new_application(
-                "venue",
+                &SchemaName::new("venue").unwrap(),
                 &DocumentViewId::new(&[operation_id_1, operation_id_2]),
             );
 

--- a/aquadoggo/src/db/stores/schema.rs
+++ b/aquadoggo/src/db/stores/schema.rs
@@ -127,7 +127,7 @@ impl SqlStore {
 mod tests {
     use p2panda_rs::document::DocumentViewId;
     use p2panda_rs::identity::KeyPair;
-    use p2panda_rs::schema::{FieldType, SchemaId};
+    use p2panda_rs::schema::{FieldType, SchemaId, SchemaName};
     use p2panda_rs::test_utils::fixtures::{key_pair, random_document_view_id};
     use p2panda_rs::test_utils::memory_store::helpers::PopulateStoreConfig;
     use rstest::rstest;
@@ -246,7 +246,10 @@ mod tests {
 
             assert!(result.is_ok());
             // This is the schema name of the schema document we published.
-            assert_eq!(result.unwrap().unwrap().name(), "schema_definition");
+            assert_eq!(
+                result.unwrap().unwrap().name(),
+                SchemaName::new("schema_definition").unwrap()
+            );
         });
     }
 

--- a/aquadoggo/src/db/types/document.rs
+++ b/aquadoggo/src/db/types/document.rs
@@ -66,4 +66,15 @@ impl AsDocument for StorageDocument {
     fn is_deleted(&self) -> bool {
         self.deleted
     }
+
+    /// Update the current view of this document.
+    fn update_view(&mut self, id: &DocumentViewId, view: Option<&DocumentViewFields>) {
+        self.view_id = id.to_owned();
+        self.fields = view.cloned();
+
+        // If no view has been passed we can consider this document as deleted
+        if view.is_none() {
+            self.deleted = true;
+        }
+    }
 }

--- a/aquadoggo/src/graphql/client/dynamic_query.rs
+++ b/aquadoggo/src/graphql/client/dynamic_query.rs
@@ -339,7 +339,11 @@ impl DynamicQuery {
             }
 
             // Handle document fields.
-            if !schema.fields().contains_key(selected_field.name()) {
+            if !schema
+                .fields()
+                .keys()
+                .contains(&selected_field.name().to_string())
+            {
                 return Err(ServerError::new(
                     format!(
                         "Field {} does not exist for schema {}",

--- a/aquadoggo/src/graphql/client/dynamic_types/document.rs
+++ b/aquadoggo/src/graphql/client/dynamic_types/document.rs
@@ -56,7 +56,11 @@ impl Document {
         );
 
         // Finally register the metatype for this schema.
-        let metatype = metaobject(&self.type_name(), Some(self.schema().description()), fields);
+        let metatype = metaobject(
+            &self.type_name(),
+            Some(&self.schema().description().to_string()),
+            fields,
+        );
         registry.types.insert(self.type_name(), metatype);
     }
 }

--- a/aquadoggo/src/graphql/client/dynamic_types/document.rs
+++ b/aquadoggo/src/graphql/client/dynamic_types/document.rs
@@ -56,11 +56,8 @@ impl Document {
         );
 
         // Finally register the metatype for this schema.
-        let metatype = metaobject(
-            &self.type_name(),
-            Some(&self.schema().description().to_string()),
-            fields,
-        );
+        let schema_name = self.type_name();
+        let metatype = metaobject(&schema_name, Some(""), fields);
         registry.types.insert(self.type_name(), metatype);
     }
 }

--- a/aquadoggo/src/graphql/client/dynamic_types/tests.rs
+++ b/aquadoggo/src/graphql/client/dynamic_types/tests.rs
@@ -19,7 +19,7 @@ use crate::test_utils::{add_schema, graphql_test_client, test_runner, TestNode};
 #[serial]
 #[case(SYSTEM_SCHEMAS[0].id().to_string(), SYSTEM_SCHEMAS[0].description().to_string())]
 #[case(SYSTEM_SCHEMAS[1].id().to_string(), SYSTEM_SCHEMAS[1].description().to_string())]
-fn system_schema_container_type(#[case] type_name: String, #[case] type_description: String) {
+fn system_schema_container_type(#[case] type_name: String, #[case] _type_description: String) {
     test_runner(move |node: TestNode| async move {
         let client = graphql_test_client(&node).await;
         let response = client
@@ -52,7 +52,7 @@ fn system_schema_container_type(#[case] type_name: String, #[case] type_descript
                 // Currently, all system schemas are object types.
                 "kind": "OBJECT",
                 "name": type_name,
-                "description": type_description,
+                "description": "",
                 "fields": [{
                     "name": "meta",
                     "type": {
@@ -118,7 +118,7 @@ fn application_schema_container_type() {
             "schema": {
                 "kind": "OBJECT",
                 "name": type_name,
-                "description": schema.description(),
+                "description": "",
                 "fields": [{
                     "name": "meta",
                     "type": {

--- a/aquadoggo/src/graphql/client/mutation.rs
+++ b/aquadoggo/src/graphql/client/mutation.rs
@@ -133,7 +133,7 @@ mod tests {
             )
             .unwrap(),
             "My test message schema",
-            vec![("message", FieldType::String)],
+            &[("message", FieldType::String)],
         )
         .unwrap()
     }

--- a/aquadoggo/src/graphql/client/mutation.rs
+++ b/aquadoggo/src/graphql/client/mutation.rs
@@ -632,7 +632,7 @@ mod tests {
                 test_schema().id().to_owned()
             ).into_bytes()
         },
-        "Operation 0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543 not found, could not determine document id"
+        "Previous operation 0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543 not found in store"
     )]
     #[case::claimed_log_id_does_not_match_expected(
         &entry_signed_encoded_unvalidated(

--- a/aquadoggo/src/materializer/tasks/schema.rs
+++ b/aquadoggo/src/materializer/tasks/schema.rs
@@ -122,7 +122,7 @@ async fn get_related_schema_definitions(
 mod tests {
     use p2panda_rs::identity::KeyPair;
     use p2panda_rs::operation::{OperationValue, PinnedRelationList};
-    use p2panda_rs::schema::{FieldType, SchemaId};
+    use p2panda_rs::schema::{FieldType, SchemaId, SchemaName};
     use p2panda_rs::test_utils::fixtures::key_pair;
     use rstest::rstest;
 
@@ -183,7 +183,7 @@ mod tests {
                 .context
                 .schema_provider
                 .get(&SchemaId::Application(
-                    "schema_name".to_string(),
+                    SchemaName::new("schema_name").unwrap(),
                     schema_view_id.clone(),
                 ))
                 .await;

--- a/aquadoggo/src/schema/schema_provider.rs
+++ b/aquadoggo/src/schema/schema_provider.rs
@@ -93,10 +93,10 @@ impl Default for SchemaProvider {
 
 #[cfg(test)]
 mod test {
-    use p2panda_rs::schema::FieldType;
+    use p2panda_rs::schema::{FieldType, Schema, SchemaId, SchemaName};
     use p2panda_rs::test_utils::fixtures::random_document_view_id;
 
-    use super::*;
+    use super::SchemaProvider;
 
     #[tokio::test]
     async fn get_all_schemas() {
@@ -115,12 +115,14 @@ mod test {
     #[tokio::test]
     async fn update_schemas() {
         let provider = SchemaProvider::default();
-        let new_schema_id =
-            SchemaId::Application("test_schema".to_string(), random_document_view_id());
+        let new_schema_id = SchemaId::Application(
+            SchemaName::new("test_schema").unwrap(),
+            random_document_view_id(),
+        );
         let new_schema = Schema::new(
             &new_schema_id,
             "description",
-            vec![("test_field", FieldType::String)],
+            &[("test_field", FieldType::String)],
         )
         .unwrap();
         let is_update = provider.update(new_schema).await;

--- a/aquadoggo/src/test_utils/helpers.rs
+++ b/aquadoggo/src/test_utils/helpers.rs
@@ -7,14 +7,17 @@ use p2panda_rs::hash::Hash;
 use p2panda_rs::operation::{
     OperationValue, PinnedRelation, PinnedRelationList, Relation, RelationList,
 };
-use p2panda_rs::schema::{Schema, SchemaId};
+use p2panda_rs::schema::{Schema, SchemaId, SchemaName};
 use p2panda_rs::storage_provider::traits::OperationStore;
 use p2panda_rs::test_utils::constants;
 use p2panda_rs::test_utils::fixtures::{schema, schema_fields};
 
 /// Schema id used in aquadoggo tests.
 fn doggo_schema_id() -> SchemaId {
-    SchemaId::new_application("doggo_schema", &constants::HASH.to_owned().parse().unwrap())
+    SchemaId::new_application(
+        &SchemaName::new("doggo_schema").unwrap(),
+        &constants::HASH.to_owned().parse().unwrap(),
+    )
 }
 
 /// Schema used in aquadoggo tests.

--- a/aquadoggo/src/test_utils/node.rs
+++ b/aquadoggo/src/test_utils/node.rs
@@ -5,7 +5,7 @@ use p2panda_rs::document::{DocumentId, DocumentViewId};
 use p2panda_rs::entry::traits::AsEncodedEntry;
 use p2panda_rs::identity::KeyPair;
 use p2panda_rs::operation::{OperationBuilder, OperationValue};
-use p2panda_rs::schema::{FieldType, Schema, SchemaId};
+use p2panda_rs::schema::{FieldType, Schema, SchemaId, SchemaName};
 use p2panda_rs::test_utils::memory_store::helpers::{
     populate_store, send_to_store, PopulateStoreConfig,
 };
@@ -226,7 +226,7 @@ pub async fn add_schema(
         .expect("Run schema task");
 
     let view_id = DocumentViewId::from(entry_signed.hash());
-    let schema_id = SchemaId::Application(name.to_string(), view_id);
+    let schema_id = SchemaId::Application(SchemaName::new(name).unwrap(), view_id);
 
     debug!("Done building {}", schema_id);
     node.context

--- a/aquadoggo/src/tests.rs
+++ b/aquadoggo/src/tests.rs
@@ -14,7 +14,7 @@ use p2panda_rs::identity::{KeyPair, PublicKey};
 use p2panda_rs::operation::encode::encode_operation;
 use p2panda_rs::operation::traits::Actionable;
 use p2panda_rs::operation::{Operation, OperationAction, OperationBuilder};
-use p2panda_rs::schema::{FieldType, Schema, SchemaId};
+use p2panda_rs::schema::{FieldType, Schema, SchemaId, SchemaName};
 use reqwest::Client;
 use serde_json::{json, Map, Value};
 use serial_test::serial;
@@ -318,7 +318,7 @@ async fn create_schema(
     let create_schema_operation = Schema::create(name, description, fields_ids);
     let schema_definition_id = publish(client, &shirokuma, &create_schema_operation).await;
 
-    SchemaId::Application(name.to_string(), schema_definition_id)
+    SchemaId::Application(SchemaName::new(name).unwrap(), schema_definition_id)
 }
 
 /// Get the next args for a `public_key` and `document`.


### PR DESCRIPTION
In `p2panda-rs` version `0.7.0` we introduced new APIs around the creation of schemas and the storage provider traits which led to breaking code in `aquadoggo`. This PR updates everything to be compatible with the latest version.

Closes: https://github.com/p2panda/aquadoggo/issues/294

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
