### PR TITLE
Ignore libp2p deprecation warnings (clippy)

### DIFF
--- a/aquadoggo/src/network/identity.rs
+++ b/aquadoggo/src/network/identity.rs
@@ -44,6 +44,8 @@ impl Identity for Keypair {
     }
 
     /// Encode the private key as a hex string and save it to the given file path.
+    // See: https://github.com/p2panda/aquadoggo/issues/295
+    #[allow(deprecated)]
     fn save(&self, path: &Path) -> Result<()> {
         // Retrieve the private key from the key pair
         let private_key = match self {
@@ -65,6 +67,8 @@ impl Identity for Keypair {
     }
 
     /// Load a key pair from file at the given path.
+    // See: https://github.com/p2panda/aquadoggo/issues/295
+    #[allow(deprecated)]
     fn load(path: &Path) -> Result<Self>
     where
         Self: Sized,

--- a/aquadoggo/src/test_utils/client.rs
+++ b/aquadoggo/src/test_utils/client.rs
@@ -2,7 +2,6 @@
 
 use std::convert::TryFrom;
 use std::net::{SocketAddr, TcpListener};
-use std::time::Duration;
 
 use axum::body::HttpBody;
 use axum::BoxError;
@@ -10,7 +9,6 @@ use http::header::{HeaderName, HeaderValue};
 use http::{Request, StatusCode};
 use hyper::{Body, Server};
 use tokio::sync::broadcast;
-use tokio::task::{self, JoinHandle};
 use tower::make::Shared;
 use tower_service::Service;
 


### PR DESCRIPTION
Silences clippy warnings for usage of deprecated `libp2p` methods in the `save()` and `load()` methods implementing `Identity` for `Keypair`.

See https://github.com/p2panda/aquadoggo/issues/295 for details.

I've also removed unused import warnings for `aquadoggo/src/test_utils/client.rs` (encountered when running tests).