### PR TITLE
Introduce `identify` and `rendezvous` network protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Introduce `identify` and `rendezvous` network protocols / behaviours [#304](https://github.com/p2panda/aquadoggo/pull/304)
+
 ### Added
 
 - Introduce libp2p networking service and configuration [#282](https://github.com/p2panda/aquadoggo/pull/282)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +623,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bimap"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
 
 [[package]]
 name = "bincode"
@@ -1808,7 +1825,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -1817,7 +1843,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2072,7 +2098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -2217,11 +2243,13 @@ dependencies = [
  "instant",
  "libp2p-core",
  "libp2p-dns",
+ "libp2p-identify",
  "libp2p-identity",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-ping",
  "libp2p-quic",
+ "libp2p-rendezvous",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-webrtc",
@@ -2272,6 +2300,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-identify"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d1da1f75baf824cfdc80f6aced51f7cbf8dc14e32363e9443570a80d4ee337"
+dependencies = [
+ "asynchronous-codec",
+ "either",
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "lru",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "smallvec",
+ "thiserror",
+ "void",
+]
+
+[[package]]
 name = "libp2p-identity"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a42ec91e227d7d0dafa4ce88b333cdf5f277253873ab087555c92798db2ddd46"
 dependencies = [
  "libp2p-core",
+ "libp2p-identify",
  "libp2p-ping",
  "libp2p-swarm",
  "prometheus-client",
@@ -2382,6 +2433,28 @@ dependencies = [
  "rustls 0.20.8",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "libp2p-rendezvous"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633f2dc23d63ad04955642f3025e740a943da4deb79b252b5fcf882208164467"
+dependencies = [
+ "asynchronous-codec",
+ "bimap",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "thiserror",
+ "void",
 ]
 
 [[package]]
@@ -2535,6 +2608,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -4233,7 +4315,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "atoi",
  "base64 0.13.1",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "aquadoggo",
  "clap",
  "env_logger",
+ "libp2p",
  "tokio",
 ]
 
@@ -1018,6 +1019,12 @@ checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -1914,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,8 +2256,10 @@ dependencies = [
  "instant",
  "libp2p-core",
  "libp2p-dns",
+ "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
+ "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-ping",
@@ -2279,6 +2294,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
+ "serde",
  "smallvec",
  "thiserror",
  "unsigned-varint",
@@ -2297,6 +2313,37 @@ dependencies = [
  "parking_lot 0.12.1",
  "smallvec",
  "trust-dns-resolver",
+]
+
+[[package]]
+name = "libp2p-gossipsub"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708235886ca7c8f3792a8683ef81f9b7fb0a952bbd15fe5038b7610689a88390"
+dependencies = [
+ "asynchronous-codec",
+ "base64 0.21.0",
+ "byteorder",
+ "bytes",
+ "fnv",
+ "futures",
+ "hex_fmt",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "prometheus-client",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "sha2 0.10.6",
+ "smallvec",
+ "thiserror",
+ "unsigned-varint",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -2336,8 +2383,38 @@ dependencies = [
  "prost-build",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "thiserror",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc57e02d7ad49a63792370f24b829af38f34982ff56556e59e4cb325a4dbf6b"
+dependencies = [
+ "arrayvec 0.7.2",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "log",
+ "quick-protobuf",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.6",
+ "smallvec",
+ "thiserror",
+ "uint",
+ "unsigned-varint",
+ "void",
 ]
 
 [[package]]
@@ -2771,6 +2848,8 @@ dependencies = [
  "core2",
  "digest 0.10.6",
  "multihash-derive",
+ "serde",
+ "serde-big-array",
  "sha2 0.10.6",
  "unsigned-varint",
 ]
@@ -4071,6 +4150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4888,6 +4976,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions 1.1.0",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5132,6 +5232,21 @@ checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
 dependencies = [
  "futures-util",
  "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -38,6 +38,8 @@ libp2p = { version = "^0.51.0", features = [
     "quic",
     "ping",
     "mdns",
+    "identify",
+    "rendezvous"
 ] }
 lipmaa-link = "^0.2.2"
 log = "^0.4.17"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -39,7 +39,8 @@ libp2p = { version = "^0.51.0", features = [
     "ping",
     "mdns",
     "identify",
-    "rendezvous"
+    "rendezvous",
+    "serde",
 ] }
 lipmaa-link = "^0.2.2"
 log = "^0.4.17"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "pietgeursen <pietgeursen@gmail.com>",
     "sandreae <contact@samandreae.com>",
     "sophiiistika <sophiiistika@mailbox.org>",
+    "glyph <glyph@mycelial.technology>",
 ]
 description = "Embeddable p2p network node"
 license = "AGPL-3.0-or-later"

--- a/aquadoggo/src/network/behaviour.rs
+++ b/aquadoggo/src/network/behaviour.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use anyhow::Result;
+use libp2p::identity::Keypair;
+use libp2p::swarm::behaviour::toggle::Toggle;
+use libp2p::swarm::NetworkBehaviour;
+use libp2p::{identify, mdns, ping, rendezvous, PeerId};
+use log::debug;
+
+use crate::network::config::NODE_NAMESPACE;
+use crate::network::NetworkConfiguration;
+
+/// Network behaviour for the aquadoggo node.
+#[derive(NetworkBehaviour)]
+pub struct Behaviour {
+    /// Automatically discover peers on the local network.
+    pub mdns: Toggle<mdns::tokio::Behaviour>,
+
+    /// Respond to inbound pings and periodically send outbound ping on every established
+    /// connection.
+    pub ping: Toggle<ping::Behaviour>,
+
+    /// Register with a rendezvous server and query remote peer addresses.
+    pub rendezvous_client: Toggle<rendezvous::client::Behaviour>,
+
+    /// Serve as a rendezvous point for remote peers to register their external addresses
+    /// and query the addresses of other peers.
+    pub rendezvous_server: Toggle<rendezvous::server::Behaviour>,
+
+    /// Periodically exchange information between peer on an established connection. This
+    /// is useful for learning the external address of the local node from a remote peer.
+    pub identify: Toggle<identify::Behaviour>,
+}
+
+impl Behaviour {
+    /// Generate a new instance of the composed network behaviour according to
+    /// the network configuration context.
+    pub fn new(
+        network_config: &NetworkConfiguration,
+        peer_id: PeerId,
+        key_pair: Keypair,
+    ) -> Result<Self> {
+        let public_key = key_pair.public();
+
+        // Create an mDNS behaviour with default configuration if the mDNS flag is set
+        let mdns = if network_config.mdns {
+            debug!("mDNS network behaviour enabled");
+            Some(mdns::Behaviour::new(Default::default(), peer_id)?)
+        } else {
+            None
+        };
+
+        // Create a ping behaviour with default configuration if the ping flag is set
+        let ping = if network_config.ping {
+            debug!("Ping network behaviour enabled");
+            Some(ping::Behaviour::default())
+        } else {
+            None
+        };
+
+        // Create a rendezvous client behaviour with default configuration if the rendezvous client
+        // flag is set
+        let rendezvous_client = if network_config.rendezvous_client {
+            debug!("Rendezvous client network behaviour enabled");
+            Some(rendezvous::client::Behaviour::new(key_pair))
+        } else {
+            None
+        };
+
+        // Create a rendezvous server behaviour with default configuration if the rendezvous server
+        // flag is set
+        let rendezvous_server = if network_config.rendezvous_server {
+            debug!("Rendezvous server network behaviour enabled");
+            Some(rendezvous::server::Behaviour::new(
+                rendezvous::server::Config::default(),
+            ))
+        } else {
+            None
+        };
+
+        // Create an identify server behaviour with default configuration if either the rendezvous
+        // client or server flag is set
+        let identify = if network_config.rendezvous_client || network_config.rendezvous_server {
+            debug!("Identify network behaviour enabled");
+            Some(identify::Behaviour::new(identify::Config::new(
+                format!("{NODE_NAMESPACE}/1.0.0"),
+                public_key,
+            )))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            mdns: mdns.into(), // Convert the `Option` into a `Toggle`
+            ping: ping.into(),
+            rendezvous_client: rendezvous_client.into(),
+            rendezvous_server: rendezvous_server.into(),
+            identify: identify.into(),
+        })
+    }
+}

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use libp2p::identity::Keypair;
 use libp2p::swarm::ConnectionLimits;
+use libp2p::{Multiaddr, PeerId};
 use log::info;
 use serde::{Deserialize, Serialize};
 
@@ -75,7 +76,7 @@ pub struct NetworkConfiguration {
     pub quic_port: u16,
 
     /// The addresses of remote peers to replicate from.
-    pub remote_peers: Vec<String>,
+    pub remote_peers: Vec<Multiaddr>,
 
     /// Rendezvous client behaviour enabled.
     ///
@@ -88,10 +89,10 @@ pub struct NetworkConfiguration {
     pub rendezvous_server: bool,
 
     /// Address of a rendezvous server in the form of a multiaddress.
-    pub rendezvous_address: Option<String>,
+    pub rendezvous_address: Option<Multiaddr>,
 
     /// Peer ID of a rendezvous server.
-    pub rendezvous_peer_id: Option<String>,
+    pub rendezvous_peer_id: Option<PeerId>,
 }
 
 impl Default for NetworkConfiguration {

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -14,7 +14,6 @@ use crate::network::identity::Identity;
 /// Key pair file name.
 const KEY_PAIR_FILE_NAME: &str = "private-key";
 
-// TODO: make the namespace dynamic (ie. can be user-assigned)
 /// The namespace used by the `identify` network behaviour.
 pub const NODE_NAMESPACE: &str = "aquadoggo";
 

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -13,6 +13,10 @@ use crate::network::identity::Identity;
 /// Key pair file name.
 const KEY_PAIR_FILE_NAME: &str = "private-key";
 
+// TODO: make the namespace dynamic (ie. can be user-assigned)
+/// The namespace used by the `identify` network behaviour.
+pub const NODE_NAMESPACE: &str = "aquadoggo";
+
 /// Network config for the node.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NetworkConfiguration {
@@ -72,6 +76,22 @@ pub struct NetworkConfiguration {
 
     /// The addresses of remote peers to replicate from.
     pub remote_peers: Vec<String>,
+
+    /// Rendezvous client behaviour enabled.
+    ///
+    /// Connect to a rendezvous point, register the local node and query addresses of remote peers.
+    pub rendezvous_client: bool,
+
+    /// Rendezvous server behaviour enabled.
+    ///
+    /// Serve as a rendezvous point for peer discovery, allowing peer registration and queries.
+    pub rendezvous_server: bool,
+
+    /// Address of a rendezvous server in the form of a multiaddress.
+    pub rendezvous_address: Option<String>,
+
+    /// Peer ID of a rendezvous server.
+    pub rendezvous_peer_id: Option<String>,
 }
 
 impl Default for NetworkConfiguration {
@@ -89,6 +109,10 @@ impl Default for NetworkConfiguration {
             ping: false,
             quic_port: 2022,
             remote_peers: Vec::new(),
+            rendezvous_client: false,
+            rendezvous_server: false,
+            rendezvous_address: None,
+            rendezvous_peer_id: None,
         }
     }
 }

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+mod behaviour;
 mod config;
 mod identity;
 mod service;

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -112,6 +112,9 @@ pub async fn network_service(
                 }
                 SwarmEvent::ConnectionEstablished { peer_id, .. }
                     if network_config.rendezvous_client
+                        && swarm.behaviour().rendezvous_client.is_enabled()
+                        // Should be safe to unwrap rendezvous_peer_id because the CLI parser ensures
+                        // it's provided if rendezvous_client is set to true
                         && network_config.rendezvous_peer_id.unwrap() == peer_id =>
                 {
                     debug!(
@@ -122,7 +125,7 @@ pub async fn network_service(
                         .behaviour_mut()
                         .rendezvous_client
                         .as_mut()
-                        .unwrap()
+                        .unwrap() // Safe to unwrap because rendezvous_client behaviour is enabled
                         .discover(
                             Some(rendezvous::Namespace::new(NODE_NAMESPACE.to_string()).unwrap()),
                             None,

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -116,7 +116,6 @@ pub async fn network_service(
                     num_established,
                     ..
                 } => debug!("ConnectionEstablished: {peer_id} {endpoint:?} {num_established}"),
-
                 SwarmEvent::Dialing(peer_id) => info!("Dialing: {peer_id}"),
                 SwarmEvent::ExpiredListenAddr {
                     listener_id,
@@ -206,7 +205,6 @@ pub async fn network_service(
                             registrations.len()
                         );
                     }
-                    // TODO: consider exhaustive matching with logging for each discrete event
                     other => debug!("Unhandled rendezvous server event: {:?}", other),
                 },
                 SwarmEvent::Behaviour(BehaviourEvent::Identify(event)) => {

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -245,7 +245,15 @@ pub async fn network_service(
                                     );
                             }
                         }
-                        other => debug!("Unhandled identify event: {:?}", other),
+                        identify::Event::Sent { peer_id } | identify::Event::Pushed { peer_id } => {
+                            debug!(
+                                "Sent identification information of the local node to peer {}",
+                                peer_id
+                            )
+                        }
+                        identify::Event::Error { peer_id, error } => {
+                            warn!("Failed to identify the remote peer {}: {}", peer_id, error)
+                        }
                     }
                 }
             }

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -115,8 +115,7 @@ pub async fn network_service(
                         && network_config.rendezvous_peer_id.unwrap() == peer_id =>
                 {
                     debug!(
-                        "Connected to rendezvous point, discovering nodes in '{}' namespace ...",
-                        NODE_NAMESPACE
+                        "Connected to rendezvous point, discovering nodes in '{NODE_NAMESPACE}' namespace ..."
                     );
 
                     swarm
@@ -191,7 +190,7 @@ pub async fn network_service(
                         for registration in registrations {
                             for address in registration.record.addresses() {
                                 let peer = registration.record.peer_id();
-                                debug!("Discovered peer {} at {}", peer, address);
+                                debug!("Discovered peer {peer} at {address}");
 
                                 let p2p_suffix = Protocol::P2p(*peer.as_ref());
                                 let address_with_p2p = if !address
@@ -207,15 +206,15 @@ pub async fn network_service(
                         }
                     }
                     rendezvous::client::Event::RegisterFailed(error) => {
-                        warn!("Failed to register with rendezvous point: {}", error);
+                        warn!("Failed to register with rendezvous point: {error}");
                     }
-                    other => debug!("Unhandled rendezvous client event: {:?}", other),
+                    other => debug!("Unhandled rendezvous client event: {other:?}"),
                 },
                 SwarmEvent::Behaviour(BehaviourEvent::RendezvousServer(event)) => match event {
                     rendezvous::server::Event::PeerRegistered { peer, registration } => {
                         debug!(
-                            "Peer {} registered for namespace '{}'",
-                            peer, registration.namespace
+                            "Peer {peer} registered for namespace '{}'",
+                            registration.namespace
                         );
                     }
                     rendezvous::server::Event::DiscoverServed {
@@ -223,20 +222,19 @@ pub async fn network_service(
                         registrations,
                     } => {
                         debug!(
-                            "Served peer {} with {} registrations",
-                            enquirer,
+                            "Served peer {enquirer} with {} registrations",
                             registrations.len()
                         );
                     }
-                    other => debug!("Unhandled rendezvous server event: {:?}", other),
+                    other => debug!("Unhandled rendezvous server event: {other:?}"),
                 },
                 SwarmEvent::Behaviour(BehaviourEvent::Identify(event)) => {
                     match event {
                         identify::Event::Received { peer_id, info } => {
-                            debug!("Received identify information from peer {}", peer_id);
+                            debug!("Received identify information from peer {peer_id}");
                             debug!(
-                                "Peer {} reported local external address: {}",
-                                peer_id, info.observed_addr
+                                "Peer {peer_id} reported local external address: {}",
+                                info.observed_addr
                             );
 
                             swarm.add_external_address(info.observed_addr, AddressScore::Infinite);
@@ -265,12 +263,11 @@ pub async fn network_service(
                         }
                         identify::Event::Sent { peer_id } | identify::Event::Pushed { peer_id } => {
                             debug!(
-                                "Sent identification information of the local node to peer {}",
-                                peer_id
+                                "Sent identification information of the local node to peer {peer_id}"
                             )
                         }
                         identify::Event::Error { peer_id, error } => {
-                            warn!("Failed to identify the remote peer {}: {}", peer_id, error)
+                            warn!("Failed to identify the remote peer {peer_id}: {error}")
                         }
                     }
                 }

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -197,6 +197,9 @@ pub async fn network_service(
                             }
                         }
                     }
+                    rendezvous::client::Event::RegisterFailed(error) => {
+                        warn!("Failed to register with rendezvous server: {}", error);
+                    }
                     other => debug!("Unhandled rendezvous client event: {:?}", other),
                 },
                 SwarmEvent::Behaviour(BehaviourEvent::RendezvousServer(event)) => match event {

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -111,29 +111,28 @@ pub async fn network_service(
                     debug!("ConnectionClosed: {peer_id} {endpoint:?} {num_established} {cause:?}")
                 }
                 SwarmEvent::ConnectionEstablished { peer_id, .. }
+                    // Match on a connection with the rendezvous server
                     if network_config.rendezvous_client
-                        && swarm.behaviour().rendezvous_client.is_enabled()
                         // Should be safe to unwrap rendezvous_peer_id because the CLI parser ensures
                         // it's provided if rendezvous_client is set to true
                         && network_config.rendezvous_peer_id.unwrap() == peer_id =>
                 {
-                    debug!(
-                        "Connected to rendezvous point, discovering nodes in '{NODE_NAMESPACE}' namespace ..."
-                    );
+                    if let Some(rendezvous_client) =
+                        swarm.behaviour_mut().rendezvous_client.as_mut()
+                    {
+                        debug!(
+                            "Connected to rendezvous point, discovering nodes in '{NODE_NAMESPACE}' namespace ..."
+                        );
 
-                    swarm
-                        .behaviour_mut()
-                        .rendezvous_client
-                        .as_mut()
-                        .unwrap() // Safe to unwrap because rendezvous_client behaviour is enabled
-                        .discover(
-                            Some(rendezvous::Namespace::new(NODE_NAMESPACE.to_string()).unwrap()),
+                        rendezvous_client.discover(
+                            Some(rendezvous::Namespace::from_static(NODE_NAMESPACE)),
                             None,
                             None,
                             network_config
                                 .rendezvous_peer_id
                                 .expect("Rendezvous server peer ID was provided"),
                         );
+                    }
                 }
                 SwarmEvent::ConnectionEstablished {
                     peer_id,
@@ -250,18 +249,15 @@ pub async fn network_service(
 
                                 // We call `as_mut()` on the rendezvous client network behaviour in
                                 // order to get a mutable reference out of the `Toggle`
-                                swarm
-                                    .behaviour_mut()
-                                    .rendezvous_client
-                                    .as_mut()
-                                    .unwrap()
-                                    .register(
+                                if let Some (rendezvous_client) = swarm.behaviour_mut().rendezvous_client.as_mut() {
+                                    rendezvous_client.register(
                                         rendezvous::Namespace::from_static(NODE_NAMESPACE),
                                         network_config
                                             .rendezvous_peer_id
                                             .expect("Rendezvous server peer ID was provided"),
                                         None,
                                     );
+                                }
                             }
                         }
                         identify::Event::Sent { peer_id } | identify::Event::Pushed { peer_id } => {

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "pietgeursen <pietgeursen@gmail.com>",
     "sandreae <contact@samandreae.com>",
     "sophiiistika <sophiiistika@mailbox.org>",
+    "glyph <glyph@mycelial.technology>",
 ]
 license = "AGPL-3.0-or-later"
 repository = "https://github.com/p2panda/aquadoggo"

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "^1.0.62"
 tokio = { version = "^1.20.1", features = ["full"] }
 env_logger = "^0.9.0"
 clap = { version = "^4.1.8", features = ["derive"] }
+libp2p = "^0.51.0"
 
 [dependencies.aquadoggo]
 version = "~0.4.0"

--- a/aquadoggo_cli/README.md
+++ b/aquadoggo_cli/README.md
@@ -4,6 +4,8 @@ Node server with GraphQL API for the p2panda network.
 
 ## Usage
 
+When running the node as a rendezvous client (`--rendezvous-client true`) both the rendezvous address and peer ID must be provided.
+
 ```
 Options:
   -d, --data-dir <DATA_DIR>
@@ -27,6 +29,26 @@ Options:
           Enable ping for connected peers (send and receive ping packets), true by default
 
           [possible values: true, false]
+
+  -C, --rendezvous-client <RENDEZVOUS_CLIENT>
+          Enable rendezvous client to facilitate peer discovery via a rendezvous server, false by default
+
+          [possible values: true, false]
+
+  -S, --rendezvous-server <RENDEZVOUS_SERVER>
+          Enable rendezvous server to facilitate peer discovery for remote peers, false by default
+
+          [possible values: true, false]
+
+      --rendezvous-address <RENDEZVOUS_ADDRESS>
+          The IP address of a rendezvous server in the form of a multiaddress.
+
+          eg. --rendezvous-address "/ip4/127.0.0.1/udp/12345/quic-v1"
+
+      --rendezvous-peer-id <RENDEZVOUS_PEER_ID>
+          The peer ID of a rendezvous server in the form of an Ed25519 key encoded as a raw base58btc multihash.
+
+          eg. --rendezvous-peer-id "12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA"
 
   -h, --help
           Print help (see a summary with '-h')

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -34,6 +34,27 @@ struct Cli {
     /// Enable ping for connected peers (send and receive ping packets), true by default.
     #[arg(long)]
     ping: Option<bool>,
+
+    /// Enable rendezvous client to facilitate peer discovery via a rendezvous server, false by default.
+    #[arg(short = 'C', long)]
+    rendezvous_client: Option<bool>,
+
+    /// Enable rendezvous server to facilitate peer discovery for remote peers, false by default.
+    #[arg(short = 'S', long)]
+    rendezvous_server: Option<bool>,
+
+    /// The IP address of a rendezvous server in the form of a multiaddress.
+    ///
+    /// eg. --rendezvous-address "/ip4/127.0.0.1/udp/12345/quic-v1"
+    #[arg(long)]
+    rendezvous_address: Option<String>,
+
+    /// The peer ID of a rendezvous server in the form of an Ed25519 key encoded as a raw
+    /// base58btc multihash.
+    ///
+    /// eg. --rendezvous-peer-id "12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA"
+    #[arg(long)]
+    rendezvous_peer_id: Option<String>,
 }
 
 impl TryFrom<Cli> for Configuration {
@@ -48,6 +69,10 @@ impl TryFrom<Cli> for Configuration {
             ping: cli.ping.unwrap_or(true),
             quic_port: cli.quic_port.unwrap_or(2022),
             remote_peers: cli.remote_node_addresses,
+            rendezvous_client: cli.rendezvous_client.unwrap_or(false),
+            rendezvous_server: cli.rendezvous_server.unwrap_or(false),
+            rendezvous_address: cli.rendezvous_address,
+            rendezvous_peer_id: cli.rendezvous_peer_id,
             ..NetworkConfiguration::default()
         };
 

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use aquadoggo::{Configuration, NetworkConfiguration, Node};
 use clap::error::ErrorKind as ClapErrorKind;
 use clap::{CommandFactory, Parser};
+use libp2p::{Multiaddr, PeerId};
 
 #[derive(Parser, Debug)]
 #[command(name = "aquadoggo Node", version)]
@@ -26,7 +27,7 @@ struct Cli {
 
     /// URLs of remote nodes to replicate with.
     #[arg(short, long)]
-    remote_node_addresses: Vec<String>,
+    remote_node_addresses: Vec<Multiaddr>,
 
     /// Enable mDNS for peer discovery over LAN (using port 5353), true by default.
     #[arg(short, long)]
@@ -48,14 +49,14 @@ struct Cli {
     ///
     /// eg. --rendezvous-address "/ip4/127.0.0.1/udp/12345/quic-v1"
     #[arg(long)]
-    rendezvous_address: Option<String>,
+    rendezvous_address: Option<Multiaddr>,
 
     /// The peer ID of a rendezvous server in the form of an Ed25519 key encoded as a raw
     /// base58btc multihash.
     ///
     /// eg. --rendezvous-peer-id "12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA"
     #[arg(long)]
-    rendezvous_peer_id: Option<String>,
+    rendezvous_peer_id: Option<PeerId>,
 }
 
 impl Cli {


### PR DESCRIPTION
Addresses https://github.com/p2panda/aquadoggo/issues/303

- [x] Move `NetworkBehaviour` into a separate module (`behaviour.rs`)
- [x] Add the `identify` network behaviour / protocol
  - [x] Manually add an external address when reported via remote peer
  - [x] Handle `identify::Event::Received` event
  - [x] Handle `identify::Event::Sent` event
  - [x] Handle `identify::Event::Error` event
- [x] Add the `rendezvous` network behaviour / protocol
  - [x] Handle `rendezvous::client::Event::Registered` event
  - [x] Handle `rendezvous::client::Event::Discovered` event
  - [x] Handle `rendezvous::client::Event::Failed` event
  - [x] Handle `rendezvous::server::Event::PeerRegistered` event
  - [x] Handle `rendezvous::server::Event::DiscoverServed` event
- [x] Add configuration options for rendezvous
- [x] Expose rendezvous configuration options via CLI
- [x] Replace `String` with `Multiaddr` for `--remote-node-addresses` and `--rendezvous-address` (results in validation by parser)
- [x] Replace `String` with `PeerId` for `--rendezvous-peer-id` (results in validation by parser)
- [x] Add `glyph` to list of authors
- [x] Update CLI `README` with latest usage instructions

## 📋 Checklist

- [ ] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
