### PR TITLE
Custom validation for GraphQL `Scalar` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce libp2p networking service and configuration [#282](https://github.com/p2panda/aquadoggo/pull/282)
 - Create and validate abstract queries [#302](https://github.com/p2panda/aquadoggo/pull/302)
 - Support paginated, ordered and filtered collection queries [#308](https://github.com/p2panda/aquadoggo/pull/308)
+- Add custom validation to GraphQL scalar types [#318](https://github.com/p2panda/aquadoggo/pull/318)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,9 +1335,9 @@ checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
 
 [[package]]
 name = "dynamic-graphql"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b08ad44c63c220271bea011292f3612cd83148cb6066a876a189754c07042a6"
+checksum = "0e39ca7874ad3e6315bb19ef5a75ea8c98b06fe02909096c18127c17c9b90925"
 dependencies = [
  "async-graphql",
  "dynamic-graphql-derive",
@@ -1346,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "dynamic-graphql-derive"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233c5f1c15370c0af6950f695be572eba31838ffe8a048071d13e1a369740aa5"
+checksum = "1c547074a568bfe79c9858a4be0ba42abb18b21f9ddfee44b3c83b96a24d7ef7"
 dependencies = [
  "Inflector",
  "darling",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -27,7 +27,7 @@ deadqueue = { version = "^0.2.3", default-features = false, features = [
     "unlimited",
 ] }
 directories = "^4.0.1"
-dynamic-graphql = "^0.7.1"
+dynamic-graphql = "^0.7.3"
 envy = "^0.4.2"
 futures = "^0.3.23"
 gql_client = "^1.0.6"

--- a/aquadoggo/src/graphql/mutations/publish.rs
+++ b/aquadoggo/src/graphql/mutations/publish.rs
@@ -335,7 +335,7 @@ mod tests {
     #[case::invalid_entry_hex_encoding(
         "-/74='4,.=4-=235m-0   34.6-3",
         &OPERATION_ENCODED,
-        "Invalid value for argument \"entry\": Failed to parse \"EncodedEntry\": Invalid character '-' at position 0"
+        "Invalid value for argument \"entry\", expected type \"EncodedEntry\""
     )]
     #[case::no_entry(
         "",
@@ -373,12 +373,12 @@ mod tests {
     #[case::valid_entry_with_extra_hex_char_at_end(
         &{EncodedEntry::from_bytes(&ENTRY_ENCODED).to_string() + "A"},
         &OPERATION_ENCODED,
-        "Invalid value for argument \"entry\": Failed to parse \"EncodedEntry\": Odd number of digits"
+        "Invalid value for argument \"entry\", expected type \"EncodedEntry\""
     )]
     #[case::valid_entry_with_extra_hex_char_at_start(
         &{"A".to_string() + &EncodedEntry::from_bytes(&ENTRY_ENCODED).to_string()},
         &OPERATION_ENCODED,
-        "Invalid value for argument \"entry\": Failed to parse \"EncodedEntry\": Odd number of digits"
+        "Invalid value for argument \"entry\", expected type \"EncodedEntry\""
     )]
     #[case::should_not_have_skiplink(
         &entry_signed_encoded_unvalidated(

--- a/aquadoggo/src/graphql/queries/all_documents.rs
+++ b/aquadoggo/src/graphql/queries/all_documents.rs
@@ -235,13 +235,11 @@ mod test {
         Value::Null,
         vec!["Invalid value for argument \"meta.viewId.in\", expected type \"DocumentViewId\"".to_string()]
     )]
-    // TODO: When we have a way to add custom validation to scalar types then this case should
-    // fail as we pass in an invalid public key string. Same for documentId and viewId meta fields.
-    // #[case(
-    //     r#"(meta: { owner: { eq: "hello" }})"#.to_string(),
-    //     Value::Null,
-    //     vec!["Invalid value for argument \"meta.owner\", unknown field \"contains\" of type \"OwnerFilter\"".to_string()]
-    // )]
+    #[case(
+        r#"(meta: { owner: { eq: "hello" }})"#.to_string(),
+        Value::Null,
+        vec!["Invalid value for argument \"meta.owner.eq\", expected type \"PublicKey\"".to_string()]
+    )]
 
     fn collection_query(
         key_pair: KeyPair,

--- a/aquadoggo/src/graphql/queries/all_documents.rs
+++ b/aquadoggo/src/graphql/queries/all_documents.rs
@@ -148,17 +148,17 @@ mod test {
     #[case(
         r#"(after: HELLO)"#.to_string(), 
         Value::Null,
-        vec!["internal: not a string".to_string()]
+        vec!["Invalid value for argument \"after\", expected type \"Cursor\"".to_string()]
     )]
     #[case(
         r#"(after: "00205406410aefce40c5cbbb04488f50714b7d5657b9f17eed7358da35379bc20331")"#.to_string(), 
         Value::Null,
-        vec!["Invalid amount of cursor parts".to_string()]
+        vec!["Invalid value for argument \"after\", expected type \"Cursor\"".to_string()]
     )]
     #[case(
         r#"(after: 27)"#.to_string(), 
         Value::Null,
-        vec!["internal: not a string".to_string()]
+        vec!["Invalid value for argument \"after\", expected type \"Cursor\"".to_string()]
     )]
     #[case(
         r#"(orderBy: HELLO)"#.to_string(), 
@@ -228,12 +228,12 @@ mod test {
     #[case(
         r#"(meta: { documentId: { eq: 27 }})"#.to_string(), 
         Value::Null,
-        vec!["internal: not a string".to_string()]
+        vec!["Invalid value for argument \"meta.documentId.eq\", expected type \"DocumentId\"".to_string()]
     )]
     #[case(
         r#"(meta: { viewId: { in: "hello" }})"#.to_string(), 
         Value::Null,
-        vec!["internal: not a list".to_string()]
+        vec!["Invalid value for argument \"meta.viewId.in\", expected type \"DocumentViewId\"".to_string()]
     )]
     // TODO: When we have a way to add custom validation to scalar types then this case should
     // fail as we pass in an invalid public key string. Same for documentId and viewId meta fields.

--- a/aquadoggo/src/graphql/queries/document.rs
+++ b/aquadoggo/src/graphql/queries/document.rs
@@ -207,12 +207,12 @@ mod test {
     #[case::malformed_document_id(
         "(id: \"verboten\")",
         Value::Null,
-        vec!["invalid hex encoding in hash string".to_string()]
+        vec!["Invalid value for argument \"id\", expected type \"DocumentId\"".to_string()]
     )]
     #[case::malformed_view_id(
         "(viewId: \"verboten\")",
         Value::Null,
-        vec!["invalid hex encoding in hash string".to_string()]
+        vec!["Invalid value for argument \"viewId\", expected type \"DocumentViewId\"".to_string()]
     )]
     #[case::missing_parameters(
         "",

--- a/aquadoggo/src/graphql/queries/next_args.rs
+++ b/aquadoggo/src/graphql/queries/next_args.rs
@@ -218,7 +218,7 @@ mod tests {
             let response: Response = response.json().await;
             assert_eq!(
                 response.errors[0].message,
-                "invalid hex encoding in public key string"
+                "Invalid value for argument \"publicKey\", expected type \"PublicKey\""
             )
         })
     }

--- a/aquadoggo/src/graphql/scalars/cursor_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/cursor_scalar.rs
@@ -12,7 +12,7 @@ use crate::db::query::Cursor;
 
 /// The cursor used in paginated queries.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq)]
-#[graphql(name = "Cursor")]
+#[graphql(name = "Cursor", validator(validate))]
 pub struct CursorScalar(String, DocumentId);
 
 impl ScalarValue for CursorScalar {
@@ -60,4 +60,10 @@ impl Cursor for CursorScalar {
     fn encode(&self) -> String {
         format!("{}_{}", self.0, self.1)
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    CursorScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/cursor_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/cursor_scalar.rs
@@ -63,7 +63,7 @@ impl Cursor for CursorScalar {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     CursorScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/document_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/document_id_scalar.rs
@@ -8,7 +8,7 @@ use p2panda_rs::document::DocumentId;
 
 /// The id of a p2panda document.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq)]
-#[graphql(name = "DocumentId")]
+#[graphql(name = "DocumentId", validator(validate))]
 pub struct DocumentIdScalar(DocumentId);
 
 impl ScalarValue for DocumentIdScalar {
@@ -48,4 +48,10 @@ impl Display for DocumentIdScalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.as_str())
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    DocumentIdScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/document_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/document_id_scalar.rs
@@ -51,7 +51,7 @@ impl Display for DocumentIdScalar {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     DocumentIdScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
@@ -51,7 +51,7 @@ impl Display for DocumentViewIdScalar {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     DocumentViewIdScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
@@ -8,7 +8,7 @@ use p2panda_rs::document::DocumentViewId;
 /// The document view id of a p2panda document. Refers to a specific point in a documents history
 /// and can be used to deterministically reconstruct it's state at that time.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq)]
-#[graphql(name = "DocumentViewId")]
+#[graphql(name = "DocumentViewId", validator(validate))]
 pub struct DocumentViewIdScalar(DocumentViewId);
 
 impl ScalarValue for DocumentViewIdScalar {
@@ -48,4 +48,10 @@ impl Display for DocumentViewIdScalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    DocumentViewIdScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/encoded_entry_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/encoded_entry_scalar.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Signed bamboo entry, encoded as a hexadecimal string.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[graphql(name = "EncodedEntry")]
+#[graphql(name = "EncodedEntry", validator(validate))]
 pub struct EncodedEntryScalar(EncodedEntry);
 
 impl ScalarValue for EncodedEntryScalar {
@@ -38,4 +38,10 @@ impl From<EncodedEntryScalar> for EncodedEntry {
     fn from(entry: EncodedEntryScalar) -> EncodedEntry {
         entry.0
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    EncodedEntryScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/encoded_entry_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/encoded_entry_scalar.rs
@@ -41,7 +41,7 @@ impl From<EncodedEntryScalar> for EncodedEntry {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     EncodedEntryScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/encoded_operation_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/encoded_operation_scalar.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Entry payload and p2panda operation, CBOR bytes encoded as a hexadecimal string.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[graphql(name = "EncodedOperation",validator(validate))]
+#[graphql(name = "EncodedOperation", validator(validate))]
 pub struct EncodedOperationScalar(EncodedOperation);
 
 impl ScalarValue for EncodedOperationScalar {
@@ -44,7 +44,7 @@ impl From<EncodedOperationScalar> for EncodedOperation {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     EncodedOperationScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/encoded_operation_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/encoded_operation_scalar.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Entry payload and p2panda operation, CBOR bytes encoded as a hexadecimal string.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[graphql(name = "EncodedOperation")]
+#[graphql(name = "EncodedOperation",validator(validate))]
 pub struct EncodedOperationScalar(EncodedOperation);
 
 impl ScalarValue for EncodedOperationScalar {
@@ -41,4 +41,10 @@ impl From<EncodedOperationScalar> for EncodedOperation {
     fn from(operation: EncodedOperationScalar) -> EncodedOperation {
         operation.0
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    EncodedOperationScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/entry_hash_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/entry_hash_scalar.rs
@@ -71,7 +71,7 @@ mod tests {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     EntryHashScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/entry_hash_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/entry_hash_scalar.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 /// Hash of a signed bamboo entry.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq, Serialize)]
-#[graphql(name = "EntryHash")]
+#[graphql(name = "EntryHash", validator(validate))]
 pub struct EntryHashScalar(Hash);
 
 impl ScalarValue for EntryHashScalar {
@@ -68,4 +68,10 @@ mod tests {
             hash.0.into()
         }
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    EntryHashScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/log_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/log_id_scalar.rs
@@ -78,7 +78,7 @@ impl Display for LogIdScalar {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     LogIdScalar::from_value(value.to_owned()).is_ok()
 }

--- a/aquadoggo/src/graphql/scalars/log_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/log_id_scalar.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Log id of a bamboo entry.
 #[derive(Scalar, Clone, Copy, Eq, PartialEq, Debug)]
-#[graphql(name = "LogId")]
+#[graphql(name = "LogId", validator(validate))]
 pub struct LogIdScalar(LogId);
 
 impl ScalarValue for LogIdScalar {
@@ -75,6 +75,12 @@ impl Display for LogIdScalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.as_u64())
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    LogIdScalar::from_value(value.to_owned()).is_ok()
 }
 
 #[cfg(test)]

--- a/aquadoggo/src/graphql/scalars/public_key_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/public_key_scalar.rs
@@ -8,7 +8,7 @@ use p2panda_rs::identity::PublicKey;
 
 /// Public key that signed the entry.
 #[derive(Scalar, Debug, Clone, Eq, PartialEq, Copy)]
-#[graphql(name = "PublicKey")]
+#[graphql(name = "PublicKey", validator(validate))]
 pub struct PublicKeyScalar(PublicKey);
 
 impl ScalarValue for PublicKeyScalar {
@@ -49,3 +49,10 @@ impl Display for PublicKeyScalar {
         write!(f, "{}", self.0)
     }
 }
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api. 
+fn validate(value: &Value) -> bool {
+    PublicKeyScalar::from_value(value.to_owned()).is_ok()
+}
+

--- a/aquadoggo/src/graphql/scalars/public_key_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/public_key_scalar.rs
@@ -51,8 +51,7 @@ impl Display for PublicKeyScalar {
 }
 
 /// Validation method used internally in `async-graphql` to check scalar values passed into the
-/// public api. 
+/// public api.
 fn validate(value: &Value) -> bool {
     PublicKeyScalar::from_value(value.to_owned()).is_ok()
 }
-

--- a/aquadoggo/src/graphql/scalars/seq_num_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/seq_num_scalar.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Sequence number of an entry.
 #[derive(Scalar, Clone, Copy, Debug, Eq, PartialEq)]
-#[graphql(name = "SeqNum")]
+#[graphql(name = "SeqNum", validator(validate))]
 pub struct SeqNumScalar(SeqNum);
 
 impl SeqNumScalar {
@@ -101,6 +101,12 @@ impl Display for SeqNumScalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.as_u64())
     }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api.
+fn validate(value: &Value) -> bool {
+    SeqNumScalar::from_value(value.to_owned()).is_ok()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR implements custom validation on GraphQL scalar types. This means that any invalid errors passed into the api as arguments are internally validated and if they fail, errors are returned to the user with context information about which argument in the query failed and what value type was expected.

However, a side effect of this change is that in some cases (well, two i think) the actual validation errors returned from attempting to parse the value into it's expected type are lost. 

So there is a slight trade off involved here. In some places specific validation failure errors are lost, but in other places we gain useful context about which passed value was invalid.

See the changes for examples of the differences.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
