### PR TITLE
Fix race conditions in SQLite database test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update breaking API calls for new `p2panda-rs` 0.7.0 version [#293](https://github.com/p2panda/aquadoggo/pull/293)
 - Handle decoding and parsing empty pinned relation lists [#336](https://github.com/p2panda/aquadoggo/pull/336)
 - Make `value` on `QueryRow` an option [#339](https://github.com/p2panda/aquadoggo/pull/339)
+- Fix race conditions in SQLite database test runner [#345](https://github.com/p2panda/aquadoggo/pull/345)
 
 ## [0.4.0]
 

--- a/aquadoggo/src/test_utils/config.rs
+++ b/aquadoggo/src/test_utils/config.rs
@@ -2,19 +2,17 @@
 
 use std::fmt::Debug;
 
-use once_cell::sync::Lazy;
 use serde::Deserialize;
 
 /// Configuration used in test helper methods.
 #[derive(Deserialize, Debug)]
 #[serde(default)]
 pub struct TestConfiguration {
-    /// Database url (sqlite or postgres)
+    /// Database url (SQLite or PostgreSQL).
     pub database_url: String,
 }
 
 impl TestConfiguration {
-    /// Create a new configuration object for test environments.
     pub fn new() -> Self {
         envy::from_env::<TestConfiguration>()
             .expect("Could not read environment variables for test configuration")
@@ -23,11 +21,12 @@ impl TestConfiguration {
 
 impl Default for TestConfiguration {
     fn default() -> Self {
+        // Give each database an unique name
+        let db_name = format!("dbmem{}", rand::random::<u32>());
+
         Self {
             /// SQLite database stored in memory.
-            database_url: "sqlite::memory:".into(),
+            database_url: format!("sqlite://{db_name}?mode=memory&cache=private"),
         }
     }
 }
-
-pub static TEST_CONFIG: Lazy<TestConfiguration> = Lazy::new(TestConfiguration::new);

--- a/aquadoggo/src/test_utils/mod.rs
+++ b/aquadoggo/src/test_utils/mod.rs
@@ -8,8 +8,8 @@ mod node;
 mod runner;
 
 pub use client::{graphql_test_client, TestClient};
-pub use config::{TestConfiguration, TEST_CONFIG};
-pub use db::{drop_database, initialize_db, initialize_db_with_url};
+pub use config::TestConfiguration;
+pub use db::{drop_database, initialize_db};
 pub use helpers::{build_document, doggo_fields, doggo_schema, schema_from_fields};
 pub use node::{
     add_document, add_schema, add_schema_and_documents, populate_and_materialize,

--- a/aquadoggo/src/test_utils/runner.rs
+++ b/aquadoggo/src/test_utils/runner.rs
@@ -43,7 +43,7 @@ pub fn test_runner<F: AsyncTestFn + Send + Sync + 'static>(test: F) {
 
     runtime.block_on(async {
         // Initialise store
-        let pool = initialize_db().await;
+        let (_config, pool) = initialize_db().await;
         let store = SqlStore::new(pool);
 
         // Construct the actual test node


### PR DESCRIPTION
This makes sure that every individual test runs against its own database in memory by giving it a random identifier. Apparently this was not the case before and some tests shared the same database which led to unexpected race conditions.

Closes #270 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
