### PR TITLE
Bind filter arguments in SQL query

### DIFF
--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -245,7 +245,7 @@ fn typecast_field_sql(
 }
 
 /// Helper method to convert an operation value into the right representation in SQL.
-fn value_sql(value: &OperationValue) -> String {
+fn value_sql(value: &OperationValue) -> Vec<String> {
     match &value {
         // Note that we wrap boolean values into a string here, as our operation field values are
         // stored as strings in themselves and we can't typecast them to booleans due to a
@@ -253,48 +253,53 @@ fn value_sql(value: &OperationValue) -> String {
         //
         // When comparing meta fields like `is_edited` etc. do _not_ use this method since we're
         // dealing there with native boolean values instead of strings.
-        OperationValue::Boolean(value) => (if *value { "'true'" } else { "'false'" }).to_string(),
-        OperationValue::Integer(value) => value.to_string(),
-        OperationValue::Float(value) => value.to_string(),
-        OperationValue::String(value) => format!("'{value}'"),
-        OperationValue::Relation(value) => {
-            format!("'{}'", value.document_id())
-        }
+        OperationValue::Boolean(value) => vec![(if *value { "true" } else { "false" }).to_string()],
+        OperationValue::Integer(value) => vec![value.to_string()],
+        OperationValue::Float(value) => vec![value.to_string()],
+        OperationValue::String(value) => vec![value.to_owned()],
+        OperationValue::Relation(value) => vec![value.document_id().to_string()],
         OperationValue::RelationList(value) => value
             .iter()
-            .map(|document_id| format!("'{document_id}'"))
-            .collect::<Vec<String>>()
-            .join(","),
-        OperationValue::PinnedRelation(value) => format!("'{}'", value.view_id()),
+            .map(|document_id| document_id.to_string())
+            .collect::<Vec<String>>(),
+        OperationValue::PinnedRelation(value) => vec![value.view_id().to_string()],
         OperationValue::PinnedRelationList(value) => value
             .iter()
-            .map(|view_id| format!("'{view_id}'"))
-            .collect::<Vec<String>>()
-            .join(","),
+            .map(|view_id| view_id.to_string())
+            .collect::<Vec<String>>(),
     }
 }
 
 /// Helper method to convert filter settings into SQL comparison operations.
-fn cmp_sql(sql_field: &str, filter_setting: &FilterSetting) -> String {
+fn cmp_sql(
+    sql_field: &str,
+    filter_setting: &FilterSetting,
+    args: &mut Vec<BindArgument>,
+) -> String {
     match &filter_setting.by {
         FilterBy::Element(value) => {
+            args.append(&mut value_sql(value));
+
             if !filter_setting.exclusive {
-                format!("{sql_field} = {}", value_sql(value))
+                format!("{sql_field} = ${}", args.len())
             } else {
-                format!("{sql_field} != {}", value_sql(value))
+                format!("{sql_field} != ${}", args.len())
             }
         }
         FilterBy::Set(values_vec) => {
-            let value_sql = values_vec
+            let args_sql = values_vec
                 .iter()
-                .map(value_sql)
+                .map(|value| {
+                    args.append(&mut value_sql(value));
+                    format!("${}", args.len())
+                })
                 .collect::<Vec<String>>()
                 .join(",");
 
             if !filter_setting.exclusive {
-                format!("{sql_field} IN ({})", value_sql)
+                format!("{sql_field} IN ({})", args_sql)
             } else {
-                format!("{sql_field} NOT IN ({})", value_sql)
+                format!("{sql_field} NOT IN ({})", args_sql)
             }
         }
         FilterBy::Interval(lower_value, upper_value) => {
@@ -303,30 +308,36 @@ fn cmp_sql(sql_field: &str, filter_setting: &FilterSetting) -> String {
             match lower_value {
                 LowerBound::Unbounded => (),
                 LowerBound::Greater(value) => {
-                    values.push(format!("{sql_field} > {}", value_sql(value)));
+                    args.append(&mut value_sql(value));
+                    values.push(format!("{sql_field} > ${}", args.len()));
                 }
                 LowerBound::GreaterEqual(value) => {
-                    values.push(format!("{sql_field} >= {}", value_sql(value)));
+                    args.append(&mut value_sql(value));
+                    values.push(format!("{sql_field} >= ${}", args.len()));
                 }
             }
 
             match upper_value {
                 UpperBound::Unbounded => (),
                 UpperBound::Lower(value) => {
-                    values.push(format!("{sql_field} < {}", value_sql(value)));
+                    args.append(&mut value_sql(value));
+                    values.push(format!("{sql_field} < ${}", args.len()));
                 }
                 UpperBound::LowerEqual(value) => {
-                    values.push(format!("{sql_field} <= {}", value_sql(value)));
+                    args.append(&mut value_sql(value));
+                    values.push(format!("{sql_field} <= ${}", args.len()));
                 }
             }
 
             values.join(" AND ")
         }
         FilterBy::Contains(OperationValue::String(value)) => {
+            args.push(format!("%{value}%"));
+
             if !filter_setting.exclusive {
-                format!("{sql_field} LIKE '%{value}%'")
+                format!("{sql_field} LIKE ${}", args.len())
             } else {
-                format!("{sql_field} NOT LIKE '%{value}%'")
+                format!("{sql_field} NOT LIKE ${}", args.len())
             }
         }
         _ => panic!("Unsupported filter"),
@@ -342,13 +353,17 @@ fn concatenate_sql(items: &[Option<String>]) -> String {
         .join(", ")
 }
 
-fn where_filter_sql(filter: &Filter, schema: &Schema) -> String {
-    filter
+type BindArgument = String;
+
+fn where_filter_sql(filter: &Filter, schema: &Schema) -> (String, Vec<BindArgument>) {
+    let mut args: Vec<BindArgument> = Vec::new();
+
+    let sql = filter
         .iter()
         .filter_map(|filter_setting| {
             match &filter_setting.field {
                 Field::Meta(MetaField::Owner) => {
-                    Some(format!("AND {}", cmp_sql("owner", filter_setting)))
+                    Some(format!("AND {}", cmp_sql("owner", filter_setting, &mut args)))
                 }
                 Field::Meta(MetaField::Edited) => {
                     if let FilterBy::Element(OperationValue::Boolean(filter_value)) =
@@ -376,15 +391,15 @@ fn where_filter_sql(filter: &Filter, schema: &Schema) -> String {
                 }
                 Field::Meta(MetaField::DocumentId) => Some(format!(
                     "AND {}",
-                    cmp_sql("documents.document_id", filter_setting)
+                    cmp_sql("documents.document_id", filter_setting, &mut args)
                 )),
                 Field::Meta(MetaField::DocumentViewId) => Some(format!(
                     "AND {}",
-                    cmp_sql("documents.document_view_id", filter_setting)
+                    cmp_sql("documents.document_view_id", filter_setting, &mut args)
                 )),
                 Field::Field(field_name) => {
                     let field_sql = typecast_field_sql("operation_fields_v1.value", field_name, schema, true);
-                    let filter_cmp = cmp_sql(&field_sql, filter_setting);
+                    let filter_cmp = cmp_sql(&field_sql, filter_setting, &mut args);
 
                     Some(format!(
                         r#"
@@ -406,7 +421,9 @@ fn where_filter_sql(filter: &Filter, schema: &Schema) -> String {
             }
         })
         .collect::<Vec<String>>()
-        .join("\n")
+        .join("\n");
+
+    (sql, args)
 }
 
 fn where_pagination_sql(
@@ -897,7 +914,7 @@ impl SqlStore {
 
         let where_ = where_sql(schema, &application_fields, list);
         let and_fields = where_fields_sql(&application_fields);
-        let and_filters = where_filter_sql(&args.filter, schema);
+        let (and_filters, bind_args) = where_filter_sql(&args.filter, schema);
         let and_pagination = where_pagination_sql(
             &args.pagination,
             &application_fields,
@@ -968,7 +985,14 @@ impl SqlStore {
         "#
         );
 
-        let mut rows: Vec<QueryRow> = query_as::<_, QueryRow>(&sea_quel)
+        println!("{sea_quel}");
+
+        let mut query = query_as::<_, QueryRow>(&sea_quel);
+        for arg in bind_args {
+            query = query.bind(arg);
+        }
+
+        let mut rows: Vec<QueryRow> = query
             .fetch_all(&self.pool)
             .await
             .map_err(|err| DocumentStorageError::FatalStorageError(err.to_string()))?;
@@ -1038,7 +1062,7 @@ impl SqlStore {
 
         let from = from_sql(list);
         let where_ = where_sql(schema, &application_fields, list);
-        let and_filters = where_filter_sql(&args.filter, schema);
+        let (and_filters, bind_args) = where_filter_sql(&args.filter, schema);
 
         let count_sql = format!(
             r#"
@@ -1063,7 +1087,13 @@ impl SqlStore {
             "#
         );
 
-        let result: Option<(i64,)> = query_as(&count_sql)
+        let mut query = query_as::<_, (i64,)>(&count_sql);
+
+        for arg in bind_args {
+            query = query.bind(arg);
+        }
+
+        let result: Option<(i64,)> = query
             .fetch_optional(&self.pool)
             .await
             .map_err(|err| DocumentStorageError::FatalStorageError(err.to_string()))?;


### PR DESCRIPTION
Binds untrusted filter arguments from as SQL arguments. This helps sanitization and prevention of possible SQL injection attacks.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
