### PR TITLE
Fix missing field when filtering owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix SQL ordering to correctly assemble resulting rows to documents [#347](https://github.com/p2panda/aquadoggo/pull/347)
 - Fix parsing lists arguments twice in GraphQL [#354](https://github.com/p2panda/aquadoggo/pull/354)
 - Sort paginated query field rows by document view id [#354](https://github.com/p2panda/aquadoggo/pull/354)
+- Fix missing field when filtering owner [#359](https://github.com/p2panda/aquadoggo/pull/359)
 
 ## [0.4.0]
 

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -348,7 +348,22 @@ fn where_filter_sql(filter: &Filter, schema: &Schema) -> String {
         .filter_map(|filter_setting| {
             match &filter_setting.field {
                 Field::Meta(MetaField::Owner) => {
-                    Some(format!("AND {}", cmp_sql("owner", filter_setting)))
+                    let filter_cmp = cmp_sql("operations_v1.public_key", filter_setting);
+
+                    Some(format!(
+                        r#"
+                        AND EXISTS (
+                            SELECT
+                                operations_v1.public_key
+                            FROM
+                                operations_v1
+                            WHERE
+                                operations_v1.operation_id = documents.document_id
+                                AND
+                                    {filter_cmp}
+                        )
+                        "#
+                    ))
                 }
                 Field::Meta(MetaField::Edited) => {
                     if let FilterBy::Element(OperationValue::Boolean(filter_value)) =

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -399,7 +399,7 @@ fn where_filter_sql(filter: &Filter, schema: &Schema) -> (String, Vec<BindArgume
         .filter_map(|filter_setting| {
             match &filter_setting.field {
                 Field::Meta(MetaField::Owner) => {
-                    let filter_cmp = cmp_sql("operations_v1.public_key", filter_setting);
+                    let filter_cmp = cmp_sql("operations_v1.public_key", filter_setting, &mut args);
 
                     Some(format!(
                         r#"

--- a/aquadoggo/src/graphql/queries/collection.rs
+++ b/aquadoggo/src/graphql/queries/collection.rs
@@ -147,7 +147,7 @@ mod tests {
                                         owner
                                         documentId
                                         viewId
-                                    }}            
+                                    }}
                                     fields {{
                                         line
                                     }}
@@ -174,7 +174,7 @@ mod tests {
                             owner
                             documentId
                             viewId
-                        }}            
+                        }}
                         fields {{
                             line
                         }}
@@ -780,11 +780,10 @@ mod tests {
     #[case("(orderDirection: ASC, orderBy: title)", "")]
     #[case("(orderDirection: DESC, orderBy: DOCUMENT_ID)", "")]
     #[case("(orderDirection: ASC, orderBy: DOCUMENT_VIEW_ID)", "")]
-    // @TODO: these fails, see: https://github.com/p2panda/aquadoggo/issues/353
-    // #[case("(meta: { owner: { eq: \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" } })", "")]
-    // #[case("(meta: { owner: { notEq: \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" } })", "")]
-    // #[case("(meta: { owner: { in: [ \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" ] } })", "")]
-    // #[case("(meta: { owner: { notIn: [ \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" ] } })", "")]
+    #[case("(meta: { owner: { eq: \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" } })", "")]
+    #[case("(meta: { owner: { notEq: \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" } })", "")]
+    #[case("(meta: { owner: { in: [ \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" ] } })", "")]
+    #[case("(meta: { owner: { notIn: [ \"2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96\" ] } })", "")]
     #[case("(meta: { documentId: { eq: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\" } })", "")]
     #[case("(meta: { documentId: { notEq: \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\" } })", "")]
     #[case("(meta: { documentId: { in: [ \"0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543\" ] } })", "")]
@@ -1046,17 +1045,18 @@ mod tests {
             assert_eq!(data["query"]["documents"].as_array().unwrap().len(), 0);
             assert_eq!(data["query"]["totalCount"], json!(0));
 
-            // let me = key_pair.public_key().to_string();
-            //
-            // @TODO: this fails, see: https://github.com/p2panda/aquadoggo/issues/353
-            // // What about only songs I've published to the network:
-            // let data = query_songs(
-            //     &client,
-            //     song_schema.id(),
-            //     &format!("(meta: {{ owner: {{ eq: \"{me}\" }} }})"),
-            //     "",
-            // )
-            // .await;
+            let me = key_pair.public_key().to_string();
+
+            // What about songs I've published to the network:
+            let data = query_songs(
+                &client,
+                song_schema.id(),
+                &format!("(meta: {{ owner: {{ eq: \"{me}\" }} }})"),
+                "",
+            )
+            .await;
+
+            assert_eq!(data["query"]["totalCount"], json!(3));
 
             // Oh yeh, i like that song lyric "This heaven gives me migraine"! I wonder if I can
             // find it....


### PR DESCRIPTION
We can't use aliased fields like `owner` in a WHERE clause and this broke some filter queries against `owner`. This issue fixes that bug by introducing a sub-query instead.

Closes #353 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
