### PR TITLE
libp2p networking layer for replication protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQL query for collections [#311](https://github.com/p2panda/aquadoggo/pull/311)
 - Add custom validation to GraphQL scalar types [#318](https://github.com/p2panda/aquadoggo/pull/318)
 - Introduce property tests for GraphQL query API with `proptest` [#338](https://github.com/p2panda/aquadoggo/pull/338)
+- Introduce initial libp2p network behaviour for replication protocol [#365](https://github.com/p2panda/aquadoggo/pull/365) 
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "hyper",
  "libp2p",
  "libp2p-quic",
+ "libp2p-swarm-test",
  "lipmaa-link 0.2.2",
  "log",
  "once_cell",
@@ -340,6 +341,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-global-executor"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +484,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
+]
+
+[[package]]
+name = "async-net"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4051e67316bc7eff608fe723df5d32ed639946adcd69e07df41fd42a7b411f1f"
+dependencies = [
+ "async-io",
+ "autocfg",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "autocfg",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2141,6 +2184,7 @@ dependencies = [
  "ipnet",
  "log",
  "rtnetlink",
+ "smol",
  "system-configuration",
  "tokio",
  "windows",
@@ -2593,6 +2637,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-plaintext"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff582c0b74ffda004b716b97bc9cfe7f39960204877758b876dde86093beaa8"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "log",
+ "quick-protobuf",
+ "unsigned-varint",
+ "void",
+]
+
+[[package]]
 name = "libp2p-quic"
 version = "0.7.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,11 +2771,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-swarm-test"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f6cb31f26505d134ce7106f419de02a8d9640ea56d92f751138933fbec8184d"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-plaintext",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-yamux",
+ "log",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "libp2p-tcp"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d33698596d7722d85d3ab0c86c2c322254fce1241e91208e3679b4eb3026cf"
 dependencies = [
+ "async-io",
  "futures",
  "futures-timer",
  "if-watch",
@@ -3098,6 +3179,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
+ "async-io",
  "bytes",
  "futures",
  "libc",
@@ -3963,6 +4045,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
+ "async-global-executor",
  "futures",
  "log",
  "netlink-packet-route",
@@ -4269,6 +4352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4301,6 +4394,23 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smol"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f2b548cd8447f8de0fdf1c592929f70f4fc7039a05e47404b0d096ec6987a1"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
 
 [[package]]
 name = "snafu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-axum",
  "async-trait",
+ "asynchronous-codec",
  "axum",
  "bamboo-rs-core-ed25519-yasmf",
  "bs58",
@@ -592,6 +593,8 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite",
+ "serde",
+ "serde_cbor",
 ]
 
 [[package]]
@@ -4257,6 +4260,16 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
  "serde",
 ]
 

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -80,6 +80,7 @@ ctor = "0.1.23"
 env_logger = "0.9.0"
 http = "0.2.9"
 hyper = "0.14.19"
+libp2p-swarm-test = "0.1.0"
 once_cell = "1.17.0"
 p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "50f9f0b02570c8ed895baf499cb0d98bbadd1687", features = [
     "test-utils",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -24,6 +24,7 @@ axum = "0.6.10"
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
 bs58 = "0.4.0"
 deadqueue = { version = "0.2.3", default-features = false, features = [
+    "limited",
     "unlimited",
 ] }
 directories = "4.0.1"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0.62"
 async-graphql = { version = "5.0.6", features = ["dynamic-schema"] }
 async-graphql-axum = "5.0.6"
 async-trait = "0.1.64"
+asynchronous-codec = { version = "0.6.1", features = ["cbor"] }
 axum = "0.6.10"
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
 bs58 = "0.4.0"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -25,7 +25,6 @@ axum = "0.6.10"
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
 bs58 = "0.4.0"
 deadqueue = { version = "0.2.3", default-features = false, features = [
-    "limited",
     "unlimited",
 ] }
 directories = "4.0.1"

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -6,6 +6,8 @@ mod identity;
 mod service;
 mod swarm;
 mod transport;
+// @TODO: Remove this as soon as we integrated it into the libp2p swarm
+#[allow(dead_code)]
 mod replication;
 
 pub use config::NetworkConfiguration;

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -6,6 +6,7 @@ mod identity;
 mod service;
 mod swarm;
 mod transport;
+mod replication;
 
 pub use config::NetworkConfiguration;
 pub use service::network_service;

--- a/aquadoggo/src/network/replication.rs
+++ b/aquadoggo/src/network/replication.rs
@@ -184,6 +184,34 @@ impl ConnectionHandler for Handler {
             });
         }
 
+        // Process inbound stream
+        loop {
+            match std::mem::replace(
+                &mut self.inbound_substream,
+                Some(InboundSubstreamState::Poisoned),
+            ) {
+                Some(_) => todo!(),
+                None => {
+                    self.inbound_substream = None;
+                    break;
+                }
+            }
+        }
+
+        // Process outbound stream
+        loop {
+            match std::mem::replace(
+                &mut self.outbound_substream,
+                Some(OutboundSubstreamState::Poisoned),
+            ) {
+                Some(_) => todo!(),
+                None => {
+                    self.outbound_substream = None;
+                    break;
+                }
+            }
+        }
+
         Poll::Pending
     }
 }

--- a/aquadoggo/src/network/replication.rs
+++ b/aquadoggo/src/network/replication.rs
@@ -67,7 +67,7 @@ impl Handler {
     fn on_dial_upgrade_error(
         &mut self,
         DialUpgradeError {
-            info: (), error, ..
+            info: (), error: _error, ..
         }: DialUpgradeError<
             <Self as ConnectionHandler>::OutboundOpenInfo,
             <Self as ConnectionHandler>::OutboundProtocol,
@@ -153,7 +153,7 @@ impl ConnectionHandler for Handler {
         }
     }
 
-    fn on_behaviour_event(&mut self, event: Self::InEvent) {
+    fn on_behaviour_event(&mut self, _event: Self::InEvent) {
         todo!()
     }
 
@@ -254,23 +254,23 @@ impl NetworkBehaviour for Behaviour {
     ) -> Result<THandler<Self>, ConnectionDenied> {
         Ok(Handler::new())
     }
-    fn on_swarm_event(&mut self, event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
+    fn on_swarm_event(&mut self, _event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
         todo!()
     }
 
     fn on_connection_handler_event(
         &mut self,
-        peer: PeerId,
+        _peer: PeerId,
         _: ConnectionId,
-        result: THandlerOutEvent<Self>,
+        _result: THandlerOutEvent<Self>,
     ) {
-        // self.events.push_front(Event { peer, result })
+        todo!()
     }
 
     fn poll(
         &mut self,
-        cx: &mut Context<'_>,
-        params: &mut impl libp2p::swarm::PollParameters,
+        _cx: &mut Context<'_>,
+        _params: &mut impl libp2p::swarm::PollParameters,
     ) -> Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>> {
         todo!()
     }

--- a/aquadoggo/src/network/replication.rs
+++ b/aquadoggo/src/network/replication.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::task::{Context, Poll};
+use thiserror::Error;
+
+use libp2p::core::transport::MemoryTransport;
+use libp2p::core::upgrade::{DeniedUpgrade, ReadyUpgrade};
+use libp2p::core::Endpoint;
+use libp2p::swarm::handler::{ConnectionEvent, FullyNegotiatedInbound, FullyNegotiatedOutbound};
+use libp2p::swarm::{
+    keep_alive, ConnectionDenied, ConnectionHandler, ConnectionHandlerEvent, ConnectionId,
+    KeepAlive, NetworkBehaviour, SubstreamProtocol, Swarm, SwarmEvent, THandler, THandlerOutEvent,
+};
+use libp2p::{identity, Multiaddr, PeerId};
+
+pub const PROTOCOL_NAME: &[u8] = b"/p2p/naive-comprehensive/1.0.0";
+
+pub struct Handler();
+
+impl Handler {
+    pub fn new() -> Self {
+        Self()
+    }
+}
+
+#[derive(Debug)]
+pub struct InEvent();
+
+#[derive(Debug)]
+pub struct OutEvent();
+
+#[derive(Debug, Error)]
+
+pub enum HandlerError {
+    #[error("Error!!")]
+    Custom
+}
+
+impl ConnectionHandler for Handler {
+    type InEvent = InEvent;
+    type OutEvent = OutEvent;
+    type Error = HandlerError;
+    type InboundProtocol = ReadyUpgrade<&'static [u8]>;
+    type OutboundProtocol = ReadyUpgrade<&'static [u8]>;
+    type InboundOpenInfo = ();
+    type OutboundOpenInfo = ();
+
+    fn listen_protocol(&self) -> SubstreamProtocol<ReadyUpgrade<&'static [u8]>, ()> {
+        SubstreamProtocol::new(ReadyUpgrade::new(PROTOCOL_NAME), ())
+    }
+
+    fn on_behaviour_event(&mut self, v: Self::InEvent) {
+        todo!()
+    }
+
+    fn connection_keep_alive(&self) -> KeepAlive {
+        KeepAlive::No
+    }
+
+    fn poll(
+        &mut self,
+        _: &mut Context<'_>,
+    ) -> Poll<
+        ConnectionHandlerEvent<
+            Self::OutboundProtocol,
+            Self::OutboundOpenInfo,
+            Self::OutEvent,
+            Self::Error,
+        >,
+    > {
+        Poll::Pending
+    }
+
+    fn on_connection_event(
+        &mut self,
+        event: ConnectionEvent<
+            Self::InboundProtocol,
+            Self::OutboundProtocol,
+            Self::InboundOpenInfo,
+            Self::OutboundOpenInfo,
+        >,
+    ) {
+        match event {
+            ConnectionEvent::FullyNegotiatedInbound(FullyNegotiatedInbound {
+                protocol: stream,
+                ..
+            }) => {
+                // self.inbound = Some(protocol::recv_ping(stream).boxed());
+            }
+            ConnectionEvent::FullyNegotiatedOutbound(FullyNegotiatedOutbound {
+                protocol: stream,
+                ..
+            }) => {
+                // self.timer.reset(self.config.timeout);
+                // self.outbound = Some(OutboundState::Ping(protocol::send_ping(stream).boxed()));
+            }
+            ConnectionEvent::DialUpgradeError(dial_upgrade_error) => {
+                // self.on_dial_upgrade_error(dial_upgrade_error)
+            }
+            ConnectionEvent::AddressChange(_) | ConnectionEvent::ListenUpgradeError(_) => {}
+        }
+    }
+}
+
+pub struct Behaviour();
+
+#[derive(Debug)]
+pub struct Event();
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = Handler;
+
+    type OutEvent = Event;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _: ConnectionId,
+        _: PeerId,
+        _: &Multiaddr,
+        _: &Multiaddr,
+    ) -> std::result::Result<THandler<Self>, ConnectionDenied> {
+        Ok(Handler::new())
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _: ConnectionId,
+        _: PeerId,
+        _: &Multiaddr,
+        _: Endpoint,
+    ) -> std::result::Result<THandler<Self>, ConnectionDenied> {
+        Ok(Handler::new())
+    }
+    fn on_swarm_event(&mut self, event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
+        todo!()
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer: PeerId,
+        _: ConnectionId,
+        result: THandlerOutEvent<Self>,
+    ) {
+        // self.events.push_front(Event { peer, result })
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        params: &mut impl libp2p::swarm::PollParameters,
+    ) -> std::task::Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>>
+    {
+        todo!()
+    }
+}

--- a/aquadoggo/src/network/replication.rs
+++ b/aquadoggo/src/network/replication.rs
@@ -3,18 +3,16 @@
 use std::task::{Context, Poll};
 use thiserror::Error;
 
-use libp2p::core::transport::MemoryTransport;
-use libp2p::core::upgrade::{DeniedUpgrade, ReadyUpgrade};
+use libp2p::core::upgrade::ReadyUpgrade;
 use libp2p::core::Endpoint;
 use libp2p::swarm::handler::{ConnectionEvent, FullyNegotiatedInbound, FullyNegotiatedOutbound};
 use libp2p::swarm::{
-    keep_alive, ConnectionDenied, ConnectionHandler, ConnectionHandlerEvent, ConnectionId,
-    KeepAlive, NegotiatedSubstream, NetworkBehaviour, SubstreamProtocol, Swarm, SwarmEvent,
-    THandler, THandlerOutEvent,
+    ConnectionDenied, ConnectionHandler, ConnectionHandlerEvent, ConnectionId, KeepAlive,
+    NegotiatedSubstream, NetworkBehaviour, SubstreamProtocol, THandler, THandlerOutEvent,
 };
-use libp2p::{identity, Multiaddr, PeerId};
+use libp2p::{Multiaddr, PeerId};
 
-pub const PROTOCOL_NAME: &[u8] = b"/p2p/naive-comprehensive/1.0.0";
+pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";
 
 pub struct Handler {
     /// The single long-lived outbound substream.
@@ -50,8 +48,10 @@ pub enum HandlerError {
 enum InboundSubstreamState {
     /// Waiting for a message from the remote. The idle state for an inbound substream.
     WaitingInput(NegotiatedSubstream),
+
     /// The substream is being closed.
     Closing(NegotiatedSubstream),
+
     /// An error occurred during processing.
     Poisoned,
 }
@@ -60,10 +60,13 @@ enum InboundSubstreamState {
 enum OutboundSubstreamState {
     /// Waiting for the user to send a message. The idle state for an outbound substream.
     WaitingOutput(NegotiatedSubstream),
+
     /// Waiting to send a message to the remote.
     PendingSend(NegotiatedSubstream),
+
     /// Waiting to flush the substream so that the data arrives to the remote.
     PendingFlush(NegotiatedSubstream),
+
     /// An error occurred during processing.
     Poisoned,
 }
@@ -150,7 +153,7 @@ impl NetworkBehaviour for Behaviour {
         _: PeerId,
         _: &Multiaddr,
         _: &Multiaddr,
-    ) -> std::result::Result<THandler<Self>, ConnectionDenied> {
+    ) -> Result<THandler<Self>, ConnectionDenied> {
         Ok(Handler::new())
     }
 
@@ -160,7 +163,7 @@ impl NetworkBehaviour for Behaviour {
         _: PeerId,
         _: &Multiaddr,
         _: Endpoint,
-    ) -> std::result::Result<THandler<Self>, ConnectionDenied> {
+    ) -> Result<THandler<Self>, ConnectionDenied> {
         Ok(Handler::new())
     }
     fn on_swarm_event(&mut self, event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
@@ -178,10 +181,9 @@ impl NetworkBehaviour for Behaviour {
 
     fn poll(
         &mut self,
-        cx: &mut std::task::Context<'_>,
+        cx: &mut Context<'_>,
         params: &mut impl libp2p::swarm::PollParameters,
-    ) -> std::task::Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>>
-    {
+    ) -> Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>> {
         todo!()
     }
 }

--- a/aquadoggo/src/network/replication/behaviour.rs
+++ b/aquadoggo/src/network/replication/behaviour.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::task::{Context, Poll};
+
+use libp2p::core::Endpoint;
+
+use libp2p::swarm::{ConnectionDenied, ConnectionId, NetworkBehaviour, THandler, THandlerOutEvent};
+use libp2p::{Multiaddr, PeerId};
+
+use crate::network::replication::Handler;
+
+#[derive(Debug)]
+pub struct Behaviour;
+
+#[derive(Debug)]
+pub struct Event;
+
+impl NetworkBehaviour for Behaviour {
+    type ConnectionHandler = Handler;
+
+    type OutEvent = Event;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _: ConnectionId,
+        _: PeerId,
+        _: &Multiaddr,
+        _: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(Handler::new())
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _: ConnectionId,
+        _: PeerId,
+        _: &Multiaddr,
+        _: Endpoint,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        Ok(Handler::new())
+    }
+    fn on_swarm_event(&mut self, _event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
+        todo!()
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        _peer: PeerId,
+        _: ConnectionId,
+        _result: THandlerOutEvent<Self>,
+    ) {
+        todo!()
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+        _params: &mut impl libp2p::swarm::PollParameters,
+    ) -> Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>> {
+        todo!()
+    }
+}

--- a/aquadoggo/src/network/replication/behaviour.rs
+++ b/aquadoggo/src/network/replication/behaviour.rs
@@ -14,7 +14,10 @@ use crate::network::replication::handler::{Handler, HandlerInEvent, HandlerOutEv
 use crate::network::replication::protocol::Message;
 
 #[derive(Debug)]
-pub enum BehaviourOutEvent {}
+pub enum BehaviourOutEvent {
+    MessageReceived(PeerId, Message),
+    Error,
+}
 
 #[derive(Debug)]
 pub struct Behaviour {
@@ -38,8 +41,13 @@ impl Behaviour {
         });
     }
 
-    fn handle_received_message(&self, _peer_id: &PeerId, _message: Message) {
+    fn handle_received_message(&mut self, peer_id: &PeerId, message: Message) {
         // @TODO: Handle incoming messages
+        self.events
+            .push_back(ToSwarm::GenerateEvent(BehaviourOutEvent::MessageReceived(
+                peer_id.clone(),
+                message,
+            )));
     }
 }
 

--- a/aquadoggo/src/network/replication/behaviour.rs
+++ b/aquadoggo/src/network/replication/behaviour.rs
@@ -45,8 +45,7 @@ impl Behaviour {
         // @TODO: Handle incoming messages
         self.events
             .push_back(ToSwarm::GenerateEvent(BehaviourOutEvent::MessageReceived(
-                *peer_id,
-                message,
+                *peer_id, message,
             )));
     }
 }

--- a/aquadoggo/src/network/replication/behaviour.rs
+++ b/aquadoggo/src/network/replication/behaviour.rs
@@ -3,7 +3,6 @@
 use std::task::{Context, Poll};
 
 use libp2p::core::Endpoint;
-
 use libp2p::swarm::{ConnectionDenied, ConnectionId, NetworkBehaviour, THandler, THandlerOutEvent};
 use libp2p::{Multiaddr, PeerId};
 

--- a/aquadoggo/src/network/replication/behaviour.rs
+++ b/aquadoggo/src/network/replication/behaviour.rs
@@ -45,7 +45,7 @@ impl Behaviour {
         // @TODO: Handle incoming messages
         self.events
             .push_back(ToSwarm::GenerateEvent(BehaviourOutEvent::MessageReceived(
-                peer_id.clone(),
+                *peer_id,
                 message,
             )));
     }

--- a/aquadoggo/src/network/replication/handler.rs
+++ b/aquadoggo/src/network/replication/handler.rs
@@ -5,19 +5,14 @@ use thiserror::Error;
 
 use deadqueue::limited::Queue;
 use libp2p::core::upgrade::ReadyUpgrade;
-use libp2p::core::Endpoint;
 use libp2p::swarm::handler::{
     ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
 };
 use libp2p::swarm::{
-    ConnectionDenied, ConnectionHandler, ConnectionHandlerEvent, ConnectionId, KeepAlive,
-    NegotiatedSubstream, NetworkBehaviour, SubstreamProtocol, THandler, THandlerOutEvent,
+    ConnectionHandler, ConnectionHandlerEvent, KeepAlive, NegotiatedSubstream, SubstreamProtocol,
 };
-use libp2p::{Multiaddr, PeerId};
 
-pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";
-
-enum Message {}
+use crate::network::replication::{Message, PROTOCOL_NAME};
 
 pub struct Handler {
     /// The single long-lived outbound substream.
@@ -67,13 +62,15 @@ impl Handler {
     fn on_dial_upgrade_error(
         &mut self,
         DialUpgradeError {
-            info: (), error: _error, ..
+            info: (),
+            error: _error,
+            ..
         }: DialUpgradeError<
             <Self as ConnectionHandler>::OutboundOpenInfo,
             <Self as ConnectionHandler>::OutboundProtocol,
         >,
     ) {
-        todo!();
+        todo!()
     }
 }
 
@@ -222,56 +219,5 @@ impl ConnectionHandler for Handler {
         }
 
         Poll::Pending
-    }
-}
-
-pub struct Behaviour();
-
-#[derive(Debug)]
-pub struct Event();
-
-impl NetworkBehaviour for Behaviour {
-    type ConnectionHandler = Handler;
-
-    type OutEvent = Event;
-
-    fn handle_established_inbound_connection(
-        &mut self,
-        _: ConnectionId,
-        _: PeerId,
-        _: &Multiaddr,
-        _: &Multiaddr,
-    ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(Handler::new())
-    }
-
-    fn handle_established_outbound_connection(
-        &mut self,
-        _: ConnectionId,
-        _: PeerId,
-        _: &Multiaddr,
-        _: Endpoint,
-    ) -> Result<THandler<Self>, ConnectionDenied> {
-        Ok(Handler::new())
-    }
-    fn on_swarm_event(&mut self, _event: libp2p::swarm::FromSwarm<Self::ConnectionHandler>) {
-        todo!()
-    }
-
-    fn on_connection_handler_event(
-        &mut self,
-        _peer: PeerId,
-        _: ConnectionId,
-        _result: THandlerOutEvent<Self>,
-    ) {
-        todo!()
-    }
-
-    fn poll(
-        &mut self,
-        _cx: &mut Context<'_>,
-        _params: &mut impl libp2p::swarm::PollParameters,
-    ) -> Poll<libp2p::swarm::ToSwarm<Self::OutEvent, libp2p::swarm::THandlerInEvent<Self>>> {
-        todo!()
     }
 }

--- a/aquadoggo/src/network/replication/handler.rs
+++ b/aquadoggo/src/network/replication/handler.rs
@@ -82,7 +82,7 @@ impl Handler {
 
 /// An event sent from the network behaviour to the connection handler.
 #[derive(Debug)]
-pub enum InEvent {
+pub enum HandlerInEvent {
     /// Replication message to send on outbound stream.
     Message(Message),
 }
@@ -91,7 +91,7 @@ pub enum InEvent {
 ///
 /// This informs the network behaviour of various events created by the handler.
 #[derive(Debug)]
-pub enum OutEvent {
+pub enum HandlerOutEvent {
     /// Replication message received on the inbound stream.
     Message(Message),
 }
@@ -133,8 +133,8 @@ enum OutboundSubstreamState {
 }
 
 impl ConnectionHandler for Handler {
-    type InEvent = InEvent;
-    type OutEvent = OutEvent;
+    type InEvent = HandlerInEvent;
+    type OutEvent = HandlerOutEvent;
     type Error = HandlerError;
     type InboundProtocol = Protocol;
     type OutboundProtocol = Protocol;
@@ -211,7 +211,7 @@ impl ConnectionHandler for Handler {
                             // Received message from remote peer
                             self.inbound_substream =
                                 Some(InboundSubstreamState::WaitingInput(substream));
-                            return Poll::Ready(ConnectionHandlerEvent::Custom(OutEvent::Message(
+                            return Poll::Ready(ConnectionHandlerEvent::Custom(HandlerOutEvent::Message(
                                 message,
                             )));
                         }

--- a/aquadoggo/src/network/replication/handler.rs
+++ b/aquadoggo/src/network/replication/handler.rs
@@ -6,9 +6,7 @@ use std::task::{Context, Poll};
 
 use asynchronous_codec::Framed;
 use futures::{Sink, StreamExt};
-use libp2p::swarm::handler::{
-    ConnectionEvent, DialUpgradeError, FullyNegotiatedInbound, FullyNegotiatedOutbound,
-};
+use libp2p::swarm::handler::{ConnectionEvent, FullyNegotiatedInbound, FullyNegotiatedOutbound};
 use libp2p::swarm::{
     ConnectionHandler, ConnectionHandlerEvent, KeepAlive, NegotiatedSubstream, SubstreamProtocol,
 };
@@ -67,20 +65,6 @@ impl Handler {
         >,
     ) {
         self.inbound_substream = Some(InboundSubstreamState::WaitingInput(protocol));
-    }
-
-    fn on_dial_upgrade_error(
-        &mut self,
-        DialUpgradeError {
-            info: (),
-            error: _error,
-            ..
-        }: DialUpgradeError<
-            <Self as ConnectionHandler>::OutboundOpenInfo,
-            <Self as ConnectionHandler>::OutboundProtocol,
-        >,
-    ) {
-        todo!()
     }
 }
 
@@ -164,10 +148,9 @@ impl ConnectionHandler for Handler {
             ConnectionEvent::FullyNegotiatedInbound(fully_negotiated_inbound) => {
                 self.on_fully_negotiated_inbound(fully_negotiated_inbound);
             }
-            ConnectionEvent::DialUpgradeError(dial_upgrade_error) => {
-                self.on_dial_upgrade_error(dial_upgrade_error)
-            }
-            ConnectionEvent::AddressChange(_) | ConnectionEvent::ListenUpgradeError(_) => {}
+            ConnectionEvent::DialUpgradeError(_)
+            | ConnectionEvent::AddressChange(_)
+            | ConnectionEvent::ListenUpgradeError(_) => {}
         }
     }
 

--- a/aquadoggo/src/network/replication/handler.rs
+++ b/aquadoggo/src/network/replication/handler.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::task::{Context, Poll};
-use thiserror::Error;
 
 use deadqueue::limited::Queue;
 use libp2p::core::upgrade::ReadyUpgrade;
@@ -11,6 +10,7 @@ use libp2p::swarm::handler::{
 use libp2p::swarm::{
     ConnectionHandler, ConnectionHandlerEvent, KeepAlive, NegotiatedSubstream, SubstreamProtocol,
 };
+use thiserror::Error;
 
 use crate::network::replication::{Message, PROTOCOL_NAME};
 
@@ -74,14 +74,24 @@ impl Handler {
     }
 }
 
+/// An event sent from the network behaviour to the connection handler.
 #[derive(Debug)]
-pub struct InEvent();
+pub enum InEvent {
+    /// Replication message to send on outbound stream.
+    Message(Message),
+}
 
+/// The event emitted by the connection handler.
+///
+/// This informs the network behaviour of various events created by the handler.
 #[derive(Debug)]
-pub struct OutEvent();
+pub enum OutEvent {
+    /// Replication message received on the inbound stream.
+    Message(Message),
+}
 
+// @TODO: Do we need our own error type? Use `Void` instead?
 #[derive(Debug, Error)]
-
 pub enum HandlerError {
     #[error("Error!!")]
     Custom,

--- a/aquadoggo/src/network/replication/handler.rs
+++ b/aquadoggo/src/network/replication/handler.rs
@@ -2,6 +2,7 @@
 
 use std::task::{Context, Poll};
 
+use asynchronous_codec::Framed;
 use deadqueue::limited::Queue;
 use libp2p::core::upgrade::ReadyUpgrade;
 use libp2p::swarm::handler::{
@@ -12,7 +13,7 @@ use libp2p::swarm::{
 };
 use thiserror::Error;
 
-use crate::network::replication::{Message, PROTOCOL_NAME};
+use crate::network::replication::{Codec, Message, PROTOCOL_NAME};
 
 pub struct Handler {
     /// The single long-lived outbound substream.
@@ -96,6 +97,8 @@ pub enum HandlerError {
     #[error("Error!!")]
     Custom,
 }
+
+type Stream = Framed<NegotiatedSubstream, Codec>;
 
 /// State of the inbound substream, opened either by us or by the remote.
 enum InboundSubstreamState {

--- a/aquadoggo/src/network/replication/mod.rs
+++ b/aquadoggo/src/network/replication/mod.rs
@@ -4,4 +4,4 @@ mod protocol;
 
 pub use behaviour::Behaviour;
 pub use handler::Handler;
-pub use protocol::{Message, PROTOCOL_NAME};
+pub use protocol::{Codec, Message, PROTOCOL_NAME};

--- a/aquadoggo/src/network/replication/mod.rs
+++ b/aquadoggo/src/network/replication/mod.rs
@@ -4,4 +4,4 @@ mod protocol;
 
 pub use behaviour::Behaviour;
 pub use handler::Handler;
-pub use protocol::{Codec, Message, PROTOCOL_NAME};
+pub use protocol::{Codec, Message, Protocol, PROTOCOL_NAME};

--- a/aquadoggo/src/network/replication/mod.rs
+++ b/aquadoggo/src/network/replication/mod.rs
@@ -1,0 +1,7 @@
+mod behaviour;
+mod handler;
+mod protocol;
+
+pub use behaviour::Behaviour;
+pub use handler::Handler;
+pub use protocol::{Message, PROTOCOL_NAME};

--- a/aquadoggo/src/network/replication/mod.rs
+++ b/aquadoggo/src/network/replication/mod.rs
@@ -4,4 +4,4 @@ mod protocol;
 
 pub use behaviour::Behaviour;
 pub use handler::Handler;
-pub use protocol::{Codec, Message, Protocol, PROTOCOL_NAME};
+pub use protocol::{Codec, CodecError, Message, Protocol, PROTOCOL_NAME};

--- a/aquadoggo/src/network/replication/mod.rs
+++ b/aquadoggo/src/network/replication/mod.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 mod behaviour;
 mod handler;
 mod protocol;

--- a/aquadoggo/src/network/replication/protocol.rs
+++ b/aquadoggo/src/network/replication/protocol.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";
+
+pub enum Message {}

--- a/aquadoggo/src/network/replication/protocol.rs
+++ b/aquadoggo/src/network/replication/protocol.rs
@@ -4,7 +4,8 @@ use std::pin::Pin;
 
 use asynchronous_codec::{CborCodec, CborCodecError, Framed};
 use futures::{future, AsyncRead, AsyncWrite, Future};
-use libp2p::{core::UpgradeInfo, InboundUpgrade, OutboundUpgrade};
+use libp2p::core::UpgradeInfo;
+use libp2p::{InboundUpgrade, OutboundUpgrade};
 use serde::{Deserialize, Serialize};
 
 pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";

--- a/aquadoggo/src/network/replication/protocol.rs
+++ b/aquadoggo/src/network/replication/protocol.rs
@@ -2,4 +2,5 @@
 
 pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";
 
+#[derive(Debug)]
 pub enum Message {}

--- a/aquadoggo/src/network/replication/protocol.rs
+++ b/aquadoggo/src/network/replication/protocol.rs
@@ -2,12 +2,14 @@
 
 use std::pin::Pin;
 
-use asynchronous_codec::{CborCodec, Framed};
+use asynchronous_codec::{CborCodec, CborCodecError, Framed};
 use futures::{future, AsyncRead, AsyncWrite, Future};
 use libp2p::{core::UpgradeInfo, InboundUpgrade, OutboundUpgrade};
 use serde::{Deserialize, Serialize};
 
 pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";
+
+pub type CodecError = CborCodecError;
 
 pub type Codec = CborCodec<Message, Message>;
 
@@ -40,7 +42,7 @@ where
     TSocket: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     type Output = Framed<TSocket, Codec>;
-    type Error = anyhow::Error;
+    type Error = CodecError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
     fn upgrade_inbound(self, socket: TSocket, _protocol_id: Self::Info) -> Self::Future {
@@ -53,7 +55,7 @@ where
     TSocket: AsyncWrite + AsyncRead + Unpin + Send + 'static,
 {
     type Output = Framed<TSocket, Codec>;
-    type Error = anyhow::Error;
+    type Error = CodecError;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
     fn upgrade_outbound(self, socket: TSocket, _protocol_id: Self::Info) -> Self::Future {

--- a/aquadoggo/src/network/replication/protocol.rs
+++ b/aquadoggo/src/network/replication/protocol.rs
@@ -1,13 +1,62 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use asynchronous_codec::CborCodec;
+use std::pin::Pin;
+
+use asynchronous_codec::{CborCodec, Framed};
+use futures::{future, AsyncRead, AsyncWrite, Future};
+use libp2p::{core::UpgradeInfo, InboundUpgrade, OutboundUpgrade};
 use serde::{Deserialize, Serialize};
 
 pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";
 
 pub type Codec = CborCodec<Message, Message>;
 
+// @TODO: Get this from our other replication module
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Message {
     Dummy(u64),
+}
+
+#[derive(Clone, Debug)]
+pub struct Protocol;
+
+impl Protocol {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl UpgradeInfo for Protocol {
+    type Info = Vec<u8>;
+    type InfoIter = Vec<Self::Info>;
+
+    fn protocol_info(&self) -> Self::InfoIter {
+        vec![PROTOCOL_NAME.to_vec()]
+    }
+}
+
+impl<TSocket> InboundUpgrade<TSocket> for Protocol
+where
+    TSocket: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    type Output = Framed<TSocket, Codec>;
+    type Error = anyhow::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+
+    fn upgrade_inbound(self, socket: TSocket, _protocol_id: Self::Info) -> Self::Future {
+        Box::pin(future::ok(Framed::new(socket, Codec::new())))
+    }
+}
+
+impl<TSocket> OutboundUpgrade<TSocket> for Protocol
+where
+    TSocket: AsyncWrite + AsyncRead + Unpin + Send + 'static,
+{
+    type Output = Framed<TSocket, Codec>;
+    type Error = anyhow::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
+
+    fn upgrade_outbound(self, socket: TSocket, _protocol_id: Self::Info) -> Self::Future {
+        Box::pin(future::ok(Framed::new(socket, Codec::new())))
+    }
 }

--- a/aquadoggo/src/network/replication/protocol.rs
+++ b/aquadoggo/src/network/replication/protocol.rs
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use asynchronous_codec::CborCodec;
+use serde::{Deserialize, Serialize};
+
 pub const PROTOCOL_NAME: &[u8] = b"/p2p/p2panda/1.0.0";
 
-#[derive(Debug)]
-pub enum Message {}
+pub type Codec = CborCodec<Message, Message>;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum Message {
+    Dummy(u64),
+}


### PR DESCRIPTION
Implement a `NetworkBehaviour` and `ConnectionHandler` for the libp2p swarm stack. It handles connection upgrades to our replication protocol, establishes in- and outbound streams, decodes CBOR bytes into our own message format in these streams and has some mechanisms of sending (with queues) and receiving messages.

All of this can be glued together with the work from https://github.com/p2panda/aquadoggo/pull/363 which is the actual replication protocol manager. This PR handles the networking layer of it.

Closes #371 

## Next Steps

- #373 
- #370 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
