### PR TITLE
Decouple p2panda's authentication data types from libp2p's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move GraphQL `types` into separate modules [#343](https://github.com/p2panda/aquadoggo/pull/343)
 - Set default order for root queries to document id [#352](https://github.com/p2panda/aquadoggo/pull/352)
 - Remove property tests again because of concurrency bug [#347](https://github.com/p2panda/aquadoggo/pull/347)
+- Decouple p2panda's authentication data types from libp2p's [#408](https://github.com/p2panda/aquadoggo/pull/408)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -219,6 +218,7 @@ dependencies = [
  "hex",
  "libp2p",
  "p2panda-rs",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,9 @@ dependencies = [
  "aquadoggo",
  "clap",
  "env_logger",
+ "hex",
  "libp2p",
+ "p2panda-rs",
  "tokio",
 ]
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Embed the node server in your Rust application or web container like [`Tauri`]:
 
 ```rust
 use aquadoggo::{Configuration, Node};
+use p2panda_rs::identity::KeyPair;
 
 let config = Configuration::default();
-let node = Node::start(config).await;
+let key_pair = KeyPair::new();
+let node = Node::start(key_pair, config).await;
 ```
 
 You can also run the node server simply as a [command line application][`command line application`]:

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.4.0"
 authors = [
     "adz <x1d@adz.garden>",
     "cafca <cafca@001.land>",
-    "glyph <glyph@mycelial.technology>",
     "pietgeursen <pietgeursen@gmail.com>",
     "sandreae <contact@samandreae.com>",
     "sophiiistika <sophiiistika@mailbox.org>",
+    "glyph <glyph@mycelial.technology>",
 ]
 description = "Embeddable p2p network node"
 license = "AGPL-3.0-or-later"
@@ -96,6 +96,5 @@ reqwest = { version = "0.11.11", default-features = false, features = [
 rstest = "0.15.0"
 rstest_reuse = "0.3.0"
 serde_json = "1.0.85"
-tempfile = "3.4.0"
 tower = "0.4.13"
 tower-service = "0.3.2"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.4.0"
 authors = [
     "adz <x1d@adz.garden>",
     "cafca <cafca@001.land>",
+    "glyph <glyph@mycelial.technology>",
     "pietgeursen <pietgeursen@gmail.com>",
     "sandreae <contact@samandreae.com>",
     "sophiiistika <sophiiistika@mailbox.org>",
-    "glyph <glyph@mycelial.technology>",
 ]
 description = "Embeddable p2p network node"
 license = "AGPL-3.0-or-later"

--- a/aquadoggo/README.md
+++ b/aquadoggo/README.md
@@ -69,9 +69,11 @@ Embed the node server in your Rust application or web container like [`Tauri`]:
 
 ```rust
 use aquadoggo::{Configuration, Node};
+use p2panda_rs::identity::KeyPair;
 
 let config = Configuration::default();
-let node = Node::start(config).await;
+let key_pair = KeyPair::new();
+let node = Node::start(key_pair, config).await;
 ```
 
 [`Tauri`]: https://tauri.studio

--- a/aquadoggo/src/config.rs
+++ b/aquadoggo/src/config.rs
@@ -98,11 +98,6 @@ impl Configuration {
             }
         };
 
-        // Derive peer id from key pair
-        // @TODO: This needs refactoring: https://github.com/p2panda/aquadoggo/issues/388
-        let key_pair = NetworkConfiguration::load_or_generate_key_pair(config.base_path.clone())?;
-        config.network.set_peer_id(&key_pair.public());
-
         Ok(config)
     }
 }
@@ -115,11 +110,6 @@ impl Configuration {
             database_url: Some("sqlite::memory:".to_string()),
             ..Default::default()
         };
-
-        // Generate a random key pair and just keep it in memory
-        // @TODO: This needs refactoring: https://github.com/p2panda/aquadoggo/issues/388
-        let key_pair: libp2p::identity::Keypair = crate::network::identity::Identity::new();
-        config.network.set_peer_id(&key_pair.public());
 
         config
     }

--- a/aquadoggo/src/config.rs
+++ b/aquadoggo/src/config.rs
@@ -106,11 +106,9 @@ impl Configuration {
 impl Configuration {
     /// Returns a new configuration object for a node which stores all data temporarily in memory.
     pub fn new_ephemeral() -> Self {
-        let mut config = Configuration {
+        Configuration {
             database_url: Some("sqlite::memory:".to_string()),
             ..Default::default()
-        };
-
-        config
+        }
     }
 }

--- a/aquadoggo/src/context.rs
+++ b/aquadoggo/src/context.rs
@@ -3,6 +3,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use p2panda_rs::identity::KeyPair;
 use p2panda_rs::storage_provider::traits::{DocumentStore, EntryStore, LogStore, OperationStore};
 
 use crate::config::Configuration;
@@ -15,6 +16,9 @@ pub struct Data<S>
 where
     S: EntryStore + OperationStore + LogStore + DocumentStore,
 {
+    /// Node authentication and identity provider.
+    pub key_pair: KeyPair,
+
     /// Node configuration.
     pub config: Configuration,
 
@@ -29,8 +33,14 @@ impl<S> Data<S>
 where
     S: EntryStore + OperationStore + LogStore + DocumentStore,
 {
-    pub fn new(store: S, config: Configuration, schema_provider: SchemaProvider) -> Self {
+    pub fn new(
+        store: S,
+        key_pair: KeyPair,
+        config: Configuration,
+        schema_provider: SchemaProvider,
+    ) -> Self {
         Self {
+            key_pair,
             config,
             store,
             schema_provider,
@@ -49,8 +59,18 @@ where
     S: EntryStore + OperationStore + LogStore + DocumentStore,
 {
     /// Returns a new instance of `Context`.
-    pub fn new(store: S, config: Configuration, schema_provider: SchemaProvider) -> Self {
-        Self(Arc::new(Data::new(store, config, schema_provider)))
+    pub fn new(
+        store: S,
+        key_pair: KeyPair,
+        config: Configuration,
+        schema_provider: SchemaProvider,
+    ) -> Self {
+        Self(Arc::new(Data::new(
+            store,
+            key_pair,
+            config,
+            schema_provider,
+        )))
     }
 }
 

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -24,9 +24,11 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! use aquadoggo::{Configuration, Node};
+//! use p2panda_rs::identity::KeyPair;
 //!
 //! let config = Configuration::default();
-//! let node = Node::start(config).await;
+//! let key_pair = KeyPair::new();
+//! let node = Node::start(key_pair, config).await;
 //! # }
 //! ```
 //!

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -192,6 +192,7 @@ mod tests {
             // Prepare arguments for service
             let context = Context::new(
                 node.context.store.clone(),
+                KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
             );
@@ -267,6 +268,7 @@ mod tests {
             // Prepare arguments for service
             let context = Context::new(
                 node.context.store.clone(),
+                KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
             );
@@ -332,6 +334,7 @@ mod tests {
             // Prepare arguments for service
             let context = Context::new(
                 node.context.store.clone(),
+                KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
             );
@@ -426,12 +429,14 @@ mod tests {
         key_pair: KeyPair,
     ) {
         test_runner(move |node: TestNode| async move {
-            // Populate the store with some entries and operations but DON'T materialise any resulting documents.
+            // Populate the store with some entries and operations but DON'T materialise any
+            // resulting documents.
             populate_store(&node.context.store, &config).await;
 
             // Prepare arguments for service
             let context = Context::new(
                 node.context.store.clone(),
+                KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
             );

--- a/aquadoggo/src/network/behaviour.rs
+++ b/aquadoggo/src/network/behaviour.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use libp2p::identity::Keypair;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::swarm::NetworkBehaviour;
-use libp2p::{autonat, connection_limits, identify, mdns, ping, relay, rendezvous, PeerId};
+use libp2p::{autonat, connection_limits, identify, mdns, ping, relay, rendezvous};
 use log::debug;
 
 use crate::network::config::NODE_NAMESPACE;
@@ -79,11 +79,10 @@ impl Behaviour {
     /// the network configuration context.
     pub fn new(
         network_config: &NetworkConfiguration,
-        peer_id: PeerId,
         key_pair: Keypair,
         relay_client: Option<relay::client::Behaviour>,
     ) -> Result<Self> {
-        let public_key = key_pair.public();
+        let peer_id = key_pair.public().to_peer_id();
 
         // Create an autonat behaviour with default configuration if the autonat flag is set
         let autonat = if network_config.autonat {
@@ -101,7 +100,7 @@ impl Behaviour {
             debug!("Identify network behaviour enabled");
             Some(identify::Behaviour::new(identify::Config::new(
                 format!("{NODE_NAMESPACE}/1.0.0"),
-                public_key,
+                key_pair.public(),
             )))
         } else {
             None

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -1,18 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::path::PathBuf;
-
-use anyhow::Result;
 use libp2p::connection_limits::ConnectionLimits;
-use libp2p::identity::{Keypair, PublicKey};
 use libp2p::{Multiaddr, PeerId};
-use log::info;
 use serde::{Deserialize, Serialize};
-
-use crate::network::identity::Identity;
-
-/// Key pair file name.
-const KEY_PAIR_FILE_NAME: &str = "private-key";
 
 /// The namespace used by the `identify` network behaviour.
 pub const NODE_NAMESPACE: &str = "aquadoggo";
@@ -103,9 +93,6 @@ pub struct NetworkConfiguration {
     ///
     /// Serve as a rendezvous point for peer discovery, allowing peer registration and queries.
     pub rendezvous_server_enabled: bool,
-
-    /// Our local peer id.
-    pub peer_id: Option<PeerId>,
 }
 
 impl Default for NetworkConfiguration {
@@ -130,17 +117,11 @@ impl Default for NetworkConfiguration {
             rendezvous_address: None,
             rendezvous_peer_id: None,
             rendezvous_server_enabled: false,
-            peer_id: None,
         }
     }
 }
 
 impl NetworkConfiguration {
-    /// Derive peer id from a given public key.
-    pub fn set_peer_id(&mut self, public_key: &PublicKey) {
-        self.peer_id = Some(PeerId::from_public_key(public_key));
-    }
-
     /// Define the connection limits of the swarm.
     pub fn connection_limits(&self) -> ConnectionLimits {
         ConnectionLimits::default()
@@ -149,69 +130,5 @@ impl NetworkConfiguration {
             .with_max_established_outgoing(Some(self.max_connections_out))
             .with_max_established_incoming(Some(self.max_connections_in))
             .with_max_established_per_peer(Some(self.max_connections_per_peer))
-    }
-
-    /// Load the key pair from the file at the specified path.
-    ///
-    /// If the file does not exist, a random key pair is generated and saved. If no path is
-    /// specified, a random key pair is generated.
-    pub fn load_or_generate_key_pair(path: Option<PathBuf>) -> Result<Keypair> {
-        let key_pair = match path {
-            Some(mut path) => {
-                // Extend the base data directory path with the key pair filename
-                path.push(KEY_PAIR_FILE_NAME);
-
-                // Check if the key pair file exists.
-                // If not, generate a new key pair and write it to file
-                if !path.is_file() {
-                    let identity: Keypair = Identity::new();
-                    identity.save(&path)?;
-                    info!("Created new network key pair and saved it to {:?}", path);
-                    identity.key_pair()
-                } else {
-                    // If the key pair file exists, open it and load the key pair
-                    let stored_identity: Keypair = Identity::load(&path)?;
-                    stored_identity.key_pair()
-                }
-            }
-            None => {
-                // No path was provided. Generate and return a random key pair
-                Identity::new()
-            }
-        };
-
-        Ok(key_pair)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use tempfile::TempDir;
-
-    use super::NetworkConfiguration;
-
-    #[test]
-    fn generates_new_key_pair() {
-        let key_pair = NetworkConfiguration::load_or_generate_key_pair(None);
-        assert!(key_pair.is_ok());
-    }
-
-    #[test]
-    fn saves_and_loads_key_pair() {
-        let tmp_dir = TempDir::new().unwrap();
-        let tmp_path = tmp_dir.path().to_owned();
-
-        // Attempt to load the key pair from the temporary path
-        // This should result in a new key pair being generated and written to file
-        let key_pair_1 = NetworkConfiguration::load_or_generate_key_pair(Some(tmp_path.clone()));
-        assert!(key_pair_1.is_ok());
-
-        // Attempt to load the key pair from the same temporary path
-        // This should result in the previously-generated key pair being loaded from file
-        let key_pair_2 = NetworkConfiguration::load_or_generate_key_pair(Some(tmp_path));
-        assert!(key_pair_2.is_ok());
-
-        // Ensure that both key pairs have the same public key
-        assert_eq!(key_pair_1.unwrap().public(), key_pair_2.unwrap().public());
     }
 }

--- a/aquadoggo/src/network/identity.rs
+++ b/aquadoggo/src/network/identity.rs
@@ -14,11 +14,6 @@ pub fn to_libp2p_peer_id(public_key: &PublicKey) -> libp2p::PeerId {
     libp2p_public.to_peer_id()
 }
 
-/// Helper method to convert from libp2p `PeerId` to p2panda `PublicKey`.
-pub fn to_public_key(peer_id: &libp2p::PeerId) -> PublicKey {
-    PublicKey::new(&peer_id.to_string()).unwrap()
-}
-
 /// Helper method to convert p2panda `KeyPair` to the libp2p equivalent.
 pub fn to_libp2p_key_pair(key_pair: &KeyPair) -> libp2p::identity::Keypair {
     let bytes = key_pair.private_key().as_bytes();
@@ -30,15 +25,20 @@ pub fn to_libp2p_key_pair(key_pair: &KeyPair) -> libp2p::identity::Keypair {
 mod tests {
     use p2panda_rs::identity::KeyPair;
 
-    use super::{to_libp2p_key_pair, to_libp2p_peer_id, to_public_key};
+    use super::{to_libp2p_key_pair, to_libp2p_peer_id};
 
     #[test]
     fn peer_id_public_key_conversion() {
-        let key_pair = KeyPair::new();
+        let key_pair = KeyPair::from_private_key_str(
+            "799faf7a1fa47c54fac705f30d3c4d80c40efb562da19315fabefcc995a228a1",
+        )
+        .unwrap();
         let public_key = key_pair.public_key();
         let peer_id = to_libp2p_peer_id(&public_key);
-        let public_key_converted = to_public_key(&peer_id);
-        assert_eq!(public_key, public_key_converted);
+        assert_eq!(
+            peer_id.to_string(),
+            "12D3KooWCw68m5CRcV8vD9iuR325oKwJHLYqTYH5mYwD6k2QV4nm".to_string(),
+        )
     }
 
     #[test]

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -2,7 +2,7 @@
 
 mod behaviour;
 mod config;
-mod identity;
+pub mod identity;
 mod peers;
 mod service;
 mod shutdown;

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -2,7 +2,7 @@
 
 mod behaviour;
 mod config;
-pub mod identity;
+mod identity;
 mod peers;
 mod service;
 mod shutdown;

--- a/aquadoggo/src/network/peers/behaviour.rs
+++ b/aquadoggo/src/network/peers/behaviour.rs
@@ -13,6 +13,7 @@ use libp2p::{Multiaddr, PeerId};
 use log::trace;
 use p2panda_rs::Human;
 
+use crate::network::identity::{to_libp2p_peer_id, to_public_key};
 use crate::network::peers::handler::{Handler, HandlerInEvent, HandlerOutEvent};
 use crate::network::peers::Peer;
 use crate::replication::SyncMessage;
@@ -92,13 +93,13 @@ impl Behaviour {
     }
 
     fn on_connection_established(&mut self, peer_id: PeerId, connection_id: ConnectionId) {
-        let peer = Peer::new(peer_id, connection_id);
+        let peer = Peer::new(to_public_key(&peer_id), connection_id);
         self.events
             .push_back(ToSwarm::GenerateEvent(Event::PeerConnected(peer)));
     }
 
     fn on_connection_closed(&mut self, peer_id: PeerId, connection_id: ConnectionId) {
-        let peer = Peer::new(peer_id, connection_id);
+        let peer = Peer::new(to_public_key(&peer_id), connection_id);
         self.events
             .push_back(ToSwarm::GenerateEvent(Event::PeerDisconnected(peer)));
     }
@@ -109,7 +110,7 @@ impl Behaviour {
         connection_id: ConnectionId,
         message: SyncMessage,
     ) {
-        let peer = Peer::new(peer_id, connection_id);
+        let peer = Peer::new(to_public_key(&peer_id), connection_id);
         trace!(
             "Notify swarm of received sync message: {} {}",
             peer.display(),
@@ -128,7 +129,7 @@ impl Behaviour {
             message.display(),
         );
         self.events.push_back(ToSwarm::NotifyHandler {
-            peer_id: peer.id(),
+            peer_id: to_libp2p_peer_id(&peer.id()),
             event: HandlerInEvent::Message(message),
             handler: NotifyHandler::One(peer.connection_id()),
         });
@@ -136,7 +137,7 @@ impl Behaviour {
 
     pub fn handle_critical_error(&mut self, peer: Peer) {
         self.events.push_back(ToSwarm::NotifyHandler {
-            peer_id: peer.id(),
+            peer_id: to_libp2p_peer_id(&peer.id()),
             event: HandlerInEvent::CriticalError,
             handler: NotifyHandler::One(peer.connection_id()),
         });
@@ -231,6 +232,7 @@ mod tests {
     use p2panda_rs::schema::SchemaId;
     use rstest::rstest;
 
+    use crate::network::identity::{to_libp2p_peer_id, to_public_key};
     use crate::network::Peer;
     use crate::replication::{Message, SyncMessage, TargetSet};
     use crate::test_utils::helpers::random_target_set;
@@ -300,7 +302,10 @@ mod tests {
 
         // Send a message from to swarm_1 local peer from swarm_2 local peer.
         swarm_1.behaviour_mut().send_message(
-            Peer::new(swarm_2_peer_id, ConnectionId::new_unchecked(1)),
+            Peer::new(
+                to_public_key(&swarm_2_peer_id),
+                ConnectionId::new_unchecked(1),
+            ),
             SyncMessage::new(0, Message::SyncRequest(0.into(), TargetSet::new(&vec![]))),
         );
 
@@ -355,11 +360,11 @@ mod tests {
         // The first event should have been a ConnectionEstablished containing the expected peer
         // id
         let (peer_2, message) = events_1[0].clone();
-        assert_eq!(peer_2.id(), swarm_2_peer_id);
+        assert_eq!(to_libp2p_peer_id(&peer_2.id()), swarm_2_peer_id);
         assert!(message.is_none());
 
         let (peer_1, message) = events_2[0].clone();
-        assert_eq!(peer_1.id(), swarm_1_peer_id);
+        assert_eq!(to_libp2p_peer_id(&peer_1.id()), swarm_1_peer_id);
         assert!(message.is_none());
 
         // Send a message from swarm_1 to swarm_2
@@ -387,7 +392,7 @@ mod tests {
 
         // swarm_1 should have received the message from swarm_2 peer
         let (peer, message) = events_1[1].clone();
-        assert_eq!(peer.id(), swarm_2_peer_id);
+        assert_eq!(to_libp2p_peer_id(&peer.id()), swarm_2_peer_id);
         assert_eq!(
             message.unwrap(),
             SyncMessage::new(1, Message::SyncRequest(0.into(), target_set_2.clone()))
@@ -395,7 +400,7 @@ mod tests {
 
         // swarm_2 should have received the message from swarm_1 peer
         let (peer, message) = events_2[1].clone();
-        assert_eq!(peer.id(), swarm_1_peer_id);
+        assert_eq!(to_libp2p_peer_id(&peer.id()), swarm_1_peer_id);
         assert_eq!(
             message.unwrap(),
             SyncMessage::new(0, Message::SyncRequest(0.into(), target_set_1))

--- a/aquadoggo/src/network/peers/peer.rs
+++ b/aquadoggo/src/network/peers/peer.rs
@@ -3,7 +3,7 @@
 use std::cmp::Ordering;
 
 use libp2p::swarm::ConnectionId;
-use p2panda_rs::identity::PublicKey;
+use libp2p::PeerId;
 use p2panda_rs::Human;
 
 /// Identifier of a p2panda peer.
@@ -12,26 +12,26 @@ use p2panda_rs::Human;
 /// connection handler deals with the communication with that peer. In case connections get stale
 /// or fail we can use this information to understand which peer got affected.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct Peer(PublicKey, ConnectionId);
+pub struct Peer(PeerId, ConnectionId);
 
 impl Peer {
     /// Returns a new instance of a peer.
-    pub fn new(public_key: PublicKey, connection_id: ConnectionId) -> Self {
-        Self(public_key, connection_id)
+    pub fn new(peer_id: PeerId, connection_id: ConnectionId) -> Self {
+        Self(peer_id, connection_id)
     }
 
     /// Returns a new instance of our local peer.
     ///
     /// Local peers can not have a connection "to themselves", still we want to be able to compare
     /// our local peer with a remote one. This method therefore sets a "fake" `ConnectionId`.
-    pub fn new_local_peer(local_public_key: PublicKey) -> Self {
-        Self(local_public_key, ConnectionId::new_unchecked(0))
+    pub fn new_local_peer(local_peer_id: PeerId) -> Self {
+        Self(local_peer_id, ConnectionId::new_unchecked(0))
     }
 
     /// Returns the public key of this peer which serves as its identifier.
     ///
     /// The public key is used to determine which peer "wins" over a duplicate session conflict.
-    pub fn id(&self) -> PublicKey {
+    pub fn id(&self) -> PeerId {
         self.0
     }
 
@@ -44,7 +44,7 @@ impl Peer {
 impl Ord for Peer {
     fn cmp(&self, other: &Self) -> Ordering {
         // When comparing `Peer` instances (for example to handle duplicate session requests), we
-        // only look at the internal `PublicKey` since this is what both peers (local and remote)
+        // only look at the internal `PeerId` since this is what both peers (local and remote)
         // know about (the connection id might be different)
         self.0.to_bytes().cmp(&other.0.to_bytes())
     }

--- a/aquadoggo/src/network/peers/peer.rs
+++ b/aquadoggo/src/network/peers/peer.rs
@@ -8,7 +8,7 @@ use p2panda_rs::Human;
 
 /// Identifier of a p2panda peer.
 ///
-/// Additional to the unique public key we also store the `ConnectionId` to understand which libp2p
+/// Additional to the unique `PeerId` we also store the `ConnectionId` to understand which libp2p
 /// connection handler deals with the communication with that peer. In case connections get stale
 /// or fail we can use this information to understand which peer got affected.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -28,9 +28,9 @@ impl Peer {
         Self(local_peer_id, ConnectionId::new_unchecked(0))
     }
 
-    /// Returns the public key of this peer which serves as its identifier.
+    /// Returns the `PeerId` of this peer.
     ///
-    /// The public key is used to determine which peer "wins" over a duplicate session conflict.
+    /// The `PeerId` is used to determine which peer "wins" over a duplicate session conflict.
     pub fn id(&self) -> PeerId {
         self.0
     }

--- a/aquadoggo/src/network/peers/peer.rs
+++ b/aquadoggo/src/network/peers/peer.rs
@@ -46,7 +46,7 @@ impl Ord for Peer {
         // When comparing `Peer` instances (for example to handle duplicate session requests), we
         // only look at the internal `PeerId` since this is what both peers (local and remote)
         // know about (the connection id might be different)
-        self.0.to_bytes().cmp(&other.0.to_bytes())
+        self.0.cmp(&other.0)
     }
 }
 

--- a/aquadoggo/src/network/swarm.rs
+++ b/aquadoggo/src/network/swarm.rs
@@ -4,9 +4,7 @@ use std::convert::TryInto;
 
 use anyhow::Result;
 use libp2p::identity::Keypair;
-use libp2p::swarm::SwarmBuilder;
-use libp2p::Swarm;
-use log::info;
+use libp2p::swarm::{Swarm, SwarmBuilder};
 
 use crate::network::behaviour::Behaviour;
 use crate::network::transport;
@@ -16,20 +14,17 @@ pub async fn build_swarm(
     network_config: &NetworkConfiguration,
     key_pair: Keypair,
 ) -> Result<Swarm<Behaviour>> {
-    let peer_id = network_config.peer_id.expect("Peer id needs to be given");
-    info!("Local peer id: {peer_id}");
-
+    let peer_id = key_pair.public().to_peer_id();
     let relay_client_enabled = network_config.relay_address.is_some();
 
+    // Prepare QUIC transport
     let (transport, relay_client) =
         transport::build_transport(&key_pair, relay_client_enabled).await;
 
-    // Instantiate the custom network behaviour with default configuration
-    // and the libp2p peer ID
-    let behaviour = Behaviour::new(network_config, peer_id, key_pair, relay_client)?;
+    // Instantiate the custom network behaviour
+    let behaviour = Behaviour::new(network_config, key_pair, relay_client)?;
 
-    // Initialise a swarm with QUIC transports, our composed network behaviour
-    // and the default configuration parameters
+    // Initialise a swarm with QUIC transports and our composed network behaviour
     let swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, peer_id)
         // This method expects a NonZeroU8 as input, hence the try_into conversion
         .dial_concurrency_factor(network_config.dial_concurrency_factor.try_into()?)

--- a/aquadoggo/src/node.rs
+++ b/aquadoggo/src/node.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use anyhow::Result;
+use p2panda_rs::identity::KeyPair;
 
 use crate::bus::ServiceMessage;
 use crate::config::Configuration;
@@ -48,7 +49,7 @@ pub struct Node {
 impl Node {
     /// Start p2panda node with your configuration. This method can be used to run the node within
     /// other applications.
-    pub async fn start(config: Configuration) -> Self {
+    pub async fn start(key_pair: KeyPair, config: Configuration) -> Self {
         // Initialize database and get connection pool
         let pool = initialize_db(&config)
             .await
@@ -59,7 +60,7 @@ impl Node {
         let schemas = SchemaProvider::new(store.get_all_schema().await.unwrap());
 
         // Create service manager with shared data between services
-        let context = Context::new(store, config, schemas);
+        let context = Context::new(store, key_pair, config, schemas);
         let mut manager =
             ServiceManager::<Context, ServiceMessage>::new(SERVICE_BUS_CAPACITY, context);
 

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -353,6 +353,7 @@ mod tests {
     use tokio::sync::broadcast;
 
     use crate::bus::ServiceMessage;
+    use crate::network::identity::to_public_key;
     use crate::network::Peer;
     use crate::replication::{Message, Mode, SyncMessage};
     use crate::test_utils::{test_runner, TestNode};
@@ -373,13 +374,16 @@ mod tests {
                 &node.context.schema_provider,
                 &node.context.store,
                 &tx,
-                local_peer_id,
+                to_public_key(&local_peer_id),
             );
 
             let target_set = manager.target_set().await;
 
             // Inform connection manager about new peer
-            let remote_peer = Peer::new(remote_peer_id, ConnectionId::new_unchecked(1));
+            let remote_peer = Peer::new(
+                to_public_key(&remote_peer_id),
+                ConnectionId::new_unchecked(1),
+            );
 
             manager
                 .handle_service_message(ServiceMessage::PeerConnected(remote_peer))

--- a/aquadoggo/src/test_utils/runner.rs
+++ b/aquadoggo/src/test_utils/runner.rs
@@ -4,6 +4,7 @@ use std::panic;
 use std::sync::Arc;
 
 use futures::Future;
+use p2panda_rs::identity::KeyPair;
 use tokio::runtime::Builder;
 use tokio::sync::Mutex;
 
@@ -68,6 +69,7 @@ impl TestNodeManager {
         let test_node = TestNode {
             context: Context::new(
                 store.clone(),
+                KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
             ),
@@ -100,6 +102,7 @@ pub fn test_runner<F: AsyncTestFn + Send + Sync + 'static>(test: F) {
         let node = TestNode {
             context: Context::new(
                 store.clone(),
+                KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
             ),

--- a/aquadoggo/src/tests.rs
+++ b/aquadoggo/src/tests.rs
@@ -44,6 +44,7 @@ async fn e2e() {
     // in-memory sqlite database for this test.
 
     let config = Configuration::new_ephemeral();
+    let key_pair = KeyPair::new();
 
     // Start the node.
     //
@@ -54,7 +55,7 @@ async fn e2e() {
     //
     // Nodes are the workhorses of the p2panda network, we thank you for all your efforts 🙏🏻.
 
-    let aquadoggo = Node::start(config).await; // 🐬🐕
+    let aquadoggo = Node::start(key_pair, config).await; // 🐬🐕
 
     // Create some authors.
     //

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -31,3 +31,6 @@ tokio = { version = "=1.25.0", features = ["full"] }
 [dependencies.aquadoggo]
 version = "~0.4.0"
 path = "../aquadoggo"
+
+[dev-dependencies]
+tempfile = "3.4.0"

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -21,10 +21,12 @@ doc = false
 
 [dependencies]
 anyhow = "=1.0.62"
-tokio = { version = "=1.25.0", features = ["full"] }
-env_logger = "=0.9.0"
 clap = { version = "=4.1.8", features = ["derive"] }
+env_logger = "=0.9.0"
+hex = "0.4.3"
 libp2p = "=0.51.3"
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "ae60bf754a60a1daf9c6862e9ae51ee7501b007f" }
+tokio = { version = "=1.25.0", features = ["full"] }
 
 [dependencies.aquadoggo]
 version = "~0.4.0"

--- a/aquadoggo_cli/src/key_pair.rs
+++ b/aquadoggo_cli/src/key_pair.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use p2panda_rs::identity::KeyPair;
+
+/// Returns a new instance of `KeyPair` by either loading the private key from a path or generating
+/// a new one and saving it on the file system.
+pub fn generate_or_load_key_pair(path: PathBuf) -> Result<KeyPair> {
+    let key_pair = if path.is_file() {
+        load_key_pair_from_file(path)?
+    } else {
+        let key_pair = KeyPair::new();
+        save_key_pair_to_file(&key_pair, path)?;
+        key_pair
+    };
+
+    Ok(key_pair)
+}
+
+/// Returns a new instance of `KeyPair` by generating a new key pair which is not persisted on the
+/// file system.
+///
+/// This method is useful to run nodes for testing purposes.
+#[allow(dead_code)]
+pub fn generate_ephemeral_key_pair() -> KeyPair {
+    KeyPair::new()
+}
+
+/// Saves human-readable (hex-encoded) private key string (ed25519) into a file at the given path.
+///
+/// This method automatically creates the required directories on that path and fixes the
+/// permissions of the file (0600, read and write permissions only for the owner).
+fn save_key_pair_to_file(key_pair: &KeyPair, path: PathBuf) -> Result<()> {
+    let private_key_hex = hex::encode(key_pair.private_key().as_bytes());
+
+    // Make sure that directories exist and write file into it
+    fs::create_dir_all(path.parent().unwrap())?;
+    let mut file = File::create(&path)?;
+    file.write_all(private_key_hex.as_bytes())?;
+    file.sync_all()?;
+
+    // Set permission for sensitive information
+    let mut permissions = file.metadata()?.permissions();
+    permissions.set_mode(0o600);
+    fs::set_permissions(path, permissions)?;
+
+    Ok(())
+}
+
+/// Loads a private key from a file at the given path and derives ed25519 key pair from it.
+///
+/// The private key in the file needs to be represented as a hex-encoded string.
+fn load_key_pair_from_file(path: PathBuf) -> Result<KeyPair> {
+    let mut file = File::open(path)?;
+    let mut private_key_hex = String::new();
+    file.read_to_string(&mut private_key_hex)?;
+    let key_pair = KeyPair::from_private_key_str(&private_key_hex)?;
+    Ok(key_pair)
+}
+
+/* #[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::NetworkConfiguration;
+
+    #[test]
+    fn generates_new_key_pair() {
+        let key_pair = NetworkConfiguration::load_or_generate_key_pair(None);
+        assert!(key_pair.is_ok());
+    }
+
+    #[test]
+    fn saves_and_loads_key_pair() {
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_path = tmp_dir.path().to_owned();
+
+        // Attempt to load the key pair from the temporary path
+        // This should result in a new key pair being generated and written to file
+        let key_pair_1 = NetworkConfiguration::load_or_generate_key_pair(Some(tmp_path.clone()));
+        assert!(key_pair_1.is_ok());
+
+        // Attempt to load the key pair from the same temporary path
+        // This should result in the previously-generated key pair being loaded from file
+        let key_pair_2 = NetworkConfiguration::load_or_generate_key_pair(Some(tmp_path));
+        assert!(key_pair_2.is_ok());
+
+        // Ensure that both key pairs have the same public key
+        assert_eq!(key_pair_1.unwrap().public(), key_pair_2.unwrap().public());
+    }
+} */

--- a/aquadoggo_cli/src/key_pair.rs
+++ b/aquadoggo_cli/src/key_pair.rs
@@ -8,14 +8,20 @@ use std::path::PathBuf;
 use anyhow::Result;
 use p2panda_rs::identity::KeyPair;
 
+/// File of the name where the private key will be stored inside.
+const KEY_PAIR_FILE_NAME: &str = "private-key";
+
 /// Returns a new instance of `KeyPair` by either loading the private key from a path or generating
-/// a new one and saving it on the file system.
-pub fn generate_or_load_key_pair(path: PathBuf) -> Result<KeyPair> {
-    let key_pair = if path.is_file() {
-        load_key_pair_from_file(path)?
+/// a new one and saving it in the file system.
+pub fn generate_or_load_key_pair(base_path: PathBuf) -> Result<KeyPair> {
+    let mut key_pair_path = base_path.clone();
+    key_pair_path.push(KEY_PAIR_FILE_NAME);
+
+    let key_pair = if key_pair_path.is_file() {
+        load_key_pair_from_file(key_pair_path)?
     } else {
         let key_pair = KeyPair::new();
-        save_key_pair_to_file(&key_pair, path)?;
+        save_key_pair_to_file(&key_pair, key_pair_path)?;
         key_pair
     };
 

--- a/aquadoggo_cli/src/key_pair.rs
+++ b/aquadoggo_cli/src/key_pair.rs
@@ -72,12 +72,13 @@ mod tests {
     #[test]
     fn saves_and_loads_key_pair() {
         let tmp_dir = TempDir::new().unwrap();
-        let tmp_path = tmp_dir.path().to_owned();
+        let mut tmp_path = tmp_dir.path().to_owned();
+        tmp_path.push("private-key.txt");
 
         // Attempt to load the key pair from the temporary path
         // This should result in a new key pair being generated and written to file
         let key_pair_1 = generate_or_load_key_pair(tmp_path.clone());
-        assert!(key_pair_1.is_ok());
+        assert!(key_pair_1.is_ok(), "{:?}", key_pair_1.err());
 
         // Attempt to load the key pair from the same temporary path
         // This should result in the previously-generated key pair being loaded from file

--- a/aquadoggo_cli/src/key_pair.rs
+++ b/aquadoggo_cli/src/key_pair.rs
@@ -63,17 +63,11 @@ fn load_key_pair_from_file(path: PathBuf) -> Result<KeyPair> {
     Ok(key_pair)
 }
 
-/* #[cfg(test)]
+#[cfg(test)]
 mod tests {
     use tempfile::TempDir;
 
-    use super::NetworkConfiguration;
-
-    #[test]
-    fn generates_new_key_pair() {
-        let key_pair = NetworkConfiguration::load_or_generate_key_pair(None);
-        assert!(key_pair.is_ok());
-    }
+    use super::generate_or_load_key_pair;
 
     #[test]
     fn saves_and_loads_key_pair() {
@@ -82,15 +76,18 @@ mod tests {
 
         // Attempt to load the key pair from the temporary path
         // This should result in a new key pair being generated and written to file
-        let key_pair_1 = NetworkConfiguration::load_or_generate_key_pair(Some(tmp_path.clone()));
+        let key_pair_1 = generate_or_load_key_pair(tmp_path.clone());
         assert!(key_pair_1.is_ok());
 
         // Attempt to load the key pair from the same temporary path
         // This should result in the previously-generated key pair being loaded from file
-        let key_pair_2 = NetworkConfiguration::load_or_generate_key_pair(Some(tmp_path));
+        let key_pair_2 = generate_or_load_key_pair(tmp_path);
         assert!(key_pair_2.is_ok());
 
         // Ensure that both key pairs have the same public key
-        assert_eq!(key_pair_1.unwrap().public(), key_pair_2.unwrap().public());
+        assert_eq!(
+            key_pair_1.unwrap().public_key(),
+            key_pair_2.unwrap().public_key()
+        );
     }
-} */
+}

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -11,8 +11,6 @@ use clap::error::ErrorKind as ClapErrorKind;
 use clap::{CommandFactory, Parser};
 use libp2p::{Multiaddr, PeerId};
 
-const KEY_PAIR_FILE_NAME: &str = "private-key";
-
 #[derive(Parser, Debug)]
 #[command(name = "aquadoggo Node", version)]
 /// Node server for the p2panda network.
@@ -150,14 +148,12 @@ async fn main() {
     // Load configuration parameters and apply defaults
     let config: Configuration = cli.try_into().expect("Could not load configuration");
 
-    // Generate new key pair or load it from file.
-    //
-    // We can unwrap the base path as we know it has been initialised during the conversion step
-    // before.
-    let mut key_pair_path = config.base_path.to_owned().unwrap();
-    key_pair_path.push(KEY_PAIR_FILE_NAME);
-    let key_pair = key_pair::generate_or_load_key_pair(key_pair_path)
-        .expect("Could not load key pair from file");
+    // We unwrap the path as we know it has been initialised during the conversion step before
+    let base_path = config.base_path.clone().unwrap();
+
+    // Generate new key pair or load it from file
+    let key_pair =
+        key_pair::generate_or_load_key_pair(base_path).expect("Could not load key pair from file");
 
     // Start p2panda node in async runtime
     let node = Node::start(key_pair, config).await;


### PR DESCRIPTION
## Separation of worlds

This separates the worlds of libp2p and p2panda a bit better. Before we would deal with libp2p's `Keypair` inside of our `Configuration` struct to handle and store secrets.

The only place where we "leak" libp2p into our other parts is the replication service, there we have still a notion of `PeerId`. We could wrap that around our own type to abstract it away, but at this point that seems too much.

## Making `KeyPair` more visible

This PR brings `KeyPair` into the picture by moving it out of `Configuration`, into its own `Context` field and on top into the `Node.start(key_pair, config)` method.

Closes https://github.com/p2panda/aquadoggo/issues/388

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
