### PR TITLE
Handle duplicate document view insertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort paginated query field rows by document view id [#354](https://github.com/p2panda/aquadoggo/pull/354)
 - Fix missing field when filtering owner [#359](https://github.com/p2panda/aquadoggo/pull/359)
 - Bind untrusted user filter arguments in SQL query [#358](https://github.com/p2panda/aquadoggo/pull/358)
+- Handle duplicate document view insertions in reduce task [#410](https://github.com/p2panda/aquadoggo/pull/410)
 
 ## [0.4.0]
 

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -459,7 +459,6 @@ async fn insert_document_view(
             )
         VALUES
             ($1, $2, $3)
-        ON CONFLICT(document_view_id) DO NOTHING -- @TODO: temp fix for double document view insertions: https://github.com/p2panda/aquadoggo/issues/398
         ",
     )
     .bind(document_view.id().to_string())

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -30,7 +30,6 @@
 //! retained, we use a system of "pinned relations" to identify and materialise only views we
 //! explicitly wish to keep.
 use async_trait::async_trait;
-use log::debug;
 use p2panda_rs::document::traits::AsDocument;
 use p2panda_rs::document::{Document, DocumentId, DocumentView, DocumentViewId};
 use p2panda_rs::schema::SchemaId;
@@ -318,8 +317,7 @@ impl SqlStore {
     ///
     /// This method performs one insertion in the `document_views` table and at least one in the
     /// `document_view_fields` table. If either of these operations fail then all insertions are
-    /// rolled back. A success result is returned containing a bool to indicate if the insertion
-    /// was not necessary as the document view already exists in the store.
+    /// rolled back.
     ///
     /// An error is returned in the case of a fatal storage error.
     pub async fn insert_document_view(
@@ -327,7 +325,7 @@ impl SqlStore {
         document_view: &DocumentView,
         document_id: &DocumentId,
         schema_id: &SchemaId,
-    ) -> Result<bool, DocumentStorageError> {
+    ) -> Result<(), DocumentStorageError> {
         // Start a transaction, any db insertions after this point, and before the `commit()`
         // will be rolled back in the event of an error.
         let mut tx = self
@@ -337,16 +335,15 @@ impl SqlStore {
             .map_err(|e| DocumentStorageError::FatalStorageError(e.to_string()))?;
 
         // Insert the document view into the `document_views` table. Rollback insertions if an error occurs.
-        let insertion_occured =
-            match insert_document_view(&mut tx, document_view, document_id, schema_id).await {
-                Ok(insertion_occured) => insertion_occured,
-                Err(err) => {
-                    tx.rollback()
-                        .await
-                        .map_err(|e| DocumentStorageError::FatalStorageError(e.to_string()))?;
-                    return Err(err);
-                }
-            };
+        match insert_document_view(&mut tx, document_view, document_id, schema_id).await {
+            Ok(_) => (),
+            Err(err) => {
+                tx.rollback()
+                    .await
+                    .map_err(|e| DocumentStorageError::FatalStorageError(e.to_string()))?;
+                return Err(err);
+            }
+        };
 
         // Insert the document view fields into the `document_view_fields` table. Rollback
         // insertions if an error occurs.
@@ -363,9 +360,7 @@ impl SqlStore {
         // Commit the tx here as no errors occurred.
         tx.commit()
             .await
-            .map_err(|e| DocumentStorageError::FatalStorageError(e.to_string()))?;
-
-        Ok(insertion_occured)
+            .map_err(|e| DocumentStorageError::FatalStorageError(e.to_string()))
     }
 }
 
@@ -453,8 +448,8 @@ async fn insert_document_view(
     document_view: &DocumentView,
     document_id: &DocumentId,
     schema_id: &SchemaId,
-) -> Result<bool, DocumentStorageError> {
-    let result = query(
+) -> Result<AnyQueryResult, DocumentStorageError> {
+    query(
         "
         INSERT INTO
             document_views (
@@ -464,59 +459,14 @@ async fn insert_document_view(
             )
         VALUES
             ($1, $2, $3)
+        ON CONFLICT(document_view_id) DO NOTHING -- @TODO: temp fix for double document view insertions: https://github.com/p2panda/aquadoggo/issues/398
         ",
     )
     .bind(document_view.id().to_string())
     .bind(document_id.to_string())
     .bind(schema_id.to_string())
-    .execute(&mut *tx)
-    .await;
-
-    match result {
-        Ok(_) => Ok(true),
-        Err(err) => match err {
-            // Handle errors returned from the database
-            sqlx::Error::Database(_) => {
-                // There was an error when inserting the document view. This can happen if the
-                // same document view is inserted twice into the store. It isn't a critical error
-                // though, so we want to check if the document view we are handling here already
-                // exists and silently ignore this error if so.
-                let result = query(
-                    "
-                        SELECT
-                            document_view_id
-                        FROM
-                            document_views
-                        WHERE
-                            document_view_id = $1
-                        ",
-                )
-                .bind(document_view.id().to_string())
-                .fetch_optional(&mut *tx)
-                .await;
-
-                match result {
-                    Ok(existing_document_view) => {
-                        if existing_document_view.is_some() {
-                            // The document view already exists so we return success with a false
-                            // value to signal no insertion occurred.
-
-                            debug!(
-                                "Duplicate insertion attempted for document view: {}",
-                                document_view.id()
-                            );
-                            Ok(false)
-                        } else {
-                            Err(err)
-                        }
-                    }
-                    Err(_) => Err(err),
-                }
-            }
-            // Pass on any other errors which occur
-            err => Err(err),
-        },
-    }
+    .execute(tx)
+    .await
     .map_err(|e| DocumentStorageError::FatalStorageError(e.to_string()))
 }
 
@@ -690,51 +640,6 @@ mod tests {
             assert_eq!(retrieved_document.view_id(), document.view_id());
             assert_eq!(retrieved_document.fields(), document.fields());
         });
-    }
-
-    #[rstest]
-    fn duplicate_document_view_insertions(
-        #[from(populate_store_config)]
-        #[with(2, 1, 1)]
-        config: PopulateStoreConfig,
-    ) {
-        test_runner(|node: TestNode| async move {
-            // Populate the store with some entries and operations but DON'T materialise any resulting documents.
-            let (_, document_ids) = populate_store(&node.context.store, &config).await;
-            let document_id = document_ids.get(0).expect("At least one document id");
-
-            // Get the operations and build the document.
-            let operations = node
-                .context
-                .store
-                .get_operations_by_document_id(&document_id)
-                .await
-                .unwrap();
-
-            // Build the document from the operations.
-            let document_builder = DocumentBuilder::from(&operations);
-            let document = document_builder.build().unwrap();
-
-            // Insert the document into the store (this inserts the view as well)
-            let result = node.context.store.insert_document(&document).await;
-            assert!(result.is_ok());
-
-            // Insert the documents' view again.
-            let result = node
-                .context
-                .store
-                .insert_document_view(
-                    &document.view().unwrap(),
-                    document.id(),
-                    document.schema_id(),
-                )
-                .await;
-
-            // This shouldn't error, but the value returned in the result should be `false` to
-            // indicate that no insertion actually occured (because the view already existed).
-            // assert!(result.is_ok());
-            assert!(!result.unwrap());
-        })
     }
 
     #[rstest]

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -557,7 +557,7 @@ mod tests {
             assert!(reduce_task(node.context.clone(), input).await.is_ok());
 
             // Issue a reduce task for the document view, which should succeed although no new
-            // view is inserted. 
+            // view is inserted.
             let input = TaskInput::new(None, Some(document.view_id().to_owned()));
             assert!(reduce_task(node.context.clone(), input).await.is_ok());
         })


### PR DESCRIPTION
Document views have a `UNIQUE` constraint on their `document_view_id` which means if double insertion of the same document view occurs then a fatal database error is returned. Although this is the expected behaviour, and there is no reason to want to update a document view (once inserted, no values on a document view should change), it can happen that a document is inserted twice because of two materializer tasks working towards the same document view (see issue and discussion here: https://github.com/p2panda/aquadoggo/issues/398).

This PR retains the `UNIQUE` restraint on document view id, and ~changes the behaviour of `insert_document_view` on `SqlStore`~ checks if a document view has already been materialized in the reduce task before performing any insertion.

Closes https://github.com/p2panda/aquadoggo/issues/398

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
