### PR TITLE
Fix cursor pagination over ordered queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing field when filtering owner [#359](https://github.com/p2panda/aquadoggo/pull/359)
 - Bind untrusted user filter arguments in SQL query [#358](https://github.com/p2panda/aquadoggo/pull/358)
 - Reintroduce property tests for GraphQL query api [#362](https://github.com/p2panda/aquadoggo/pull/362)
+- Fix cursor pagination over ordered queries [#412](https://github.com/p2panda/aquadoggo/pull/412)
 
 ## [0.4.0]
 

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -1458,7 +1458,7 @@ mod tests {
                     ("timestamp", 1687266055.into(), None),
                 ],
                 vec![
-                    ("message", "I'm cute and very hungry".into(), None),
+                    ("message", "I am cute and very hungry".into(), None),
                     ("username", "panda".into(), None),
                     ("timestamp", 1687266141.into(), None),
                 ],
@@ -1573,7 +1573,7 @@ mod tests {
             "Oh, howdy, Pengi!".into(),
             "How are you?".into(),
             "I miss Pengolina. How about you?".into(),
-            "I'm cute and very hungry".into(),
+            "I am cute and very hungry".into(),
             "(°◇°) !!".into(),
         ],
     )]
@@ -1582,7 +1582,7 @@ mod tests {
         "message".into(),
         vec![
             "(°◇°) !!".into(),
-            "I'm cute and very hungry".into(),
+            "I am cute and very hungry".into(),
             "I miss Pengolina. How about you?".into(),
             "How are you?".into(),
             "Oh, howdy, Pengi!".into(),
@@ -1597,7 +1597,7 @@ mod tests {
             "Hello, Panda!".into(),
             "How are you?".into(),
             "I miss Pengolina. How about you?".into(),
-            "I'm cute and very hungry".into(),
+            "I am cute and very hungry".into(),
             "Oh, howdy, Pengi!".into(),
         ],
     )]

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -634,6 +634,11 @@ fn where_pagination_sql(
             let cmp_field =
                 typecast_field_sql("operation_fields_v1.value", order_field_name, schema, false);
 
+            // Since cursors are unique per document fields this method selects the right one
+            // depending on what ordering was selected. For example if the client chose to order by
+            // "timestamp" then the cursor will be selected for each document pointing at the
+            // "timestamp" field. Like this we can correctly paginate over an ordered collection of
+            // documents.
             let cmp_value = format!(
                 r#"
                 SELECT
@@ -1176,12 +1181,6 @@ impl SqlStore {
 ///
 /// Due to the special table layout we receive one row per operation field in the query. Usually we
 /// need to merge multiple rows / operation fields into one document.
-///
-/// This method also selects one cursor per document which then can be used by the client to
-/// control pagination. Since cursors are unique per document fields this method selects the right
-/// one depending on what ordering was selected. For example if the client chose to order by
-/// "timestamp" then the cursor will be selected for each document pointing at the "timestamp"
-/// field. Like this we can correctly paginate over an ordered collection of documents.
 fn convert_rows(
     rows: Vec<QueryRow>,
     list: Option<&RelationList>,

--- a/aquadoggo/src/graphql/resolvers.rs
+++ b/aquadoggo/src/graphql/resolvers.rs
@@ -131,7 +131,10 @@ pub async fn resolve_document_field(
     // Determine name of the field to be resolved
     let name = ctx.field().name();
 
-    match document.get(name).unwrap() {
+    match document
+        .get(name)
+        .expect("Selected field should be in document")
+    {
         // Relation fields are expected to resolve to the related document
         OperationValue::Relation(relation) => {
             let document = match store.get_document(relation.document_id()).await? {


### PR DESCRIPTION
We paginate with the help of a unique `cursor`, there is one per document field.

```
Document {
  username <- Cursor #31c
  timestamp <- Cursor #21a
  message <- Cursor #d32
}

Document {
  username <- Cursor #a51
  ... and so on
}
```

When the client choses to order the resulting documents by some field (for example "timestamp") it is important that the comparison value for pagination comes from this field.

```
Query: Order "Chat" documents by "timestamp"

Document {
  username
  timestamp <- Compare
  message
}

Document {
  username
  timestamp <- Compare
  message
}

Document {
  username
  timestamp <- Compare
  message
}
```

At the same time we _need_ to always return the last `cursor` for each document to the client, since this is the point where we can safely paginate to the next document.

```
Document {
  username
  timestamp
  message <- Cursor
}

Document {
  username
  timestamp
  message <- Cursor
}

Document {
  username
  timestamp
  message <- Cursor
}
```

The bug resulted from us using the cursor to determine the field, which was only accidentally sometimes the same as chosen by the ordering.

Also, this fix uncovered a second bug which was that not always we returned the last cursor per document since the SQL sometimes orders them slightly different, indeterministicly.

This PR fixes the problem by:

1. Making sure that always the last field is selected as a cursor in `convert_rows` (before it's been a bit random, as the SQL query returns fields in different order sometimes)
2. Extending the pagination query to select the correct operation field based on the cursor and ordering setting

Closes https://github.com/p2panda/aquadoggo/issues/381

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
