### PR TITLE
Fix early document view insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort paginated query field rows by document view id [#354](https://github.com/p2panda/aquadoggo/pull/354)
 - Fix missing field when filtering owner [#359](https://github.com/p2panda/aquadoggo/pull/359)
 - Bind untrusted user filter arguments in SQL query [#358](https://github.com/p2panda/aquadoggo/pull/358)
+- Fix insertion of view before document is materialized [#413](https://github.com/p2panda/aquadoggo/pull/413)
 
 ## [0.4.0]
 

--- a/aquadoggo/migrations/20230114140233_alter-documents.sql
+++ b/aquadoggo/migrations/20230114140233_alter-documents.sql
@@ -1,3 +1,3 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
-ALTER TABLE document_views ADD COLUMN document_id TEXT NOT NULL;
+ALTER TABLE document_views ADD COLUMN document_id TEXT NOT NULL REFERENCES documents(document_id);

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -57,14 +57,11 @@ pub async fn reduce_task(context: Context, input: TaskInput) -> TaskResult<TaskI
             .map_err(|err| TaskError::Critical(err.to_string()))?;
 
         // If it wasn't found then we shouldn't reduce this view yet (as the document it's part of
-        // should be reduced first). In this case we issue a reduce task for the document, and
-        // also re-issue this reduce task.
+        // should be reduced first). In this case we assume the task for reducing the document is
+        // already in the queue and so we only re-issue this reduce task.
         if existing_document.is_none() {
-            debug!("Document for view not materialized yet, issuing reduce task for document {} and reissuing current reduce task with input {}", document_id.display(), input);
-            return Ok(Some(vec![
-                Task::new("reduce", TaskInput::new(Some(document_id), None)),
-                Task::new("reduce", input),
-            ]));
+            debug!("Document {} for view not materialized yet, reissuing current reduce task with input {}", document_id.display(), input);
+            return Ok(Some(vec![Task::new("reduce", input)]));
         };
     };
 

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -140,7 +140,7 @@ async fn reduce_document_view<O: AsOperation + WithId<OperationId> + WithPublicK
     // been once already materialized yet.
     let existing_document = context
         .store
-        .get_document(&document_id)
+        .get_document(document_id)
         .await
         .map_err(|err| TaskError::Critical(err.to_string()))?;
 

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -259,7 +259,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::materializer::tasks::reduce_task;
-    use crate::materializer::{TaskInput, Task};
+    use crate::materializer::{Task, TaskInput};
     use crate::test_utils::{
         doggo_fields, doggo_schema, populate_store_config, test_runner, TestNode,
     };

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -172,7 +172,10 @@ async fn reduce_document_view<O: AsOperation + WithId<OperationId> + WithPublicK
 
     info!("Stored {} document view {}", document, document.view_id());
 
-    debug!("Dispatch dependency task for view with id: {}", document.view_id());
+    debug!(
+        "Dispatch dependency task for view with id: {}",
+        document.view_id()
+    );
     Ok(Some(vec![Task::new(
         "dependency",
         TaskInput::new(None, Some(document.view_id().to_owned())),
@@ -218,7 +221,10 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
                 info!("Created {}", document.display(),);
             };
 
-            debug!("Dispatch dependency task for view with id: {}", document.view_id());
+            debug!(
+                "Dispatch dependency task for view with id: {}",
+                document.view_id()
+            );
             Ok(Some(vec![Task::new(
                 "dependency",
                 TaskInput::new(None, Some(document.view_id().to_owned())),


### PR DESCRIPTION
Solution for #407 which implements checking a document has been materialized in a reduce task before inserting a document view into the store. If the document does not exist yet, the task is re-issued, assuming that the document reduce task is already in the queue somewhere.

For safety, and for assisting in identifying potential future bugs, I also introduced a foreign relation constraint onto the `document_id` column in `document_views` table. We don't rely on this being hit in our code though. 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
