### PR TITLE
Fix race condition when check for existing view ids was too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bind untrusted user filter arguments in SQL query [#358](https://github.com/p2panda/aquadoggo/pull/358)
 - Fix insertion of view before document is materialized [#413](https://github.com/p2panda/aquadoggo/pull/413)
 - Handle duplicate document view insertions in reduce task [#410](https://github.com/p2panda/aquadoggo/pull/410)
+- Fix race condition when check for existing view ids was too early [#420](https://github.com/p2panda/aquadoggo/pull/420)
 
 ### Open Sauce
 


### PR DESCRIPTION
This fixes a race condition where the check for duplicate document view ids in the database was too early.

The `reduce` task started, checked if a view id existed, if not, it happily went on, while another task could have created the view id in the meantime before we come to the point where we created the view id (again). Probably because of the ON CONFLICT clause we didn't notice that issue before.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
