### PR TITLE
Make `TaskInput` an enum and other minor clean ups in materialiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set default order for root queries to document id [#352](https://github.com/p2panda/aquadoggo/pull/352)
 - Remove property tests again because of concurrency bug [#347](https://github.com/p2panda/aquadoggo/pull/347)
 - Decouple p2panda's authentication data types from libp2p's [#408](https://github.com/p2panda/aquadoggo/pull/408)
+- Make `TaskInput` an enum and other minor clean ups in materialiser [#429](https://github.com/p2panda/aquadoggo/pull/429)
 
 ### Fixed
 

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -264,10 +264,10 @@ impl DocumentStore for SqlStore {
     }
 }
 
-/// Storage api offering an interface for inserting documents and document views into the database.
+/// Storage API offering an interface for inserting documents and document views into the database.
 ///
-/// These methods are specific to `aquadoggo`s approach to document caching and are defined
-/// outside of the required `DocumentStore` trait.
+/// These methods are specific to aquadoggos approach to document caching and are defined outside
+/// of the required `DocumentStore` trait.
 impl SqlStore {
     /// Insert a document into the database.
     ///
@@ -285,8 +285,8 @@ impl SqlStore {
     /// Note: "out-of-date" document views will remain in storage when a document already existed
     /// and is updated. If they are not needed for anything else they can be garbage collected.
     pub async fn insert_document(&self, document: &Document) -> Result<(), DocumentStorageError> {
-        // Start a transaction, any db insertions after this point, and before the `commit()`
-        // can be rolled back in the event of an error.
+        // Start a transaction, any db insertions after this point, and before the `commit()` can
+        // be rolled back in the event of an error.
         let mut tx = self
             .pool
             .begin()
@@ -416,6 +416,7 @@ async fn insert_document_fields(
     document_view: &DocumentView,
 ) -> Result<Vec<AnyQueryResult>, DocumentStorageError> {
     let mut results = Vec::with_capacity(document_view.len());
+
     for (name, value) in document_view.iter() {
         let result = query(
             "
@@ -498,7 +499,7 @@ async fn insert_document(
     .bind(document.schema_id().to_string())
     .execute(&mut *tx)
     .await
-    .map_err(|e| DocumentStorageError::FatalStorageError(e.to_string()))?;
+    .map_err(|err| DocumentStorageError::FatalStorageError(err.to_string()))?;
 
     // If the document is not deleted, then we also want to insert it's view and fields.
     if !document.is_deleted() && document.view().is_some() {
@@ -506,7 +507,7 @@ async fn insert_document(
         let document_view =
             DocumentView::new(document.view_id(), document.view().unwrap().fields());
 
-        // Insert the document view.
+        // Insert the document view
         insert_document_view(
             &mut *tx,
             &document_view,
@@ -514,7 +515,8 @@ async fn insert_document(
             document.schema_id(),
         )
         .await?;
-        // Insert the document view fields.
+
+        // Insert the document view fields
         insert_document_fields(&mut *tx, &document_view).await?;
     };
 

--- a/aquadoggo/src/materializer/input.rs
+++ b/aquadoggo/src/materializer/input.rs
@@ -9,36 +9,26 @@ use p2panda_rs::document::{DocumentId, DocumentViewId};
 /// The workers are designed such that they EITHER await a `DocumentId` OR a `DocumentViewId`.
 /// Setting both values `None` or both values `Some` will be rejected.
 #[derive(Clone, Eq, PartialEq, Debug, Hash)]
-pub struct TaskInput {
+pub enum TaskInput {
     /// Specifying a `DocumentId`, indicating that we're interested in processing the "latest"
     /// state of that document.
-    pub document_id: Option<DocumentId>,
+    DocumentId(DocumentId),
 
     /// Specifying a `DocumentViewId`, indicating that we're interested in processing the state of
     /// that document view at this point.
-    pub document_view_id: Option<DocumentViewId>,
-}
-
-impl TaskInput {
-    /// Returns a new instance of `TaskInput`.
-    pub fn new(document_id: Option<DocumentId>, document_view_id: Option<DocumentViewId>) -> Self {
-        Self {
-            document_id,
-            document_view_id,
-        }
-    }
+    DocumentViewId(DocumentViewId),
 }
 
 impl Display for TaskInput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let document_id = match &self.document_id {
-            Some(id) => format!("{}", id),
-            None => "-".to_string(),
+        let document_id = match &self {
+            Self::DocumentId(id) => format!("{}", id),
+            Self::DocumentViewId(_) => "-".to_string(),
         };
 
-        let view_id = match &self.document_view_id {
-            Some(view_id) => format!("{}", view_id),
-            None => "-".to_string(),
+        let view_id = match &self {
+            Self::DocumentViewId(view_id) => format!("{}", view_id),
+            Self::DocumentId(_) => "-".to_string(),
         };
 
         write!(f, "<TaskInput {}/{}>", document_id, view_id)

--- a/aquadoggo/src/materializer/worker.rs
+++ b/aquadoggo/src/materializer/worker.rs
@@ -538,10 +538,7 @@ where
                             error_signal.trigger();
                         }
                         Err(TaskError::Failure(err)) => {
-                            debug!(
-                                "Silently failing worker {} with task {}: {}",
-                                name, item, err
-                            );
+                            debug!("Worker {} aborted task {}: {}", name, item, err);
                         }
                         _ => (), // Task succeeded, but nothing to dispatch
                     };

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -104,7 +104,7 @@ struct ConnectionManager {
     /// Sender for messages to other services.
     rx: BroadcastStream<ServiceMessage>,
 
-    /// Provider to retreive our currently supported schema ids.
+    /// Provider to retrieve our currently supported schema ids.
     schema_provider: SchemaProvider,
 }
 

--- a/aquadoggo/src/test_utils/node.rs
+++ b/aquadoggo/src/test_utils/node.rs
@@ -94,7 +94,7 @@ pub async fn populate_and_materialize(
     // Iterate over document id's and materialize into the store.
     for document_id in document_ids.clone() {
         // Create reduce task input.
-        let input = TaskInput::new(Some(document_id), None);
+        let input = TaskInput::DocumentId(document_id);
         // Run reduce task and collect returned dependency tasks.
         let dependency_tasks = reduce_task(node.context.clone(), input.clone())
             .await
@@ -143,7 +143,7 @@ pub async fn add_document(
         .await
         .expect("Publish CREATE operation");
 
-    let input = TaskInput::new(Some(DocumentId::from(entry_signed.hash())), None);
+    let input = TaskInput::DocumentId(DocumentId::from(entry_signed.hash()));
     let dependency_tasks = reduce_task(node.context.clone(), input.clone())
         .await
         .expect("Reduce document");
@@ -181,7 +181,7 @@ pub async fn add_schema(
         .await
         .expect("Publish schema fields");
 
-        let input = TaskInput::new(Some(DocumentId::from(entry_signed.hash())), None);
+        let input = TaskInput::DocumentId(DocumentId::from(entry_signed.hash()));
         reduce_task(node.context.clone(), input).await.unwrap();
 
         info!("Added field '{}' ({})", field.0, field.1);
@@ -199,13 +199,13 @@ pub async fn add_schema(
     .await
     .expect("Publish schema");
 
-    let input = TaskInput::new(Some(DocumentId::from(entry_signed.hash())), None);
+    let input = TaskInput::DocumentId(DocumentId::from(entry_signed.hash()));
     reduce_task(node.context.clone(), input.clone())
         .await
         .expect("Reduce schema document");
 
     // Run schema task for this spec
-    let input = TaskInput::new(None, Some(DocumentViewId::from(entry_signed.hash())));
+    let input = TaskInput::DocumentViewId(DocumentViewId::from(entry_signed.hash()));
     schema_task(node.context.clone(), input)
         .await
         .expect("Run schema task");

--- a/aquadoggo_cli/src/key_pair.rs
+++ b/aquadoggo_cli/src/key_pair.rs
@@ -14,7 +14,7 @@ const KEY_PAIR_FILE_NAME: &str = "private-key";
 /// Returns a new instance of `KeyPair` by either loading the private key from a path or generating
 /// a new one and saving it in the file system.
 pub fn generate_or_load_key_pair(base_path: PathBuf) -> Result<KeyPair> {
-    let mut key_pair_path = base_path.clone();
+    let mut key_pair_path = base_path;
     key_pair_path.push(KEY_PAIR_FILE_NAME);
 
     let key_pair = if key_pair_path.is_file() {


### PR DESCRIPTION
This PR cleans up and refactors the materialisation logic slightly:

* Make `TaskInput` an enum
* Remove TODO for graceful shutdown, not sure we want this actually .. #164 
* Fix "task failure" message in logs #264 
* A bunch of minor documentation clean ups and typo fixes
* Make some logging less verbose

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
