### PR TITLE
Replicate `entries` and `operations` in their topologically sorted order 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.0"
-source = "git+https://github.com/p2panda/p2panda?rev=b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b#b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b"
+source = "git+https://github.com/p2panda/p2panda?rev=a535ee229b367c79f18a50626c6bcab61581e32b#a535ee229b367c79f18a50626c6bcab61581e32b"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.0"
-source = "git+https://github.com/p2panda/p2panda?rev=ae60bf754a60a1daf9c6862e9ae51ee7501b007f#ae60bf754a60a1daf9c6862e9ae51ee7501b007f"
+source = "git+https://github.com/p2panda/p2panda?rev=b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b#b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -51,7 +51,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a535ee229b367c79f18a50626c6bcab61581e32b", features = [
     "storage-provider",
 ] }
 serde = { version = "1.0.152", features = ["derive"] }
@@ -84,7 +84,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a535ee229b367c79f18a50626c6bcab61581e32b", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -51,7 +51,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "ae60bf754a60a1daf9c6862e9ae51ee7501b007f", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b", features = [
     "storage-provider",
 ] }
 serde = { version = "1.0.152", features = ["derive"] }
@@ -84,7 +84,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "ae60bf754a60a1daf9c6862e9ae51ee7501b007f", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/migrations/20230523135826_alter-operations.sql
+++ b/aquadoggo/migrations/20230523135826_alter-operations.sql
@@ -1,3 +1,3 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
-ALTER TABLE operations_v1 ADD COLUMN sorted_index NUMERIC;
+ALTER TABLE operations_v1 ADD COLUMN sorted_index INT;

--- a/aquadoggo/migrations/20230523135826_alter-operations.sql
+++ b/aquadoggo/migrations/20230523135826_alter-operations.sql
@@ -1,0 +1,3 @@
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+ALTER TABLE operations_v1 ADD COLUMN sorted_index NUMERIC;

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -26,6 +26,15 @@ pub struct OperationRow {
     /// separator.
     pub previous: Option<String>,
 
+    /// Index for the position of this operation once topological sorting of the operation graph
+    /// has been performed.
+    /// 
+    /// This is an option as when an operation which is not appended to the tip of a
+    /// document graph is handled then a `reduce` materialization task will be issued and all
+    /// indexes for operations in the effected document re-calculated.
+    /// 
+    /// If this value is None we can assume the operation has not been processed yet and we are
+    /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,
 }
 
@@ -102,5 +111,14 @@ pub struct OperationFieldsJoinedRow {
     /// field.
     pub list_index: Option<i32>,
 
+    /// Index for the position of this operation once topological sorting of the operation graph
+    /// has been performed.
+    /// 
+    /// This is an option as when an operation which is not appended to the tip of a
+    /// document graph is handled then a `reduce` materialization task will be issued and all
+    /// indexes for operations in the effected document re-calculated.
+    /// 
+    /// If this value is None we can assume the operation has not been processed yet and we are
+    /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,
 }

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -25,6 +25,8 @@ pub struct OperationRow {
     /// The previous operations of this operation concatenated into string format with `_`
     /// separator.
     pub previous: Option<String>,
+
+    pub sorted_index: Option<i32>,
 }
 
 /// A struct representing a single operation field row as it is inserted in the database.
@@ -99,4 +101,6 @@ pub struct OperationFieldsJoinedRow {
     /// This numeric value is a simple list index to represent multiple values within one operation
     /// field.
     pub list_index: Option<i32>,
+
+    pub sorted_index: Option<i32>,
 }

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -28,11 +28,11 @@ pub struct OperationRow {
 
     /// Index for the position of this operation once topological sorting of the operation graph
     /// has been performed.
-    /// 
+    ///
     /// This is an option as when an operation which is not appended to the tip of a
     /// document graph is handled then a `reduce` materialization task will be issued and all
     /// indexes for operations in the effected document re-calculated.
-    /// 
+    ///
     /// If this value is None we can assume the operation has not been processed yet and we are
     /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,
@@ -113,11 +113,11 @@ pub struct OperationFieldsJoinedRow {
 
     /// Index for the position of this operation once topological sorting of the operation graph
     /// has been performed.
-    /// 
+    ///
     /// This is an option as when an operation which is not appended to the tip of a
     /// document graph is handled then a `reduce` materialization task will be issued and all
     /// indexes for operations in the effected document re-calculated.
-    /// 
+    ///
     /// If this value is None we can assume the operation has not been processed yet and we are
     /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -188,6 +188,7 @@ pub fn parse_operation_rows(
         previous: operation.previous(),
         fields: operation.fields(),
         public_key,
+        sorted_index,
     };
 
     Some(operation)

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -35,6 +35,7 @@ pub fn parse_operation_rows(
     let public_key = PublicKey::new(&first_row.public_key).unwrap();
     let operation_id = first_row.operation_id.parse().unwrap();
     let document_id = first_row.document_id.parse().unwrap();
+    let sorted_index = first_row.sorted_index;
 
     let mut relation_lists: BTreeMap<String, Vec<DocumentId>> = BTreeMap::new();
     let mut pinned_relation_lists: BTreeMap<String, Vec<DocumentViewId>> = BTreeMap::new();

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -431,6 +431,7 @@ mod tests {
                 field_type: Some("int".to_string()),
                 value: Some("28".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -449,6 +450,7 @@ mod tests {
                 field_type: Some("float".to_string()),
                 value: Some("3.5".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -467,6 +469,7 @@ mod tests {
                 field_type: Some("bool".to_string()),
                 value: Some("false".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -488,6 +491,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -509,6 +513,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(1),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -530,6 +535,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -551,6 +557,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(1),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -572,6 +579,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -593,6 +601,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(1),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -614,6 +623,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -635,6 +645,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -653,6 +664,7 @@ mod tests {
                 field_type: Some("str".to_string()),
                 value: Some("bubu".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -671,6 +683,7 @@ mod tests {
                 field_type: Some("pinned_relation_list".to_string()),
                 value: None,
                 list_index: Some(0),
+                sorted_index: None,
             },
         ];
 

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::collections::BTreeMap;
 use std::fmt::Display;
 
 use async_trait::async_trait;

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -96,10 +96,11 @@ impl OperationStore for SqlStore {
                     operation_id,
                     action,
                     schema_id,
-                    previous
+                    previous,
+                    sorted_index
                 )
             VALUES
-                ($1, $2, $3, $4, $5, $6)
+                ($1, $2, $3, $4, $5, $6, null)
             ",
         )
         .bind(public_key.to_string())
@@ -183,6 +184,7 @@ impl OperationStore for SqlStore {
                 operations_v1.action,
                 operations_v1.schema_id,
                 operations_v1.previous,
+                operations_v1.sorted_index,
                 operation_fields_v1.name,
                 operation_fields_v1.field_type,
                 operation_fields_v1.value,
@@ -221,6 +223,7 @@ impl OperationStore for SqlStore {
                 operations_v1.action,
                 operations_v1.schema_id,
                 operations_v1.previous,
+                operations_v1.sorted_index,
                 operation_fields_v1.name,
                 operation_fields_v1.field_type,
                 operation_fields_v1.value,
@@ -277,6 +280,7 @@ impl OperationStore for SqlStore {
                     operations_v1.action,
                     operations_v1.schema_id,
                     operations_v1.previous,
+                    operations_v1.sorted_index,
                     operation_fields_v1.name,
                     operation_fields_v1.field_type,
                     operation_fields_v1.value,

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -311,8 +311,7 @@ fn group_and_parse_operation_rows(
     let mut current_operation_id = operation_rows.first().unwrap().operation_id.clone();
     let mut current_operation_rows = vec![];
 
-    let mut operation_rows_iter = operation_rows.into_iter();
-    while let Some(row) = operation_rows_iter.next() {
+    for row in operation_rows {
         if row.operation_id == current_operation_id {
             // If this row is part of the current operation push it to the current rows vec.
             current_operation_rows.push(row);
@@ -332,7 +331,7 @@ fn group_and_parse_operation_rows(
     // Parse all the operation rows into operations.
     grouped_operation_rows
         .into_iter()
-        .filter_map(|operation_rows| parse_operation_rows(operation_rows.to_owned()))
+        .filter_map(parse_operation_rows)
         .collect()
 }
 
@@ -593,7 +592,8 @@ mod tests {
 
             // The operations should be in their topologically sorted order.
             let operations = DocumentBuilder::from(&operations_by_document_id).operations();
-            let expected_operation_order = build_graph(&operations).unwrap().sort().unwrap().sorted();
+            let expected_operation_order =
+                build_graph(&operations).unwrap().sort().unwrap().sorted();
 
             assert_eq!(operations, expected_operation_order);
         });

--- a/aquadoggo/src/db/types/operation.rs
+++ b/aquadoggo/src/db/types/operation.rs
@@ -7,7 +7,7 @@ use p2panda_rs::operation::{OperationAction, OperationFields, OperationId, Opera
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::WithId;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct StorageOperation {
     /// The id of the document this operation is part of.
     pub(crate) document_id: DocumentId,

--- a/aquadoggo/src/db/types/operation.rs
+++ b/aquadoggo/src/db/types/operation.rs
@@ -32,6 +32,12 @@ pub struct StorageOperation {
 
     /// The public key of the key pair used to publish this operation.
     pub(crate) public_key: PublicKey,
+
+    /// Index for the position of this operation once topological sorting of the operation graph
+    /// has been performed.
+    ///
+    /// Is None when the operation has not been materialized into it's document yet.
+    pub(crate) sorted_index: Option<i32>,
 }
 
 impl WithPublicKey for StorageOperation {

--- a/aquadoggo/src/graphql/mutations/publish.rs
+++ b/aquadoggo/src/graphql/mutations/publish.rs
@@ -680,18 +680,6 @@ mod tests {
         },
         "Previous operation 0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543 not found in store"
     )]
-    #[case::claimed_log_id_does_not_match_expected(
-        &entry_signed_encoded_unvalidated(
-            1,
-            2,
-            None,
-            None,
-            Some(EncodedOperation::from_bytes(&OPERATION_ENCODED)),
-            key_pair(PRIVATE_KEY)
-        ).to_string(),
-        &OPERATION_ENCODED,
-        "Entry's claimed log id of 2 does not match expected next log id of 1 for given public key"
-    )]
     fn validation_of_entry_and_operation_values(
         #[case] entry_encoded: &str,
         #[case] encoded_operation: &[u8],

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -659,7 +659,7 @@ mod tests {
                 .unwrap();
 
             // Run a reduce task with the document id as input.
-            let input = TaskInput::new(Some(document_id.clone()), None);
+            let input = TaskInput::DocumentId(document_id.clone());
             assert!(reduce_task(node.context.clone(), input.clone())
                 .await
                 .is_ok());

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -276,7 +276,11 @@ mod tests {
 
     use p2panda_rs::document::materialization::build_graph;
     use p2panda_rs::document::traits::AsDocument;
-    use p2panda_rs::document::{Document, DocumentBuilder, DocumentId, DocumentViewId};
+    use p2panda_rs::document::{
+        Document, DocumentBuilder, DocumentId, DocumentViewFields, DocumentViewId,
+        DocumentViewValue,
+    };
+    use p2panda_rs::operation::traits::AsOperation;
     use p2panda_rs::operation::OperationValue;
     use p2panda_rs::schema::Schema;
     use p2panda_rs::storage_provider::traits::{DocumentStore, OperationStore};
@@ -287,6 +291,7 @@ mod tests {
     use p2panda_rs::test_utils::memory_store::helpers::{
         populate_store, send_to_store, PopulateStoreConfig,
     };
+    use p2panda_rs::WithId;
     use rstest::rstest;
 
     use crate::materializer::tasks::reduce_task;
@@ -598,6 +603,110 @@ mod tests {
             // is inserted
             let input = TaskInput::DocumentViewId(document.view_id().clone());
             assert!(reduce_task(node.context.clone(), input).await.is_ok());
+        })
+    }
+
+    #[rstest]
+    fn updates_operations_sorted_index(
+        schema: Schema,
+        #[from(populate_store_config)]
+        #[with(
+            3,
+            1,
+            1,
+            false,
+            constants::schema(),
+            constants::test_fields(),
+            constants::test_fields()
+        )]
+        config: PopulateStoreConfig,
+    ) {
+        test_runner(move |node: TestNode| async move {
+            // Populate the store with some entries and operations but DON'T materialise any resulting documents.
+            let (key_pairs, document_ids) = populate_store(&node.context.store, &config).await;
+            let document_id = document_ids
+                .get(0)
+                .expect("There should be at least one document id");
+
+            let key_pair = key_pairs
+                .get(0)
+                .expect("There should be at least one key_pair");
+
+            // Now we create and insert an UPDATE operation for this document which is pointing at
+            // the root CREATE operation.
+            let (_, _) = send_to_store(
+                &node.context.store,
+                &operation(
+                    Some(operation_fields(vec![(
+                        "username",
+                        OperationValue::String("hello".to_string()),
+                    )])),
+                    Some(document_id.as_str().parse().unwrap()),
+                    schema.id().to_owned(),
+                ),
+                &schema,
+                key_pair,
+            )
+            .await
+            .unwrap();
+
+            // Before running the reduce task retrieve the operations. These should not be in
+            // their topologically sorted order.
+            let pre_materialization_operations = node
+                .context
+                .store
+                .get_operations_by_document_id(&document_id)
+                .await
+                .unwrap();
+
+            // Run a reduce task with the document id as input.
+            let input = TaskInput::new(Some(document_id.clone()), None);
+            assert!(reduce_task(node.context.clone(), input.clone())
+                .await
+                .is_ok());
+
+            // Retrieve the operations again, they should now be in their topologically sorted order.
+            let post_materialization_operations = node
+                .context
+                .store
+                .get_operations_by_document_id(&document_id)
+                .await
+                .unwrap();
+
+            // Check we got 4 operations both times.
+            assert_eq!(pre_materialization_operations.len(), 4);
+            assert_eq!(post_materialization_operations.len(), 4);
+            // Check the ordering is different.
+            assert_ne!(
+                pre_materialization_operations,
+                post_materialization_operations
+            );
+
+            // The first operation should be a CREATE.
+            let create_operation = post_materialization_operations.first().unwrap();
+            assert!(create_operation.is_create());
+
+            // Reduce the operations to a document view.
+            let mut document_view_fields = DocumentViewFields::new();
+            for operation in post_materialization_operations {
+                let fields = operation.fields().unwrap();
+                for (key, value) in fields.iter() {
+                    let document_view_value = DocumentViewValue::new(operation.id(), value);
+                    document_view_fields.insert(key, document_view_value);
+                }
+            }
+
+            // Retrieve the expected document from the store.
+            let expected_document = node
+                .context
+                .store
+                .get_document(document_id)
+                .await
+                .unwrap()
+                .unwrap();
+
+            // The fields should be the same.
+            assert_eq!(document_view_fields, *expected_document.fields().unwrap());
         })
     }
 }

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -3,6 +3,7 @@
 use std::convert::TryFrom;
 
 use log::{debug, info, trace};
+use p2panda_rs::document::materialization::build_graph;
 use p2panda_rs::document::traits::AsDocument;
 use p2panda_rs::document::{Document, DocumentBuilder, DocumentId, DocumentViewId};
 use p2panda_rs::operation::traits::{AsOperation, WithPublicKey};
@@ -206,6 +207,13 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
 
             if document_view_exists {
                 return Ok(None);
+            };
+
+            let operations = DocumentBuilder::from(operations).operations();
+            let sorted_operations = build_graph(&operations).unwrap().sort().unwrap().sorted();
+
+            for (index, (id, _, _)) in sorted_operations.iter().enumerate() {
+                // @TODO: Update operations in document with correct sorted index
             }
 
             // Insert this document into storage. If it already existed, this will update it's

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -216,10 +216,9 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
             // Iterate over the sorted document operations and update their sorted index on the
             // operations_v1 table.
             for (index, (operation_id, _, _)) in sorted_operations.iter().enumerate() {
-                let sorted_index = { index + 1 } as i32;
                 context
                     .store
-                    .update_operation_index(operation_id, sorted_index)
+                    .update_operation_index(operation_id, index as i32)
                     .await
                     .map_err(|err| TaskError::Critical(err.to_string()))?;
             }

--- a/aquadoggo/src/replication/errors.rs
+++ b/aquadoggo/src/replication/errors.rs
@@ -45,7 +45,7 @@ pub enum IngestError {
     DecodeOperation(#[from] p2panda_rs::operation::error::DecodeOperationError),
 
     #[error("Duplicate entry received: {0}")]
-    DuplicateEntry(Hash)
+    DuplicateEntry(Hash),
 }
 
 #[derive(Error, Debug)]

--- a/aquadoggo/src/replication/errors.rs
+++ b/aquadoggo/src/replication/errors.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use p2panda_rs::hash::Hash;
 use thiserror::Error;
 
 use crate::replication::TargetSet;
@@ -42,6 +43,9 @@ pub enum IngestError {
 
     #[error("Decoding operation failed: {0}")]
     DecodeOperation(#[from] p2panda_rs::operation::error::DecodeOperationError),
+
+    #[error("Duplicate entry received: {0}")]
+    DuplicateEntry(Hash)
 }
 
 #[derive(Error, Debug)]

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -2,13 +2,12 @@
 
 use log::trace;
 use p2panda_rs::api::publish;
-use p2panda_rs::entry::decode::decode_entry;
-use p2panda_rs::entry::traits::{AsEncodedEntry, AsEntry};
+use p2panda_rs::entry::traits::AsEncodedEntry;
 use p2panda_rs::entry::EncodedEntry;
 use p2panda_rs::operation::decode::decode_operation;
 use p2panda_rs::operation::traits::Schematic;
 use p2panda_rs::operation::{EncodedOperation, OperationId};
-use p2panda_rs::Human;
+use p2panda_rs::storage_provider::traits::EntryStore;
 
 use crate::bus::{ServiceMessage, ServiceSender};
 use crate::db::SqlStore;
@@ -41,8 +40,19 @@ impl SyncIngest {
             Mode::Document => {
                 trace!("Received entry and operation: {}", encoded_entry.hash());
 
-                let operation = decode_operation(&encoded_operation)?;
+                // Check if we already have this entry. This can happen if another peer sent it to
+                // us during a concurrent sync session.
+                let is_duplicate = store
+                    .get_entry(&encoded_entry.hash())
+                    .await
+                    .expect("Fatal database error")
+                    .is_some();
+                if is_duplicate {
+                    return Err(IngestError::DuplicateEntry(encoded_entry.hash()));
+                }
 
+                // Make sure we have the relevant schema materialized on the node.
+                let operation = decode_operation(&encoded_operation)?;
                 let schema = self
                     .schema_provider
                     .get(operation.schema_id())

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -1,22 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use log::trace;
-use p2panda_rs::api::validation::{
-    ensure_document_not_deleted, get_checked_document_id_for_view_id, get_expected_skiplink,
-    is_next_seq_num, validate_claimed_schema_id,
-};
-use p2panda_rs::api::{publish, DomainError};
-use p2panda_rs::document::DocumentId;
+use p2panda_rs::api::publish;
 use p2panda_rs::entry::decode::decode_entry;
 use p2panda_rs::entry::traits::{AsEncodedEntry, AsEntry};
 use p2panda_rs::entry::EncodedEntry;
 use p2panda_rs::operation::decode::decode_operation;
-use p2panda_rs::operation::plain::PlainOperation;
-use p2panda_rs::operation::traits::{AsOperation, Schematic};
-use p2panda_rs::operation::validate::validate_operation_with_entry;
-use p2panda_rs::operation::{EncodedOperation, Operation, OperationAction, OperationId};
-use p2panda_rs::schema::Schema;
-use p2panda_rs::storage_provider::traits::{EntryStore, LogStore, OperationStore};
+use p2panda_rs::operation::traits::Schematic;
+use p2panda_rs::operation::{EncodedOperation, OperationId};
 use p2panda_rs::Human;
 
 use crate::bus::{ServiceMessage, ServiceSender};
@@ -24,92 +15,6 @@ use crate::db::SqlStore;
 use crate::replication::errors::IngestError;
 use crate::replication::Mode;
 use crate::schema::SchemaProvider;
-
-// @TODO: This method exists in `p2panda-rs`, we need to make it public there
-async fn validate_entry_and_operation<S: EntryStore + OperationStore + LogStore>(
-    store: &S,
-    schema: &Schema,
-    entry: &impl AsEntry,
-    encoded_entry: &impl AsEncodedEntry,
-    plain_operation: &PlainOperation,
-    encoded_operation: &EncodedOperation,
-) -> Result<(Operation, OperationId), DomainError> {
-    // Verify that the claimed seq num matches the expected seq num for this public_key and log.
-    let latest_entry = store
-        .get_latest_entry(entry.public_key(), entry.log_id())
-        .await?;
-    let latest_seq_num = latest_entry.as_ref().map(|entry| entry.seq_num());
-    is_next_seq_num(latest_seq_num, entry.seq_num())?;
-
-    // If a skiplink is claimed, get the expected skiplink from the database, errors if it can't be found.
-    let skiplink = match entry.skiplink() {
-        Some(_) => Some(
-            get_expected_skiplink(store, entry.public_key(), entry.log_id(), entry.seq_num())
-                .await?,
-        ),
-        None => None,
-    };
-
-    // Construct params as `validate_operation_with_entry` expects.
-    let skiplink_params = skiplink.as_ref().map(|entry| {
-        let hash = entry.hash();
-        (entry.clone(), hash)
-    });
-
-    // The backlink for this entry is the latest entry from this public key's log.
-    let backlink_params = latest_entry.as_ref().map(|entry| {
-        let hash = entry.hash();
-        (entry.clone(), hash)
-    });
-
-    // Perform validation of the entry and it's operation.
-    let (operation, operation_id) = validate_operation_with_entry(
-        entry,
-        encoded_entry,
-        skiplink_params.as_ref().map(|(entry, hash)| (entry, hash)),
-        backlink_params.as_ref().map(|(entry, hash)| (entry, hash)),
-        plain_operation,
-        encoded_operation,
-        schema,
-    )?;
-
-    Ok((operation, operation_id))
-}
-
-// @TODO: This method exists in `p2panda-rs`, we need to make it public there
-async fn determine_document_id<S: OperationStore>(
-    store: &S,
-    operation: &impl AsOperation,
-    operation_id: &OperationId,
-) -> Result<DocumentId, DomainError> {
-    let document_id = match operation.action() {
-        OperationAction::Create => {
-            // Derive the document id for this new document.
-            Ok::<DocumentId, DomainError>(DocumentId::new(operation_id))
-        }
-        _ => {
-            // We can unwrap previous operations here as we know all UPDATE and DELETE operations contain them.
-            let previous = operation.previous().unwrap();
-
-            // Validate claimed schema for this operation matches the expected found in the
-            // previous operations.
-            validate_claimed_schema_id(store, &operation.schema_id(), &previous).await?;
-
-            // Get the document_id for the document_view_id contained in previous operations.
-            // This performs several validation steps (check method doc string).
-            let document_id = get_checked_document_id_for_view_id(store, &previous).await?;
-
-            Ok(document_id)
-        }
-    }?;
-
-    // Ensure the document isn't deleted.
-    ensure_document_not_deleted(store, &document_id)
-        .await
-        .map_err(|_| DomainError::DeletedDocument)?;
-
-    Ok(document_id)
-}
 
 #[derive(Debug, Clone)]
 pub struct SyncIngest {
@@ -133,73 +38,6 @@ impl SyncIngest {
         encoded_operation: &EncodedOperation,
     ) -> Result<(), IngestError> {
         match mode {
-            Mode::LogHeight => {
-                let entry = decode_entry(encoded_entry)?;
-
-                trace!(
-                    "Received entry {:?} for log {:?} and {}",
-                    entry.seq_num(),
-                    entry.log_id(),
-                    entry.public_key().display()
-                );
-
-                let plain_operation = decode_operation(encoded_operation)?;
-
-                let schema = self
-                    .schema_provider
-                    .get(plain_operation.schema_id())
-                    .await
-                    .ok_or_else(|| IngestError::UnsupportedSchema)?;
-
-                let (operation, operation_id) = validate_entry_and_operation(
-                    store,
-                    &schema,
-                    &entry,
-                    encoded_entry,
-                    &plain_operation,
-                    encoded_operation,
-                )
-                .await?;
-
-                let document_id = determine_document_id(store, &operation, &operation_id).await?;
-
-                // If the entries' seq num is 1 we insert a new log here
-                if entry.seq_num().is_first() {
-                    store
-                        .insert_log(
-                            entry.log_id(),
-                            entry.public_key(),
-                            Schematic::schema_id(&operation),
-                            &document_id,
-                        )
-                        .await
-                        .expect("Fatal database error");
-                }
-
-                store
-                    .insert_entry(&entry, encoded_entry, Some(encoded_operation))
-                    .await
-                    .expect("Fatal database error");
-
-                store
-                    .insert_operation(&operation_id, entry.public_key(), &operation, &document_id)
-                    .await
-                    .expect("Fatal database error");
-
-                // Inform other services about received data
-                let operation_id: OperationId = encoded_entry.hash().into();
-
-                if self
-                    .tx
-                    .send(ServiceMessage::NewOperation(operation_id))
-                    .is_err()
-                {
-                    // Silently fail here as we don't mind if there are no subscribers. We have
-                    // tests in other places to check if messages arrive.
-                }
-
-                Ok(())
-            }
             Mode::Document => {
                 let operation = decode_operation(&encoded_operation)?;
 
@@ -242,7 +80,12 @@ impl SyncIngest {
 
                 Ok(())
             }
-            _ => panic!("Unsupported mode"),
+            _ => {
+                // @TODO: For now we just don't ingest any enries arriving via other modes, we can
+                // remove support for LogHeight replication completely if we want to migrate to
+                // the new Document approach.
+                Ok(())
+            }
         }
     }
 }

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -39,6 +39,8 @@ impl SyncIngest {
     ) -> Result<(), IngestError> {
         match mode {
             Mode::Document => {
+                trace!("Received entry and operation: {}", encoded_entry.hash());
+
                 let operation = decode_operation(&encoded_operation)?;
 
                 let schema = self

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -59,14 +59,7 @@ impl SyncIngest {
         // PUBLISH THE ENTRY AND OPERATION //
         /////////////////////////////////////
 
-        let _ = publish(
-            store,
-            &schema,
-            encoded_entry,
-            &operation,
-            encoded_operation,
-        )
-        .await?;
+        let _ = publish(store, &schema, encoded_entry, &operation, encoded_operation).await?;
 
         ////////////////////////////////////////
         // SEND THE OPERATION TO MATERIALIZER //

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -32,7 +32,6 @@ impl SyncIngest {
     pub async fn handle_entry(
         &self,
         store: &SqlStore,
-        mode: Mode,
         encoded_entry: &EncodedEntry,
         encoded_operation: &EncodedOperation,
     ) -> Result<(), IngestError> {
@@ -121,7 +120,6 @@ mod tests {
             let result = ingest
                 .handle_entry(
                     &node.context.store,
-                    Mode::LogHeight,
                     &encoded_entry,
                     &encoded_operation,
                 )
@@ -132,7 +130,6 @@ mod tests {
             let result = ingest
                 .handle_entry(
                     &node.context.store,
-                    Mode::LogHeight,
                     &encoded_entry,
                     &encoded_operation,
                 )

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -460,7 +460,6 @@ where
                 .ingest
                 .handle_entry(
                     &self.store,
-                    session.mode(),
                     entry_bytes,
                     // @TODO: This should handle entries with removed payloads
                     operation_bytes

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -19,7 +19,7 @@ use super::errors::IngestError;
 
 pub const INITIAL_SESSION_ID: SessionId = 0;
 
-pub const SUPPORTED_MODES: [Mode; 2] = [Mode::LogHeight, Mode::Document];
+pub const SUPPORTED_MODES: [Mode; 1] = [Mode::LogHeight];
 
 pub const SUPPORT_LIVE_MODE: bool = false;
 
@@ -529,7 +529,7 @@ mod tests {
     use tokio::sync::broadcast;
 
     use crate::replication::errors::{DuplicateSessionRequestError, ReplicationError};
-    use crate::replication::message::{Message, MessageType, HAVE_DOCUMENTS_TYPE, HAVE_TYPE, SYNC_DONE_TYPE};
+    use crate::replication::message::{Message, MessageType, HAVE_TYPE, SYNC_DONE_TYPE};
     use crate::replication::{Mode, SyncIngest, SyncMessage, TargetSet};
     use crate::schema::SchemaProvider;
     use crate::test_utils::helpers::random_target_set;
@@ -1061,7 +1061,6 @@ mod tests {
     // ◄────────────────────┘
     #[rstest]
     #[case(Mode::LogHeight, Message::Have(vec![]), HAVE_TYPE)]
-    #[case(Mode::Document, Message::HaveDocuments(vec![]), HAVE_DOCUMENTS_TYPE)]
     fn sync_lifetime(
         #[from(populate_store_config)]
         #[with(2, 1, 3)]

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -478,7 +478,7 @@ where
             // closed. This is expected behavior which may occur when concurrent sync sessions
             // are running. We catch and handle this error here, returning an Ok result.
             if let Err(IngestError::DuplicateEntry(_)) = res {
-                return ok_result
+                return ok_result;
             }
 
             // Return any other errors.

--- a/aquadoggo/src/replication/session.rs
+++ b/aquadoggo/src/replication/session.rs
@@ -177,7 +177,7 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-    use p2panda_rs::test_utils::memory_store::helpers::PopulateStoreConfig;
+    use p2panda_rs::test_utils::memory_store::helpers::{PopulateStoreConfig, populate_store};
     use rstest::rstest;
 
     use crate::replication::manager::INITIAL_SESSION_ID;

--- a/aquadoggo/src/replication/session.rs
+++ b/aquadoggo/src/replication/session.rs
@@ -177,13 +177,16 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-    use p2panda_rs::test_utils::memory_store::helpers::{PopulateStoreConfig, populate_store};
+    use p2panda_rs::test_utils::memory_store::helpers::{populate_store, PopulateStoreConfig};
     use rstest::rstest;
 
     use crate::replication::manager::INITIAL_SESSION_ID;
     use crate::replication::{Message, Mode, SessionState, TargetSet};
     use crate::test_utils::helpers::random_target_set;
-    use crate::test_utils::{populate_store_config, test_runner, TestNode, populate_and_materialize, test_runner_with_manager, TestNodeManager};
+    use crate::test_utils::{
+        populate_and_materialize, populate_store_config, test_runner, test_runner_with_manager,
+        TestNode, TestNodeManager,
+    };
 
     use super::Session;
 
@@ -221,7 +224,7 @@ mod tests {
         #[with(5, 2, 1)]
         config: PopulateStoreConfig,
     ) {
-        test_runner_with_manager(move |manager: TestNodeManager | async move {
+        test_runner_with_manager(move |manager: TestNodeManager| async move {
             let target_set = TargetSet::new(&vec![config.schema.id().to_owned()]);
             let mut session = Session::new(
                 &INITIAL_SESSION_ID,

--- a/aquadoggo/src/replication/session.rs
+++ b/aquadoggo/src/replication/session.rs
@@ -177,7 +177,7 @@ impl Session {
 
 #[cfg(test)]
 mod tests {
-    use p2panda_rs::test_utils::memory_store::helpers::{populate_store, PopulateStoreConfig};
+    use p2panda_rs::test_utils::memory_store::helpers::PopulateStoreConfig;
     use rstest::rstest;
 
     use crate::replication::manager::INITIAL_SESSION_ID;

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 env_logger = "0.9.0"
 hex = "0.4.3"
 libp2p = "0.52.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a535ee229b367c79f18a50626c6bcab61581e32b" }
 tokio = { version = "=1.28.2", features = ["full"] }
 
 [dependencies.aquadoggo]

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -25,8 +25,8 @@ clap = { version = "4.1.8", features = ["derive"] }
 env_logger = "0.9.0"
 hex = "0.4.3"
 libp2p = "0.52.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "ae60bf754a60a1daf9c6862e9ae51ee7501b007f" }
-tokio = { version = "1.28.2", features = ["full"] }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "b0d8182908b14f6ac492d3ed4edbbdb690ce3e7b" }
+tokio = { version = "=1.28.2", features = ["full"] }
 
 [dependencies.aquadoggo]
 version = "~0.4.0"


### PR DESCRIPTION
`LogHeightStrategy` sends `entries` and `operations` in their topologically sorted order and `Ingest` expects them to arrive in this way.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
