### PR TITLE
Maintain sorted operation indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Naive protocol replication [#380](https://github.com/p2panda/aquadoggo/pull/380)
 - Integrate replication manager with networking stack [#387](https://github.com/p2panda/aquadoggo/pull/387) 🥞
 - Reverse lookup for pinned relations in dependency task  [#434](https://github.com/p2panda/aquadoggo/pull/434)
+- Persist and maintain index of operation's position in document [#438](https://github.com/p2panda/aquadoggo/pull/438) 
 
 ### Changed
 

--- a/aquadoggo/migrations/20230523135826_alter-operations.sql
+++ b/aquadoggo/migrations/20230523135826_alter-operations.sql
@@ -1,3 +1,3 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
-ALTER TABLE operations_v1 ADD COLUMN sorted_index NUMERIC;
+ALTER TABLE operations_v1 ADD COLUMN sorted_index INT;

--- a/aquadoggo/migrations/20230523135826_alter-operations.sql
+++ b/aquadoggo/migrations/20230523135826_alter-operations.sql
@@ -1,0 +1,3 @@
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+ALTER TABLE operations_v1 ADD COLUMN sorted_index NUMERIC;

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -26,6 +26,15 @@ pub struct OperationRow {
     /// separator.
     pub previous: Option<String>,
 
+    /// Index for the position of this operation once topological sorting of the operation graph
+    /// has been performed.
+    /// 
+    /// This is an option as when an operation which is not appended to the tip of a
+    /// document graph is handled then a `reduce` materialization task will be issued and all
+    /// indexes for operations in the effected document re-calculated.
+    /// 
+    /// If this value is None we can assume the operation has not been processed yet and we are
+    /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,
 }
 
@@ -102,5 +111,14 @@ pub struct OperationFieldsJoinedRow {
     /// field.
     pub list_index: Option<i32>,
 
+    /// Index for the position of this operation once topological sorting of the operation graph
+    /// has been performed.
+    /// 
+    /// This is an option as when an operation which is not appended to the tip of a
+    /// document graph is handled then a `reduce` materialization task will be issued and all
+    /// indexes for operations in the effected document re-calculated.
+    /// 
+    /// If this value is None we can assume the operation has not been processed yet and we are
+    /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,
 }

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -25,6 +25,8 @@ pub struct OperationRow {
     /// The previous operations of this operation concatenated into string format with `_`
     /// separator.
     pub previous: Option<String>,
+
+    pub sorted_index: Option<i32>,
 }
 
 /// A struct representing a single operation field row as it is inserted in the database.
@@ -99,4 +101,6 @@ pub struct OperationFieldsJoinedRow {
     /// This numeric value is a simple list index to represent multiple values within one operation
     /// field.
     pub list_index: Option<i32>,
+
+    pub sorted_index: Option<i32>,
 }

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -28,11 +28,11 @@ pub struct OperationRow {
 
     /// Index for the position of this operation once topological sorting of the operation graph
     /// has been performed.
-    /// 
+    ///
     /// This is an option as when an operation which is not appended to the tip of a
     /// document graph is handled then a `reduce` materialization task will be issued and all
     /// indexes for operations in the effected document re-calculated.
-    /// 
+    ///
     /// If this value is None we can assume the operation has not been processed yet and we are
     /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,
@@ -113,11 +113,11 @@ pub struct OperationFieldsJoinedRow {
 
     /// Index for the position of this operation once topological sorting of the operation graph
     /// has been performed.
-    /// 
+    ///
     /// This is an option as when an operation which is not appended to the tip of a
     /// document graph is handled then a `reduce` materialization task will be issued and all
     /// indexes for operations in the effected document re-calculated.
-    /// 
+    ///
     /// If this value is None we can assume the operation has not been processed yet and we are
     /// waiting for the reduce task to complete.
     pub sorted_index: Option<i32>,

--- a/aquadoggo/src/db/models/operation.rs
+++ b/aquadoggo/src/db/models/operation.rs
@@ -26,15 +26,10 @@ pub struct OperationRow {
     /// separator.
     pub previous: Option<String>,
 
-    /// Index for the position of this operation once topological sorting of the operation graph
-    /// has been performed.
+    /// Index of this operation once topological sorting of the operation graph has been performed.
     ///
-    /// This is an option as when an operation which is not appended to the tip of a
-    /// document graph is handled then a `reduce` materialization task will be issued and all
-    /// indexes for operations in the effected document re-calculated.
-    ///
-    /// If this value is None we can assume the operation has not been processed yet and we are
-    /// waiting for the reduce task to complete.
+    /// If this value is `None` we can assume the operation has not been processed yet and we are
+    /// waiting for the `reduce` task to complete materialization.
     pub sorted_index: Option<i32>,
 }
 
@@ -111,14 +106,9 @@ pub struct OperationFieldsJoinedRow {
     /// field.
     pub list_index: Option<i32>,
 
-    /// Index for the position of this operation once topological sorting of the operation graph
-    /// has been performed.
+    /// Index of this operation once topological sorting of the operation graph has been performed.
     ///
-    /// This is an option as when an operation which is not appended to the tip of a
-    /// document graph is handled then a `reduce` materialization task will be issued and all
-    /// indexes for operations in the effected document re-calculated.
-    ///
-    /// If this value is None we can assume the operation has not been processed yet and we are
-    /// waiting for the reduce task to complete.
+    /// If this value is `None` we can assume the operation has not been processed yet and we are
+    /// waiting for the `reduce` task to complete materialization.
     pub sorted_index: Option<i32>,
 }

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -188,6 +188,7 @@ pub fn parse_operation_rows(
         previous: operation.previous(),
         fields: operation.fields(),
         public_key,
+        sorted_index,
     };
 
     Some(operation)

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -35,6 +35,7 @@ pub fn parse_operation_rows(
     let public_key = PublicKey::new(&first_row.public_key).unwrap();
     let operation_id = first_row.operation_id.parse().unwrap();
     let document_id = first_row.document_id.parse().unwrap();
+    let sorted_index = first_row.sorted_index;
 
     let mut relation_lists: BTreeMap<String, Vec<DocumentId>> = BTreeMap::new();
     let mut pinned_relation_lists: BTreeMap<String, Vec<DocumentViewId>> = BTreeMap::new();

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -431,6 +431,7 @@ mod tests {
                 field_type: Some("int".to_string()),
                 value: Some("28".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -449,6 +450,7 @@ mod tests {
                 field_type: Some("float".to_string()),
                 value: Some("3.5".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -467,6 +469,7 @@ mod tests {
                 field_type: Some("bool".to_string()),
                 value: Some("false".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -488,6 +491,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -509,6 +513,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(1),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -530,6 +535,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -551,6 +557,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(1),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -572,6 +579,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -593,6 +601,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(1),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -614,6 +623,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -635,6 +645,7 @@ mod tests {
                         .to_string(),
                 ),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -653,6 +664,7 @@ mod tests {
                 field_type: Some("str".to_string()),
                 value: Some("bubu".to_string()),
                 list_index: Some(0),
+                sorted_index: None,
             },
             OperationFieldsJoinedRow {
                 public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
@@ -671,6 +683,7 @@ mod tests {
                 field_type: Some("pinned_relation_list".to_string()),
                 value: None,
                 list_index: Some(0),
+                sorted_index: None,
             },
         ];
 

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::collections::BTreeMap;
 use std::fmt::Display;
 
 use async_trait::async_trait;

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -58,10 +58,10 @@ impl OperationStore for SqlStore {
         Ok(document_id.map(|id_str| id_str.parse().unwrap()))
     }
 
-    /// Insert an operation into storage along with the `PublicKey` of the author who created it the 
+    /// Insert an operation into storage along with the `PublicKey` of the author who created it the
     /// `DocumentId` of the document it's part of and it's `OperationId` derived from the hash of
     /// the entry it was published with.
-    /// 
+    ///
     /// The `sorted_index` of the inserted operation will be set to `null` as this value is only
     /// available once materialization has occurred. Use `update_operation_index` to set this
     /// value.
@@ -273,7 +273,7 @@ impl SqlStore {
     }
 
     /// Insert an operation as well as the index for it's position in the document after
-    /// materialization has occurred. 
+    /// materialization has occurred.
     async fn insert_operation_with_index(
         &self,
         id: &OperationId,

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -274,7 +274,7 @@ impl SqlStore {
         Ok(())
     }
 
-    pub async fn insert_operation_with_index(
+    async fn insert_operation_with_index(
         &self,
         id: &OperationId,
         public_key: &PublicKey,

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -96,10 +96,11 @@ impl OperationStore for SqlStore {
                     operation_id,
                     action,
                     schema_id,
-                    previous
+                    previous,
+                    sorted_index
                 )
             VALUES
-                ($1, $2, $3, $4, $5, $6)
+                ($1, $2, $3, $4, $5, $6, null)
             ",
         )
         .bind(public_key.to_string())
@@ -183,6 +184,7 @@ impl OperationStore for SqlStore {
                 operations_v1.action,
                 operations_v1.schema_id,
                 operations_v1.previous,
+                operations_v1.sorted_index,
                 operation_fields_v1.name,
                 operation_fields_v1.field_type,
                 operation_fields_v1.value,
@@ -221,6 +223,7 @@ impl OperationStore for SqlStore {
                 operations_v1.action,
                 operations_v1.schema_id,
                 operations_v1.previous,
+                operations_v1.sorted_index,
                 operation_fields_v1.name,
                 operation_fields_v1.field_type,
                 operation_fields_v1.value,
@@ -277,6 +280,7 @@ impl OperationStore for SqlStore {
                     operations_v1.action,
                     operations_v1.schema_id,
                     operations_v1.previous,
+                    operations_v1.sorted_index,
                     operation_fields_v1.name,
                     operation_fields_v1.field_type,
                     operation_fields_v1.value,

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -311,8 +311,7 @@ fn group_and_parse_operation_rows(
     let mut current_operation_id = operation_rows.first().unwrap().operation_id.clone();
     let mut current_operation_rows = vec![];
 
-    let mut operation_rows_iter = operation_rows.into_iter();
-    while let Some(row) = operation_rows_iter.next() {
+    for row in operation_rows {
         if row.operation_id == current_operation_id {
             // If this row is part of the current operation push it to the current rows vec.
             current_operation_rows.push(row);
@@ -332,7 +331,7 @@ fn group_and_parse_operation_rows(
     // Parse all the operation rows into operations.
     grouped_operation_rows
         .into_iter()
-        .filter_map(|operation_rows| parse_operation_rows(operation_rows.to_owned()))
+        .filter_map(parse_operation_rows)
         .collect()
 }
 
@@ -593,7 +592,8 @@ mod tests {
 
             // The operations should be in their topologically sorted order.
             let operations = DocumentBuilder::from(&operations_by_document_id).operations();
-            let expected_operation_order = build_graph(&operations).unwrap().sort().unwrap().sorted();
+            let expected_operation_order =
+                build_graph(&operations).unwrap().sort().unwrap().sorted();
 
             assert_eq!(operations, expected_operation_order);
         });

--- a/aquadoggo/src/db/types/operation.rs
+++ b/aquadoggo/src/db/types/operation.rs
@@ -36,7 +36,7 @@ pub struct StorageOperation {
     /// Index for the position of this operation once topological sorting of the operation graph
     /// has been performed.
     ///
-    /// Is None when the operation has not been materialized into it's document yet.
+    /// Is `None` when the operation has not been materialized into it's document yet.
     pub(crate) sorted_index: Option<i32>,
 }
 

--- a/aquadoggo/src/db/types/operation.rs
+++ b/aquadoggo/src/db/types/operation.rs
@@ -7,7 +7,7 @@ use p2panda_rs::operation::{OperationAction, OperationFields, OperationId, Opera
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::WithId;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct StorageOperation {
     /// The id of the document this operation is part of.
     pub(crate) document_id: DocumentId,

--- a/aquadoggo/src/db/types/operation.rs
+++ b/aquadoggo/src/db/types/operation.rs
@@ -32,6 +32,12 @@ pub struct StorageOperation {
 
     /// The public key of the key pair used to publish this operation.
     pub(crate) public_key: PublicKey,
+
+    /// Index for the position of this operation once topological sorting of the operation graph
+    /// has been performed.
+    ///
+    /// Is None when the operation has not been materialized into it's document yet.
+    pub(crate) sorted_index: Option<i32>,
 }
 
 impl WithPublicKey for StorageOperation {

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -659,7 +659,7 @@ mod tests {
                 .unwrap();
 
             // Run a reduce task with the document id as input.
-            let input = TaskInput::new(Some(document_id.clone()), None);
+            let input = TaskInput::DocumentId(document_id.clone());
             assert!(reduce_task(node.context.clone(), input.clone())
                 .await
                 .is_ok());

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -276,7 +276,11 @@ mod tests {
 
     use p2panda_rs::document::materialization::build_graph;
     use p2panda_rs::document::traits::AsDocument;
-    use p2panda_rs::document::{Document, DocumentBuilder, DocumentId, DocumentViewId};
+    use p2panda_rs::document::{
+        Document, DocumentBuilder, DocumentId, DocumentViewFields, DocumentViewId,
+        DocumentViewValue,
+    };
+    use p2panda_rs::operation::traits::AsOperation;
     use p2panda_rs::operation::OperationValue;
     use p2panda_rs::schema::Schema;
     use p2panda_rs::storage_provider::traits::{DocumentStore, OperationStore};
@@ -287,6 +291,7 @@ mod tests {
     use p2panda_rs::test_utils::memory_store::helpers::{
         populate_store, send_to_store, PopulateStoreConfig,
     };
+    use p2panda_rs::WithId;
     use rstest::rstest;
 
     use crate::materializer::tasks::reduce_task;
@@ -598,6 +603,110 @@ mod tests {
             // is inserted
             let input = TaskInput::DocumentViewId(document.view_id().clone());
             assert!(reduce_task(node.context.clone(), input).await.is_ok());
+        })
+    }
+
+    #[rstest]
+    fn updates_operations_sorted_index(
+        schema: Schema,
+        #[from(populate_store_config)]
+        #[with(
+            3,
+            1,
+            1,
+            false,
+            constants::schema(),
+            constants::test_fields(),
+            constants::test_fields()
+        )]
+        config: PopulateStoreConfig,
+    ) {
+        test_runner(move |node: TestNode| async move {
+            // Populate the store with some entries and operations but DON'T materialise any resulting documents.
+            let (key_pairs, document_ids) = populate_store(&node.context.store, &config).await;
+            let document_id = document_ids
+                .get(0)
+                .expect("There should be at least one document id");
+
+            let key_pair = key_pairs
+                .get(0)
+                .expect("There should be at least one key_pair");
+
+            // Now we create and insert an UPDATE operation for this document which is pointing at
+            // the root CREATE operation.
+            let (_, _) = send_to_store(
+                &node.context.store,
+                &operation(
+                    Some(operation_fields(vec![(
+                        "username",
+                        OperationValue::String("hello".to_string()),
+                    )])),
+                    Some(document_id.as_str().parse().unwrap()),
+                    schema.id().to_owned(),
+                ),
+                &schema,
+                key_pair,
+            )
+            .await
+            .unwrap();
+
+            // Before running the reduce task retrieve the operations. These should not be in
+            // their topologically sorted order.
+            let pre_materialization_operations = node
+                .context
+                .store
+                .get_operations_by_document_id(&document_id)
+                .await
+                .unwrap();
+
+            // Run a reduce task with the document id as input.
+            let input = TaskInput::new(Some(document_id.clone()), None);
+            assert!(reduce_task(node.context.clone(), input.clone())
+                .await
+                .is_ok());
+
+            // Retrieve the operations again, they should now be in their topologically sorted order.
+            let post_materialization_operations = node
+                .context
+                .store
+                .get_operations_by_document_id(&document_id)
+                .await
+                .unwrap();
+
+            // Check we got 4 operations both times.
+            assert_eq!(pre_materialization_operations.len(), 4);
+            assert_eq!(post_materialization_operations.len(), 4);
+            // Check the ordering is different.
+            assert_ne!(
+                pre_materialization_operations,
+                post_materialization_operations
+            );
+
+            // The first operation should be a CREATE.
+            let create_operation = post_materialization_operations.first().unwrap();
+            assert!(create_operation.is_create());
+
+            // Reduce the operations to a document view.
+            let mut document_view_fields = DocumentViewFields::new();
+            for operation in post_materialization_operations {
+                let fields = operation.fields().unwrap();
+                for (key, value) in fields.iter() {
+                    let document_view_value = DocumentViewValue::new(operation.id(), value);
+                    document_view_fields.insert(key, document_view_value);
+                }
+            }
+
+            // Retrieve the expected document from the store.
+            let expected_document = node
+                .context
+                .store
+                .get_document(document_id)
+                .await
+                .unwrap()
+                .unwrap();
+
+            // The fields should be the same.
+            assert_eq!(document_view_fields, *expected_document.fields().unwrap());
         })
     }
 }

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -3,6 +3,7 @@
 use std::convert::TryFrom;
 
 use log::{debug, info, trace};
+use p2panda_rs::document::materialization::build_graph;
 use p2panda_rs::document::traits::AsDocument;
 use p2panda_rs::document::{Document, DocumentBuilder, DocumentId, DocumentViewId};
 use p2panda_rs::operation::traits::{AsOperation, WithPublicKey};
@@ -206,6 +207,13 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
 
             if document_view_exists {
                 return Ok(None);
+            };
+
+            let operations = DocumentBuilder::from(operations).operations();
+            let sorted_operations = build_graph(&operations).unwrap().sort().unwrap().sorted();
+
+            for (index, (id, _, _)) in sorted_operations.iter().enumerate() {
+                // @TODO: Update operations in document with correct sorted index
             }
 
             // Insert this document into storage. If it already existed, this will update it's

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -216,10 +216,9 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
             // Iterate over the sorted document operations and update their sorted index on the
             // operations_v1 table.
             for (index, (operation_id, _, _)) in sorted_operations.iter().enumerate() {
-                let sorted_index = { index + 1 } as i32;
                 context
                     .store
-                    .update_operation_index(operation_id, sorted_index)
+                    .update_operation_index(operation_id, index as i32)
                     .await
                     .map_err(|err| TaskError::Critical(err.to_string()))?;
             }


### PR DESCRIPTION
We want to persist and maintain sorted position indexes for all operations which have been materialized into a document. This index is the operations position once topological sorting has occurred and can be understood as the `sorted_index` of a particular operation, or also the documents "depth" at that point in it's history.

This is done by introducing the following:
- add a `sorted_index` column to the `operations_v1` table
- update all operation models and data types accordingly
- introduce a `update_operation_index` method to the `OperationStore`
- in a `reduce` task update the `sorted_index` of all operations in a document

Note, there is a period of time when an operation has been inserted into the store, but it's `sorted_index` is `None` because materialization has not been performed yet. As we have a "retry" system already in-place to account for a node shutting down unexpectedly before tasks could be completed, then we can be confident all operations will be processed and have their `sorted_index` set eventually.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
