### PR TITLE
Ingest check for duplicate entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decouple p2panda's authentication data types from libp2p's [#408](https://github.com/p2panda/aquadoggo/pull/408)
 - Make `TaskInput` an enum and other minor clean ups in materialiser [#429](https://github.com/p2panda/aquadoggo/pull/429)
 - Use `libp2p` `0.52.0` [#425](https://github.com/p2panda/aquadoggo/pull/425)
+- Check for duplicate entries arriving to `Ingest` before consuming [#439](https://github.com/p2panda/aquadoggo/pull/439)
 
 ### Fixed
 

--- a/aquadoggo/src/replication/errors.rs
+++ b/aquadoggo/src/replication/errors.rs
@@ -45,7 +45,7 @@ pub enum IngestError {
     DecodeOperation(#[from] p2panda_rs::operation::error::DecodeOperationError),
 
     #[error("Duplicate entry received: {0}")]
-    DuplicateEntry(Hash)
+    DuplicateEntry(Hash),
 }
 
 #[derive(Error, Debug)]

--- a/aquadoggo/src/replication/errors.rs
+++ b/aquadoggo/src/replication/errors.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use p2panda_rs::hash::Hash;
 use thiserror::Error;
 
 use crate::replication::TargetSet;
@@ -42,6 +43,9 @@ pub enum IngestError {
 
     #[error("Decoding operation failed: {0}")]
     DecodeOperation(#[from] p2panda_rs::operation::error::DecodeOperationError),
+
+    #[error("Duplicate entry received: {0}")]
+    DuplicateEntry(Hash)
 }
 
 #[derive(Error, Debug)]

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -203,3 +203,54 @@ impl SyncIngest {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use p2panda_rs::entry::EncodedEntry;
+    use p2panda_rs::operation::EncodedOperation;
+    use p2panda_rs::schema::Schema;
+    use p2panda_rs::test_utils::fixtures::{encoded_entry, encoded_operation, schema};
+    use rstest::rstest;
+    use tokio::sync::broadcast;
+
+    use crate::replication::errors::IngestError;
+    use crate::replication::{Mode, SyncIngest};
+    use crate::test_utils::{test_runner_with_manager, TestNodeManager};
+
+    #[rstest]
+    fn reject_duplicate_entries(
+        schema: Schema,
+        encoded_entry: EncodedEntry,
+        encoded_operation: EncodedOperation,
+    ) {
+        test_runner_with_manager(move |manager: TestNodeManager| async move {
+            let mut node = manager.create().await;
+            node.context.schema_provider.update(schema).await;
+
+            let (tx, _rx) = broadcast::channel(8);
+            let ingest = SyncIngest::new(node.context.schema_provider.clone(), tx.clone());
+
+            let result = ingest
+                .handle_entry(
+                    &node.context.store,
+                    Mode::Document,
+                    &encoded_entry,
+                    &encoded_operation,
+                )
+                .await;
+
+            assert!(result.is_ok());
+
+            let result = ingest
+                .handle_entry(
+                    &node.context.store,
+                    Mode::Document,
+                    &encoded_entry,
+                    &encoded_operation,
+                )
+                .await;
+
+            assert!(matches!(result, Err(IngestError::DuplicateEntry(_))));
+        })
+    }
+}

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -230,21 +230,13 @@ mod tests {
             let ingest = SyncIngest::new(node.context.schema_provider.clone(), tx.clone());
 
             let result = ingest
-                .handle_entry(
-                    &node.context.store,
-                    &encoded_entry,
-                    &encoded_operation,
-                )
+                .handle_entry(&node.context.store, &encoded_entry, &encoded_operation)
                 .await;
 
             assert!(result.is_ok());
 
             let result = ingest
-                .handle_entry(
-                    &node.context.store,
-                    &encoded_entry,
-                    &encoded_operation,
-                )
+                .handle_entry(&node.context.store, &encoded_entry, &encoded_operation)
                 .await;
 
             assert!(matches!(result, Err(IngestError::DuplicateEntry(_))));

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -17,7 +17,6 @@ use p2panda_rs::operation::validate::validate_operation_with_entry;
 use p2panda_rs::operation::{EncodedOperation, Operation, OperationAction, OperationId};
 use p2panda_rs::schema::Schema;
 use p2panda_rs::storage_provider::traits::{EntryStore, LogStore, OperationStore};
-use p2panda_rs::Human;
 
 use crate::bus::{ServiceMessage, ServiceSender};
 use crate::db::SqlStore;
@@ -214,7 +213,7 @@ mod tests {
     use tokio::sync::broadcast;
 
     use crate::replication::errors::IngestError;
-    use crate::replication::{Mode, SyncIngest};
+    use crate::replication::SyncIngest;
     use crate::test_utils::{test_runner_with_manager, TestNodeManager};
 
     #[rstest]
@@ -224,7 +223,7 @@ mod tests {
         encoded_operation: EncodedOperation,
     ) {
         test_runner_with_manager(move |manager: TestNodeManager| async move {
-            let mut node = manager.create().await;
+            let node = manager.create().await;
             node.context.schema_provider.update(schema).await;
 
             let (tx, _rx) = broadcast::channel(8);
@@ -233,7 +232,6 @@ mod tests {
             let result = ingest
                 .handle_entry(
                     &node.context.store,
-                    Mode::Document,
                     &encoded_entry,
                     &encoded_operation,
                 )
@@ -244,7 +242,6 @@ mod tests {
             let result = ingest
                 .handle_entry(
                     &node.context.store,
-                    Mode::Document,
                     &encoded_entry,
                     &encoded_operation,
                 )

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -133,14 +133,14 @@ impl SyncIngest {
 
         trace!("Received entry and operation: {}", encoded_entry.hash());
 
-        // Check if we already have this entry. This can happen if another peer sent it to
-        // us during a concurrent sync session.
-        let is_duplicate = store
+        // Check if we already have this entry. This can happen if another peer sent it to us
+        // during a concurrent sync session.
+        if store
             .get_entry(&encoded_entry.hash())
             .await
             .expect("Fatal database error")
-            .is_some();
-        if is_duplicate {
+            .is_some()
+        {
             return Err(IngestError::DuplicateEntry(encoded_entry.hash()));
         }
 

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -10,7 +10,7 @@ use p2panda_rs::operation::EncodedOperation;
 use p2panda_rs::Human;
 
 use crate::db::SqlStore;
-use crate::replication::errors::{DuplicateSessionRequestError, ReplicationError, IngestError};
+use crate::replication::errors::{DuplicateSessionRequestError, IngestError, ReplicationError};
 use crate::replication::{
     Message, Mode, Session, SessionId, SessionState, SyncIngest, SyncMessage, TargetSet,
 };
@@ -476,7 +476,7 @@ where
             // closed. This is expected behavior which may occur when concurrent sync sessions
             // are running. We catch and handle this error here, returning an Ok result.
             if let Err(IngestError::DuplicateEntry(_)) = res {
-                return ok_result
+                return ok_result;
             }
 
             // Return any other errors.


### PR DESCRIPTION
Check if an entry already exists on the node before consuming in `Ingest`. If the entry is present, don't ingest it again and don't prematurely close the sync session.

This is to account for the case where the same entry is sent by two different peers at the same time.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
