### PR TITLE
Use fork of `asynchronous-codec` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decouple p2panda's authentication data types from libp2p's [#408](https://github.com/p2panda/aquadoggo/pull/408)
 - Make `TaskInput` an enum and other minor clean ups in materialiser [#429](https://github.com/p2panda/aquadoggo/pull/429)
 - Use `libp2p` `0.52.0` [#425](https://github.com/p2panda/aquadoggo/pull/425)
+- Use fork of `asynchronous-codec` [#440](https://github.com/p2panda/aquadoggo/pull/440)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decouple p2panda's authentication data types from libp2p's [#408](https://github.com/p2panda/aquadoggo/pull/408)
 - Make `TaskInput` an enum and other minor clean ups in materialiser [#429](https://github.com/p2panda/aquadoggo/pull/429)
 - Use `libp2p` `0.52.0` [#425](https://github.com/p2panda/aquadoggo/pull/425)
-- Use fork of `asynchronous-codec` [#440](https://github.com/p2panda/aquadoggo/pull/440)
 
 ### Fixed
 
@@ -62,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix insertion of view before document is materialized [#413](https://github.com/p2panda/aquadoggo/pull/413)
 - Handle duplicate document view insertions in reduce task [#410](https://github.com/p2panda/aquadoggo/pull/410)
 - Fix race condition when check for existing view ids was too early [#420](https://github.com/p2panda/aquadoggo/pull/420)
+- Use fork of `asynchronous-codec` to temporarily fix CBOR decoding bug [#440](https://github.com/p2panda/aquadoggo/pull/440)
 
 ### Open Sauce
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-axum",
  "async-trait",
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (git+https://github.com/p2panda/asynchronous-codec?rev=6eef38b30ade6ce2d66accc966652bd15d74e274)",
  "axum",
  "bamboo-rs-core-ed25519-yasmf",
  "bs58 0.4.0",
@@ -480,6 +480,18 @@ name = "asynchronous-codec"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.6.1"
+source = "git+https://github.com/p2panda/asynchronous-codec?rev=6eef38b30ade6ce2d66accc966652bd15d74e274#6eef38b30ade6ce2d66accc966652bd15d74e274"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -2116,7 +2128,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e378da62e8c9251f6e885ed173a561663f29b251e745586cf6ae6150b295c37"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.21.2",
  "byteorder",
  "bytes",
@@ -2149,7 +2161,7 @@ version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a29675a32dbcc87790db6cf599709e64308f1ae9d5ecea2d259155889982db8"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either",
  "futures",
  "futures-timer",
@@ -2190,7 +2202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5588b884dcb1dadc04e49de342f634f60cf28b6beaaca5a4fe3dd1f09bb30041"
 dependencies = [
  "arrayvec 0.7.4",
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "either",
  "fnv",
@@ -2299,7 +2311,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37266c683a757df713f7dcda0cdcb5ad4681355ffa1b37b77c113c176a531195"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "futures",
  "libp2p-core",
@@ -2337,7 +2349,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6da29ec69430dd4f1f6d271dd62d6fc26f50f6c2a7ea97eeadc6ff23ff08a"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "either",
  "futures",
@@ -2362,7 +2374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20f92973a954f8b9dfb809a41dc1a8c05bba52c067361763649f6f5ce04dc47c"
 dependencies = [
  "async-trait",
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bimap",
  "futures",
  "futures-timer",
@@ -3238,7 +3250,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
  "quick-protobuf",
  "thiserror",
@@ -4556,7 +4568,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes",
 ]
 

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.62"
 async-graphql = { version = "5.0.6", features = ["dynamic-schema"] }
 async-graphql-axum = "5.0.6"
 async-trait = "0.1.64"
-asynchronous-codec = { version = "0.6.1", features = ["cbor"] }
+asynchronous-codec = { git = "https://github.com/p2panda/asynchronous-codec", rev = "6eef38b30ade6ce2d66accc966652bd15d74e274", features = ["cbor"] }
 axum = "0.6.10"
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
 bs58 = "0.4.0"


### PR DESCRIPTION
We forked `asynchronous-codec` in order to introduce a change which fixes a bug we have (being discussed [here](https://github.com/mxinden/asynchronous-codec/issues/6).

It would be nice to have a test for this, but I've never seen it occur in tests before and am not sure how we could re-produce it.

## 📋 Checklist

- [x] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
