### PR TITLE
Replicate operations in topo order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,7 +2908,7 @@ checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.0"
-source = "git+https://github.com/p2panda/p2panda?rev=ae60bf754a60a1daf9c6862e9ae51ee7501b007f#ae60bf754a60a1daf9c6862e9ae51ee7501b007f"
+source = "git+https://github.com/p2panda/p2panda?rev=a535ee229b367c79f18a50626c6bcab61581e32b#a535ee229b367c79f18a50626c6bcab61581e32b"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -51,7 +51,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "ae60bf754a60a1daf9c6862e9ae51ee7501b007f", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a535ee229b367c79f18a50626c6bcab61581e32b", features = [
     "storage-provider",
 ] }
 serde = { version = "1.0.152", features = ["derive"] }
@@ -84,7 +84,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "ae60bf754a60a1daf9c6862e9ae51ee7501b007f", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a535ee229b367c79f18a50626c6bcab61581e32b", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/src/graphql/mutations/publish.rs
+++ b/aquadoggo/src/graphql/mutations/publish.rs
@@ -680,18 +680,6 @@ mod tests {
         },
         "Previous operation 0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543 not found in store"
     )]
-    #[case::claimed_log_id_does_not_match_expected(
-        &entry_signed_encoded_unvalidated(
-            1,
-            2,
-            None,
-            None,
-            Some(EncodedOperation::from_bytes(&OPERATION_ENCODED)),
-            key_pair(PRIVATE_KEY)
-        ).to_string(),
-        &OPERATION_ENCODED,
-        "Entry's claimed log id of 2 does not match expected next log id of 1 for given public key"
-    )]
     fn validation_of_entry_and_operation_values(
         #[case] entry_encoded: &str,
         #[case] encoded_operation: &[u8],

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -62,9 +62,9 @@ impl SyncIngest {
         let _ = publish(
             store,
             &schema,
-            &encoded_entry,
+            encoded_entry,
             &plain_operation,
-            &encoded_operation,
+            encoded_operation,
         )
         .await?;
 

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -1,113 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use log::trace;
-use p2panda_rs::api::validation::{
-    ensure_document_not_deleted, get_checked_document_id_for_view_id, get_expected_skiplink,
-    is_next_seq_num, validate_claimed_schema_id,
-};
-use p2panda_rs::api::DomainError;
-use p2panda_rs::document::DocumentId;
-use p2panda_rs::entry::decode::decode_entry;
-use p2panda_rs::entry::traits::{AsEncodedEntry, AsEntry};
+use p2panda_rs::api::publish;
+use p2panda_rs::entry::traits::AsEncodedEntry;
 use p2panda_rs::entry::EncodedEntry;
 use p2panda_rs::operation::decode::decode_operation;
-use p2panda_rs::operation::plain::PlainOperation;
-use p2panda_rs::operation::traits::{AsOperation, Schematic};
-use p2panda_rs::operation::validate::validate_operation_with_entry;
-use p2panda_rs::operation::{EncodedOperation, Operation, OperationAction, OperationId};
-use p2panda_rs::schema::Schema;
-use p2panda_rs::storage_provider::traits::{EntryStore, LogStore, OperationStore};
+use p2panda_rs::operation::traits::Schematic;
+use p2panda_rs::operation::{EncodedOperation, OperationId};
+use p2panda_rs::storage_provider::traits::EntryStore;
 
 use crate::bus::{ServiceMessage, ServiceSender};
 use crate::db::SqlStore;
 use crate::replication::errors::IngestError;
 use crate::schema::SchemaProvider;
-
-// @TODO: This method exists in `p2panda-rs`, we need to make it public there
-async fn validate_entry_and_operation<S: EntryStore + OperationStore + LogStore>(
-    store: &S,
-    schema: &Schema,
-    entry: &impl AsEntry,
-    encoded_entry: &impl AsEncodedEntry,
-    plain_operation: &PlainOperation,
-    encoded_operation: &EncodedOperation,
-) -> Result<(Operation, OperationId), DomainError> {
-    // Verify that the claimed seq num matches the expected seq num for this public_key and log.
-    let latest_entry = store
-        .get_latest_entry(entry.public_key(), entry.log_id())
-        .await?;
-    let latest_seq_num = latest_entry.as_ref().map(|entry| entry.seq_num());
-    is_next_seq_num(latest_seq_num, entry.seq_num())?;
-
-    // If a skiplink is claimed, get the expected skiplink from the database, errors if it can't be found.
-    let skiplink = match entry.skiplink() {
-        Some(_) => Some(
-            get_expected_skiplink(store, entry.public_key(), entry.log_id(), entry.seq_num())
-                .await?,
-        ),
-        None => None,
-    };
-
-    // Construct params as `validate_operation_with_entry` expects.
-    let skiplink_params = skiplink.as_ref().map(|entry| {
-        let hash = entry.hash();
-        (entry.clone(), hash)
-    });
-
-    // The backlink for this entry is the latest entry from this public key's log.
-    let backlink_params = latest_entry.as_ref().map(|entry| {
-        let hash = entry.hash();
-        (entry.clone(), hash)
-    });
-
-    // Perform validation of the entry and it's operation.
-    let (operation, operation_id) = validate_operation_with_entry(
-        entry,
-        encoded_entry,
-        skiplink_params.as_ref().map(|(entry, hash)| (entry, hash)),
-        backlink_params.as_ref().map(|(entry, hash)| (entry, hash)),
-        plain_operation,
-        encoded_operation,
-        schema,
-    )?;
-
-    Ok((operation, operation_id))
-}
-
-// @TODO: This method exists in `p2panda-rs`, we need to make it public there
-async fn determine_document_id<S: OperationStore>(
-    store: &S,
-    operation: &impl AsOperation,
-    operation_id: &OperationId,
-) -> Result<DocumentId, DomainError> {
-    let document_id = match operation.action() {
-        OperationAction::Create => {
-            // Derive the document id for this new document.
-            Ok::<DocumentId, DomainError>(DocumentId::new(operation_id))
-        }
-        _ => {
-            // We can unwrap previous operations here as we know all UPDATE and DELETE operations contain them.
-            let previous = operation.previous().unwrap();
-
-            // Validate claimed schema for this operation matches the expected found in the
-            // previous operations.
-            validate_claimed_schema_id(store, &operation.schema_id(), &previous).await?;
-
-            // Get the document_id for the document_view_id contained in previous operations.
-            // This performs several validation steps (check method doc string).
-            let document_id = get_checked_document_id_for_view_id(store, &previous).await?;
-
-            Ok(document_id)
-        }
-    }?;
-
-    // Ensure the document isn't deleted.
-    ensure_document_not_deleted(store, &document_id)
-        .await
-        .map_err(|_| DomainError::DeletedDocument)?;
-
-    Ok(document_id)
-}
 
 #[derive(Debug, Clone)]
 pub struct SyncIngest {
@@ -129,8 +34,6 @@ impl SyncIngest {
         encoded_entry: &EncodedEntry,
         encoded_operation: &EncodedOperation,
     ) -> Result<(), IngestError> {
-        let entry = decode_entry(encoded_entry)?;
-
         trace!("Received entry and operation: {}", encoded_entry.hash());
 
         // Check if we already have this entry. This can happen if another peer sent it to us
@@ -152,42 +55,26 @@ impl SyncIngest {
             .await
             .ok_or_else(|| IngestError::UnsupportedSchema)?;
 
-        let (operation, operation_id) = validate_entry_and_operation(
+        /////////////////////////////////////
+        // PUBLISH THE ENTRY AND OPERATION //
+        /////////////////////////////////////
+
+        let _ = publish(
             store,
             &schema,
-            &entry,
-            encoded_entry,
+            &encoded_entry,
             &plain_operation,
-            encoded_operation,
+            &encoded_operation,
         )
         .await?;
 
-        let document_id = determine_document_id(store, &operation, &operation_id).await?;
+        ////////////////////////////////////////
+        // SEND THE OPERATION TO MATERIALIZER //
+        ////////////////////////////////////////
 
-        // If the entries' seq num is 1 we insert a new log here
-        if entry.seq_num().is_first() {
-            store
-                .insert_log(
-                    entry.log_id(),
-                    entry.public_key(),
-                    Schematic::schema_id(&operation),
-                    &document_id,
-                )
-                .await
-                .expect("Fatal database error");
-        }
+        // Send new operation on service communication bus, this will arrive eventually at
+        // the materializer service
 
-        store
-            .insert_entry(&entry, encoded_entry, Some(encoded_operation))
-            .await
-            .expect("Fatal database error");
-
-        store
-            .insert_operation(&operation_id, entry.public_key(), &operation, &document_id)
-            .await
-            .expect("Fatal database error");
-
-        // Inform other services about received data
         let operation_id: OperationId = encoded_entry.hash().into();
 
         if self
@@ -197,7 +84,7 @@ impl SyncIngest {
         {
             // Silently fail here as we don't mind if there are no subscribers. We have
             // tests in other places to check if messages arrive.
-        }
+        };
 
         Ok(())
     }

--- a/aquadoggo/src/replication/session.rs
+++ b/aquadoggo/src/replication/session.rs
@@ -183,7 +183,10 @@ mod tests {
     use crate::replication::manager::INITIAL_SESSION_ID;
     use crate::replication::{Message, Mode, SessionState, TargetSet};
     use crate::test_utils::helpers::random_target_set;
-    use crate::test_utils::{populate_store_config, test_runner, TestNode, populate_and_materialize, test_runner_with_manager, TestNodeManager};
+    use crate::test_utils::{
+        populate_and_materialize, populate_store_config, test_runner, test_runner_with_manager,
+        TestNode, TestNodeManager,
+    };
 
     use super::Session;
 
@@ -221,7 +224,7 @@ mod tests {
         #[with(5, 2, 1)]
         config: PopulateStoreConfig,
     ) {
-        test_runner_with_manager(move |manager: TestNodeManager | async move {
+        test_runner_with_manager(move |manager: TestNodeManager| async move {
             let target_set = TargetSet::new(&vec![config.schema.id().to_owned()]);
             let mut session = Session::new(
                 &INITIAL_SESSION_ID,

--- a/aquadoggo/src/replication/strategies/log_height.rs
+++ b/aquadoggo/src/replication/strategies/log_height.rs
@@ -21,7 +21,6 @@ use crate::replication::{LogHeights, Message, Mode, StrategyResult, TargetSet};
 
 type SortedIndex = i32;
 
-
 /// Retrieve entries from the store, group the result by document id and then sub-order them by
 /// their sorted index.
 async fn retrieve_entries(
@@ -34,7 +33,7 @@ async fn retrieve_entries(
         for (log_id, seq_num) in log_heights {
             // Get the entries the remote needs for each log.
             let log_entries = store
-                .get_entries_from(&public_key, &log_id, &seq_num)
+                .get_entries_from(public_key, log_id, seq_num)
                 .await
                 .expect("Fatal database error");
 

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 env_logger = "0.9.0"
 hex = "0.4.3"
 libp2p = "0.52.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "ae60bf754a60a1daf9c6862e9ae51ee7501b007f" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a535ee229b367c79f18a50626c6bcab61581e32b" }
 tokio = { version = "1.28.2", features = ["full"] }
 
 [dependencies.aquadoggo]


### PR DESCRIPTION
We want to validate all operations which arrive at a node via replication before persisting them to the node and performing materialization. In order to do this the document they are part of needs to be in it's most recent state before the in-coming operation was published. This can be achieved if entries are ordered appropriately _before_ they are sent to a remote node in replication request responses.

When preparing entries response messages in `LogHeighStrategy` they should be grouped by document id and then ordered by `sorted_index` of their operations. This way a remote can simply use `publish` to ingest all arriving entries as they arrive in their topologically sorted order and can be directly validated and added to the document.

When consuming entries in `Ingest` we should use the `publish` method provided by `p2panda-rs`, this already performs all required validation.

- [x] Use `publish` to ingest entries arriving on a node via replication
- [x] Order entries correctly before sending them to a node during replication
- [x] Tests

These changes mean that we now require that authors don't publish concurrently to the same document with the same key pair, this needs adding to the spec: https://github.com/p2panda/handbook/issues/284

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
