### PR TITLE
Remove `quick_commit` from materialization service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `libp2p` `0.52.0` [#425](https://github.com/p2panda/aquadoggo/pull/425)
 - Check for duplicate entries arriving to `Ingest` before consuming [#439](https://github.com/p2panda/aquadoggo/pull/439)
 - Replicate entries in their topologically sorted document order [#442](https://github.com/p2panda/aquadoggo/pull/442)
+- Remove `quick_commit` from materialization service [#450](https://github.com/p2panda/aquadoggo/pull/450)
 
 ### Fixed
 


### PR DESCRIPTION
This is a stop-gap solution to #448 

Eventually we want to move `quick_commit` logic into the `reduce` tasks, but that takes a little bit more thought, and as it is only an optimisation in any case we can do without it for now.

## 📋 Checklist

- [X] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
