### PR TITLE
Perform peer sampling before initiating replication requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check for duplicate entries arriving to `Ingest` before consuming [#439](https://github.com/p2panda/aquadoggo/pull/439)
 - Replicate entries in their topologically sorted document order [#442](https://github.com/p2panda/aquadoggo/pull/442)
 - Remove `quick_commit` from materialization service [#450](https://github.com/p2panda/aquadoggo/pull/450)
+- Introduce peer sampling to the replication service [#463](https://github.com/p2panda/aquadoggo/pull/463)
 
 ### Fixed
 

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -58,6 +58,7 @@ openssl-probe = "0.1.5"
 p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "392a730b3259fd836f2414b64ebf56db7767f33f", features = [
     "storage-provider",
 ] }
+rand = "0.8.5"
 serde = { version = "1.0.152", features = ["derive"] }
 sqlx = { version = "0.6.1", features = [
     "any",

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -8,6 +8,8 @@ use libp2p::PeerId;
 use log::{info, trace, warn};
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::Human;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use tokio::task;
 use tokio::time::interval;
 use tokio_stream::wrappers::{BroadcastStream, IntervalStream};
@@ -24,6 +26,9 @@ use crate::replication::{
     Mode, Session, SessionId, SyncIngest, SyncManager, SyncMessage, TargetSet,
 };
 use crate::schema::SchemaProvider;
+
+/// Maximum number of peers we replicate with at one a time.
+const MAX_PEER_SAMPLE: usize = 3;
 
 /// Maximum of replication sessions per peer.
 const MAX_SESSIONS_PER_PEER: usize = 3;
@@ -241,7 +246,7 @@ impl ConnectionManager {
         let target_set = self.target_set().await;
 
         // Iterate through all currently connected peers
-        let attempt_peers: Vec<Peer> = self
+        let mut attempt_peers: Vec<Peer> = self
             .peers
             .clone()
             .into_iter()
@@ -272,6 +277,10 @@ impl ConnectionManager {
         if attempt_peers.is_empty() {
             trace!("No peers available for replication")
         }
+
+        // Take a random sample of the remaining peers up to MAX_PEER_SAMPLE
+        attempt_peers.shuffle(&mut thread_rng());
+        attempt_peers.truncate(MAX_PEER_SAMPLE);
 
         for peer in attempt_peers {
             self.initiate_replication(&peer, &target_set).await;


### PR DESCRIPTION
Take a random sample of the available peers in the replication service and only initiate replication sessions with them.

## 📋 Checklist

- [x] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
