### PR TITLE
Reduce chatty warnings in network and replication services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check for duplicate entries arriving to `Ingest` before consuming [#439](https://github.com/p2panda/aquadoggo/pull/439)
 - Replicate entries in their topologically sorted document order [#442](https://github.com/p2panda/aquadoggo/pull/442)
 - Remove `quick_commit` from materialization service [#450](https://github.com/p2panda/aquadoggo/pull/450)
+- Reduce `warn` logging in network and replication services [#467](https://github.com/p2panda/aquadoggo/pull/467)
 
 ### Fixed
 

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -296,7 +296,7 @@ impl EventLoop {
                 send_back_addr,
                 ..
             } => {
-                warn!("Incoming connection error occurred with {local_addr} and {send_back_addr} on connection {connection_id:?}");
+                debug!("Incoming connection error occurred with {local_addr} and {send_back_addr} on connection {connection_id:?}");
             }
             SwarmEvent::ListenerClosed {
                 listener_id,
@@ -304,7 +304,7 @@ impl EventLoop {
                 reason,
             } => trace!("Listener closed: {listener_id:?} {addresses:?} {reason:?}"),
             SwarmEvent::ListenerError { error, .. } => {
-                warn!("Listener failed with error: {error}")
+                debug!("Listener failed with error: {error}")
             }
             SwarmEvent::NewListenAddr {
                 address,
@@ -318,10 +318,10 @@ impl EventLoop {
                 ..
             } => match peer_id {
                 Some(id) => {
-                    warn!("Outgoing connection error with peer {id} occurred on connection {connection_id:?}");
+                    debug!("Outgoing connection error with peer {id} occurred on connection {connection_id:?}");
                 }
                 None => {
-                    warn!("Outgoing connection error occurred on connection {connection_id:?}");
+                    debug!("Outgoing connection error occurred on connection {connection_id:?}");
                 }
             },
 
@@ -381,7 +381,7 @@ impl EventLoop {
                     }
                 }
                 rendezvous::client::Event::RegisterFailed { error, .. } => {
-                    warn!("Failed to register with rendezvous point: {error:?}");
+                    debug!("Failed to register with rendezvous point: {error:?}");
                 }
                 rendezvous::client::Event::DiscoverFailed { error, .. } => {
                     trace!("Discovery failed: {error:?}")
@@ -433,7 +433,7 @@ impl EventLoop {
                                 ) {
                                     Ok(_) => (),
                                     Err(_) => {
-                                        warn!("Failed to register peer: {rendezvous_peer_id}")
+                                        debug!("Failed to register peer: {rendezvous_peer_id}")
                                     }
                                 };
                             }
@@ -445,7 +445,7 @@ impl EventLoop {
                         )
                     }
                     identify::Event::Error { peer_id, error } => {
-                        warn!("Failed to identify the remote peer {peer_id}: {error}")
+                        debug!("Failed to identify the remote peer {peer_id}: {error}")
                     }
                 }
             }
@@ -485,7 +485,7 @@ impl EventLoop {
                                     ) {
                                         Ok(_) => (),
                                         Err(_) => {
-                                            warn!("Failed to register peer: {rendezvous_peer_id}")
+                                            debug!("Failed to register peer: {rendezvous_peer_id}")
                                         }
                                     };
                                 }
@@ -531,8 +531,8 @@ impl EventLoop {
                             .condition(PeerCondition::NotDialing)
                             .build(),
                     ) {
-                        Ok(_) => debug!("Dialing peer: {peer_id}"),
-                        Err(_) => warn!("Error dialing peer: {peer_id}"),
+                        Ok(()) => debug!("Dialing peer: {peer_id}"),
+                        Err(error) => debug!("Error dialing peer {peer_id}: {error}"),
                     };
                 }
             },

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -131,7 +131,7 @@ where
             {
                 sessions.remove(index);
             } else {
-                warn!(
+                debug!(
                     "Tried to remove nonexistent session {} with peer: {}",
                     session_id,
                     remote_peer.display()

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use libp2p::PeerId;
-use log::{info, trace, warn};
+use log::{debug, info, trace, warn};
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::Human;
 use tokio::task;
@@ -217,7 +217,11 @@ impl ConnectionManager {
         session_id: SessionId,
         error: ReplicationError,
     ) {
-        warn!("Replication with peer {} failed: {}", peer.display(), error);
+        if let ReplicationError::NoSessionFound(_, _) = error {
+            debug!("Replication session not found: {}", error);
+        } else {
+            warn!("Replication failed: {}", error);
+        }
 
         match self.peers.get_mut(&peer) {
             Some(status) => {


### PR DESCRIPTION
- [x] don't `warn!` (just `debug!`) when a session wasn't found for a replication message, this has normally been followed by the actual error which closed the session
- [x] reduce most logging which we are bubbling up from `libp2p` in the network service to `debug!` (only `warn!` when it's a connection closure event that we are explicitly responding to in panda land) 
- [x] don't `warn` when dial attempts fail, this is normally because there is an existing dial attempt in progress, it's not an actual connection error, these get picked up elsewhere.

## 📋 Checklist

- [x] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
