### PR TITLE
Don't update or announce an update in schema provider if a schema with this id exists already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't check for `affected_rows` on task deletion [#461](https://github.com/p2panda/aquadoggo/pull/461)
 - Do not critically fail when view does not exist due to race condition [#460](https://github.com/p2panda/aquadoggo/pull/460)
 - Do nothing on log insertion conflict [#468](https://github.com/p2panda/aquadoggo/pull/468)
+- Don't update or announce an update in schema provider if a schema with this id exists already [#472](https://github.com/p2panda/aquadoggo/pull/472)
 
 ### Open Sauce
 

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -2,7 +2,7 @@
 
 use std::convert::TryFrom;
 
-use log::{debug, info, trace};
+use log::{debug, trace};
 use p2panda_rs::document::materialization::build_graph;
 use p2panda_rs::document::traits::AsDocument;
 use p2panda_rs::document::{Document, DocumentBuilder, DocumentId, DocumentViewId};
@@ -171,7 +171,7 @@ async fn reduce_document_view<O: AsOperation + WithId<OperationId> + WithPublicK
         .await
         .map_err(|err| TaskError::Critical(err.to_string()))?;
 
-    info!("Stored {} document view {}", document, document.view_id());
+    debug!("Stored {} document view {}", document, document.view_id());
 
     debug!(
         "Dispatch dependency task for view with id: {}",
@@ -233,7 +233,7 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
 
             // If the document was deleted, then we return nothing
             if document.is_deleted() {
-                info!(
+                debug!(
                     "Deleted {} final view {}",
                     document.display(),
                     document.view_id().display()
@@ -242,13 +242,13 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
             }
 
             if document.is_edited() {
-                info!(
+                debug!(
                     "Updated {} latest view {}",
                     document.display(),
                     document.view_id().display()
                 );
             } else {
-                info!("Created {}", document.display());
+                debug!("Created {}", document.display());
             };
 
             debug!(


### PR DESCRIPTION
Don't update or announce an update in schema provider if a schema with this id exists already.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
