### PR TITLE
Add static file server to `http` service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,6 +2809,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,20 +4667,27 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4824,6 +4841,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -76,8 +76,9 @@ tokio = { version = "1.28.2", features = [
     "time",
 ] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
-tower-http = { version = "0.3.4", default-features = false, features = [
+tower-http = { version = "0.4.0", default-features = false, features = [
     "cors",
+    "fs",
 ] }
 triggered = "0.1.2"
 

--- a/aquadoggo/src/graphql/mutations/publish.rs
+++ b/aquadoggo/src/graphql/mutations/publish.rs
@@ -125,7 +125,7 @@ mod tests {
 
     use crate::bus::ServiceMessage;
     use crate::graphql::GraphQLSchemaManager;
-    use crate::http::HttpServiceContext;
+    use crate::http::{HttpServiceContext, BLOBS_ROUTE};
     use crate::test_utils::{
         add_schema, doggo_fields, doggo_schema, graphql_test_client, populate_and_materialize,
         populate_store_config, test_runner, TestNode,
@@ -237,7 +237,7 @@ mod tests {
                 node.context.schema_provider.clone(),
             )
             .await;
-            let context = HttpServiceContext::new(manager);
+            let context = HttpServiceContext::new(manager, BLOBS_ROUTE.into());
 
             let response = context.schema.execute(publish_request).await;
 
@@ -298,7 +298,7 @@ mod tests {
                 node.context.schema_provider.clone(),
             )
             .await;
-            let context = HttpServiceContext::new(manager);
+            let context = HttpServiceContext::new(manager, BLOBS_ROUTE.into());
 
             let response = context
                 .schema
@@ -326,7 +326,7 @@ mod tests {
                 node.context.schema_provider.clone(),
             )
             .await;
-            let context = HttpServiceContext::new(manager);
+            let context = HttpServiceContext::new(manager, BLOBS_ROUTE.into());
 
             context.schema.execute(publish_request).await;
 

--- a/aquadoggo/src/http/context.rs
+++ b/aquadoggo/src/http/context.rs
@@ -1,16 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::path::PathBuf;
+
 use crate::graphql::GraphQLSchemaManager;
 
 #[derive(Clone)]
 pub struct HttpServiceContext {
     /// Dynamic GraphQL schema manager.
     pub schema: GraphQLSchemaManager,
+
+    /// Path of the directory where blobs should be served from
+    pub blob_dir_path: PathBuf,
 }
 
 impl HttpServiceContext {
     /// Create a new HttpServiceContext.
-    pub fn new(schema: GraphQLSchemaManager) -> Self {
-        Self { schema }
+    pub fn new(schema: GraphQLSchemaManager, blob_dir_path: PathBuf) -> Self {
+        Self {
+            schema,
+            blob_dir_path,
+        }
     }
 }

--- a/aquadoggo/src/http/mod.rs
+++ b/aquadoggo/src/http/mod.rs
@@ -5,4 +5,4 @@ mod context;
 mod service;
 
 pub use context::HttpServiceContext;
-pub use service::{build_server, http_service};
+pub use service::{build_server, http_service, BLOBS_ROUTE};

--- a/aquadoggo/src/http/service.rs
+++ b/aquadoggo/src/http/service.rs
@@ -10,6 +10,7 @@ use axum::Router;
 use http::header::CONTENT_TYPE;
 use log::{debug, warn};
 use tower_http::cors::{Any, CorsLayer};
+use tower_http::services::ServeDir;
 
 use crate::bus::ServiceSender;
 use crate::context::Context;
@@ -18,7 +19,14 @@ use crate::http::api::{handle_graphql_playground, handle_graphql_query};
 use crate::http::context::HttpServiceContext;
 use crate::manager::{ServiceReadySender, Shutdown};
 
+/// Route to the GraphQL playground
 const GRAPHQL_ROUTE: &str = "/graphql";
+
+/// Route to the blobs static file server
+pub const BLOBS_ROUTE: &str = "/blobs";
+
+/// Path to the local blobs directory
+const BLOBS_DIRECTORY_PATH: &str = "blobs";
 
 /// Build HTTP server with GraphQL API.
 pub fn build_server(http_context: HttpServiceContext) -> Router {
@@ -29,7 +37,12 @@ pub fn build_server(http_context: HttpServiceContext) -> Router {
         .allow_credentials(false)
         .allow_origin(Any);
 
+    // Construct static file server
+    let blob_service = ServeDir::new(http_context.blob_dir_path.clone());
+
     Router::new()
+        // Add blobs static file server
+        .nest_service(BLOBS_ROUTE, blob_service)
         // Add GraphQL routes
         .route(
             GRAPHQL_ROUTE,
@@ -55,8 +68,15 @@ pub async fn http_service(
     let graphql_schema_manager =
         GraphQLSchemaManager::new(context.store.clone(), tx, context.schema_provider.clone()).await;
 
+    let blob_dir_path = context
+        .config
+        .base_path
+        .as_ref()
+        .expect("Base path not set")
+        .join(BLOBS_DIRECTORY_PATH);
+
     // Introduce a new context for all HTTP routes
-    let http_context = HttpServiceContext::new(graphql_schema_manager);
+    let http_context = HttpServiceContext::new(graphql_schema_manager, blob_dir_path);
 
     axum::Server::try_bind(&http_address)?
         .serve(build_server(http_context).into_make_service())
@@ -80,6 +100,7 @@ mod tests {
 
     use crate::graphql::GraphQLSchemaManager;
     use crate::http::context::HttpServiceContext;
+    use crate::http::service::BLOBS_DIRECTORY_PATH;
     use crate::schema::SchemaProvider;
     use crate::test_utils::TestClient;
     use crate::test_utils::{test_runner, TestNode};
@@ -93,7 +114,8 @@ mod tests {
             let schema_provider = SchemaProvider::default();
             let graphql_schema_manager =
                 GraphQLSchemaManager::new(node.context.store.clone(), tx, schema_provider).await;
-            let context = HttpServiceContext::new(graphql_schema_manager);
+            let context =
+                HttpServiceContext::new(graphql_schema_manager, BLOBS_DIRECTORY_PATH.into());
             let client = TestClient::new(build_server(context));
 
             let response = client

--- a/aquadoggo/src/test_utils/client.rs
+++ b/aquadoggo/src/test_utils/client.rs
@@ -13,7 +13,7 @@ use tower::make::Shared;
 use tower_service::Service;
 
 use crate::graphql::GraphQLSchemaManager;
-use crate::http::{build_server, HttpServiceContext};
+use crate::http::{build_server, HttpServiceContext, BLOBS_ROUTE};
 use crate::test_utils::TestNode;
 
 /// GraphQL client which can be used for querying a node in tests.
@@ -74,7 +74,7 @@ pub async fn graphql_test_client(node: &TestNode) -> TestClient {
         node.context.schema_provider.clone(),
     )
     .await;
-    let http_context = HttpServiceContext::new(manager);
+    let http_context = HttpServiceContext::new(manager, BLOBS_ROUTE.into());
     TestClient::new(build_server(http_context))
 }
 


### PR DESCRIPTION
Use https://docs.rs/tower-http/latest/tower_http/services/struct.ServeDir.html# to add a static file server to the http service which serves content from `$HOME/.local/share/aquadoggo/blobs` by default.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
