### PR TITLE
`aquaddogo` configured to support any schema by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `quick_commit` from materialization service [#450](https://github.com/p2panda/aquadoggo/pull/450)
 - Reduce `warn` logging in network and replication services [#467](https://github.com/p2panda/aquadoggo/pull/467)
 - `mdns` and `autonat` disabled by default [#475](https://github.com/p2panda/aquadoggo/pull/475)
+- By default, nodes support _any_ schema [#487](https://github.com/p2panda/aquadoggo/pull/487)
 
 ### Fixed
 

--- a/aquadoggo/src/config.rs
+++ b/aquadoggo/src/config.rs
@@ -46,10 +46,9 @@ pub struct Configuration {
     pub worker_pool_size: u32,
 
     /// The ids of schema this node supports.
-    pub supported_schema_ids: Vec<SchemaId>,
-
-    /// If set to true then the node will dynamically support any new schema it replicates.
-    pub dynamic_schema: bool,
+    /// 
+    /// If `None` then the node will support all system schema and any new schema it discovers.
+    pub supported_schema_ids: Option<Vec<SchemaId>>,
 }
 
 impl Default for Configuration {
@@ -61,8 +60,7 @@ impl Default for Configuration {
             http_port: 2020,
             network: NetworkConfiguration::default(),
             worker_pool_size: 16,
-            supported_schema_ids: vec![],
-            dynamic_schema: false,
+            supported_schema_ids: None,
         }
     }
 }

--- a/aquadoggo/src/config.rs
+++ b/aquadoggo/src/config.rs
@@ -46,7 +46,7 @@ pub struct Configuration {
     pub worker_pool_size: u32,
 
     /// The ids of schema this node supports.
-    /// 
+    ///
     /// If `None` then the node will support all system schema and any new schema it discovers.
     pub supported_schema_ids: Option<Vec<SchemaId>>,
 }

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -49,14 +49,12 @@ impl SyncIngest {
 
         let plain_operation = decode_operation(encoded_operation)?;
 
-        // Check that the sent operation follows one of our supported schema.
-        if !self
-            .schema_provider
-            .supported_schema()
-            .await
-            .contains(plain_operation.schema_id())
-        {
-            return Err(IngestError::UnsupportedSchema);
+        // If the node has been configured with supported_schema_ids, check that the sent
+        // operation follows one of our supported schema.
+        if let Some(supported_schema_ids) = self.schema_provider.supported_schema_ids() {
+            if supported_schema_ids.contains(plain_operation.schema_id()) {
+                return Err(IngestError::UnsupportedSchema);
+            }
         }
 
         // Retrieve the schema if it has been materialized on the node.

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -466,9 +466,9 @@ where
                 )
                 .await
             {
-                // Duplicate entries arriving at a node, or the case where a schema has not been
-                // materialized yet, we don't want to treat as an error. This is expected
-                // behavior which may occur when concurrent sync sessions are running.
+                // When duplicate entries arrive at a node, or a schema is not materialized yet,
+                // we don't want to treat as an error. This is expected behavior which may occur
+                // when concurrent sync sessions are running.
                 Ok(_) | Err(IngestError::DuplicateEntry(_)) | Err(IngestError::SchemaNotFound) => {
                     Ok(SyncResult {
                         messages: vec![],

--- a/aquadoggo/src/schema/schema_provider.rs
+++ b/aquadoggo/src/schema/schema_provider.rs
@@ -43,11 +43,8 @@ impl SchemaProvider {
         }
 
         if let Some(supported_schema_ids) = &supported_schema_ids {
-            index = index
-                .into_iter()
-                .filter(|(schema_id, _)| supported_schema_ids.contains(schema_id))
-                .collect();
-        }
+            index.retain(|schema_id, _| supported_schema_ids.contains(schema_id));
+        };
 
         let (tx, _) = channel(64);
 

--- a/aquadoggo/src/schema/schema_provider.rs
+++ b/aquadoggo/src/schema/schema_provider.rs
@@ -20,7 +20,7 @@ pub struct SchemaProvider {
 
     /// Optional list of schema this provider supports. If set only these schema will be added to the schema
     /// registry once materialized.
-    supported_schema: Option<Vec<SchemaId>>,
+    supported_schema_ids: Option<Vec<SchemaId>>,
 
     /// Sender for broadcast channel informing subscribers about updated schemas.
     tx: Sender<SchemaId>,
@@ -28,7 +28,10 @@ pub struct SchemaProvider {
 
 impl SchemaProvider {
     /// Returns a `SchemaProvider` containing the given application schemas and all system schemas.
-    pub fn new(application_schemas: Vec<Schema>) -> Self {
+    pub fn new(
+        application_schemas: Vec<Schema>,
+        supported_schema_ids: Option<Vec<SchemaId>>,
+    ) -> Self {
         // Collect all system and application schemas.
         let mut schemas = SYSTEM_SCHEMAS.clone();
         schemas.extend(&application_schemas);
@@ -39,41 +42,12 @@ impl SchemaProvider {
             index.insert(schema.id().to_owned(), schema.to_owned());
         }
 
-        let (tx, _) = channel(64);
-
-        debug!(
-            "Initialised schema provider:\n- {}",
-            index
-                .values()
-                .map(|schema| schema.to_string())
-                .collect::<Vec<String>>()
-                .join("\n- ")
-        );
-
-        Self {
-            schemas: Arc::new(Mutex::new(index)),
-            supported_schema: None,
-            tx,
+        if let Some(supported_schema_ids) = &supported_schema_ids {
+            index = index
+                .into_iter()
+                .filter(|(schema_id, _)| supported_schema_ids.contains(schema_id))
+                .collect();
         }
-    }
-
-    pub fn new_with_supported_schema(supported_schema: Vec<SchemaId>) -> Self {
-        // Validate that the passed known schema are all mentioned in the supported schema list.
-
-        // Collect all system and application schemas.
-        let system_schemas = SYSTEM_SCHEMAS.clone();
-
-        // Filter system schema against passed supported schema and collect into index Hashmap.
-        let index: HashMap<SchemaId, Schema> = system_schemas
-            .into_iter()
-            .filter_map(|schema| {
-                if supported_schema.contains(schema.id()) {
-                    Some((schema.id().to_owned(), schema.to_owned()))
-                } else {
-                    None
-                }
-            })
-            .collect();
 
         let (tx, _) = channel(64);
 
@@ -88,7 +62,7 @@ impl SchemaProvider {
 
         Self {
             schemas: Arc::new(Mutex::new(index)),
-            supported_schema: Some(supported_schema),
+            supported_schema_ids,
             tx,
         }
     }
@@ -113,7 +87,7 @@ impl SchemaProvider {
     /// Returns `true` if a schema was updated or it already existed in it's current state, and
     /// `false` if it was inserted.
     pub async fn update(&self, schema: Schema) -> Result<bool> {
-        if let Some(supported_schema) = self.supported_schema.as_ref() {
+        if let Some(supported_schema) = self.supported_schema_ids.as_ref() {
             if !supported_schema.contains(schema.id()) {
                 return Err(anyhow!(
                     "Attempted to add unsupported schema to schema provider"
@@ -143,21 +117,15 @@ impl SchemaProvider {
         Ok(is_update)
     }
 
-    // Return the configured supported schema, or all schema we know about if no restrictions on
-    // schema have been set.
-    pub async fn supported_schema(&self) -> Vec<SchemaId> {
-        match &self.supported_schema {
-            Some(supported_schema) => supported_schema.to_owned(),
-            // If `supported_schema` is None it means there are no limits on schema and so we
-            // support all schema we know about.
-            None => self.schemas.lock().await.keys().cloned().collect(),
-        }
+    // Return the configured supported schema.
+    pub fn supported_schema_ids(&self) -> Option<&Vec<SchemaId>> {
+        self.supported_schema_ids.as_ref()
     }
 }
 
 impl Default for SchemaProvider {
     fn default() -> Self {
-        Self::new(Vec::new())
+        Self::new(Vec::new(), None)
     }
 }
 
@@ -214,7 +182,7 @@ mod test {
             &[("test_field", FieldType::String)],
         )
         .unwrap();
-        let provider = SchemaProvider::new_with_supported_schema(vec![new_schema_id.clone()]);
+        let provider = SchemaProvider::new(vec![], Some(vec![new_schema_id.clone()]));
         let result = provider.update(new_schema).await;
         assert!(result.is_ok());
         assert!(!result.unwrap());
@@ -224,7 +192,7 @@ mod test {
 
     #[tokio::test]
     async fn update_unsupported_schemas() {
-        let provider = SchemaProvider::new_with_supported_schema(vec![]);
+        let provider = SchemaProvider::new(vec![], Some(vec![]));
         let new_schema_id = SchemaId::Application(
             SchemaName::new("test_schema").unwrap(),
             random_document_view_id(),

--- a/aquadoggo/src/test_utils/runner.rs
+++ b/aquadoggo/src/test_utils/runner.rs
@@ -66,8 +66,7 @@ impl TestNodeManager {
         let store = SqlStore::new(pool.clone());
 
         // Construct node config supporting any schema.
-        let mut cfg = Configuration::default();
-        cfg.dynamic_schema = true;
+        let cfg = Configuration::default();
 
         // Construct the actual test node
         let test_node = TestNode {
@@ -103,8 +102,7 @@ pub fn test_runner<F: AsyncTestFn + Send + Sync + 'static>(test: F) {
         let store = SqlStore::new(pool);
 
         // Construct node config supporting any schema.
-        let mut cfg = Configuration::default();
-        cfg.dynamic_schema = true;
+        let cfg = Configuration::default();
 
         // Construct the actual test node
         let node = TestNode {

--- a/aquadoggo/src/tests.rs
+++ b/aquadoggo/src/tests.rs
@@ -43,9 +43,7 @@ async fn e2e() {
     // default options. The only thing we want to do change is the database config. We want an
     // in-memory sqlite database for this test.
 
-    let mut config = Configuration::new_ephemeral();
-    // In this demo we any schema to be automatically supported by the node.
-    config.dynamic_schema = true;
+    let config = Configuration::new_ephemeral();
     let key_pair = KeyPair::new();
 
     // Start the node.

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -180,10 +180,12 @@ async fn main() {
 
     // Read schema ids from config.toml file or
     let supported_schemas = match File::open(CONFIG_FILE_PATH) {
-        Ok(mut file) => schemas::read_schema_ids_from_file(&mut file),
-        Err(_) => Ok(vec![]),
-    }
-    .expect("Reading schema ids from config.toml failed");
+        Ok(mut file) => Some(
+            schemas::read_schema_ids_from_file(&mut file)
+                .expect("Reading schema ids from config.toml failed"),
+        ),
+        Err(_) => None,
+    };
     config.supported_schema_ids = supported_schemas;
 
     // We unwrap the path as we know it has been initialised during the conversion step before


### PR DESCRIPTION
We recently introduced the ability to restrict a nodes behaviour with `supported_schema_ids`, configurable via a `config.toml` file https://github.com/p2panda/aquadoggo/pull/473. The default behaviour when a config file isn't found is for a node to not support any schema.

This is a rather strict default behaviour, and although maybe what you expect in a production setting, for development it adds a required steps which new users need to take when exploring `aquadoggo` (create `config.toml`, update it whenever new schema are created, make sure other local nodes support the same schema). 

This PR makes changes in order to prioritise the "new user experience", the result being that if no `config.toml` is found, the node is configured to support _any_ schema. This means that a fresh node will by default replicate all data with any other nodes it discovers, and offer publish and query endpoints for any new schema it receives. No configuration of supported schema required :star2:  

Creating a `config.toml` file will restrict this behaviour.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
