### PR TITLE
Fix: only over-write `http_port` when cli arg is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do nothing on log insertion conflict [#468](https://github.com/p2panda/aquadoggo/pull/468)
 - Don't update or announce an update in schema provider if a schema with this id exists already [#472](https://github.com/p2panda/aquadoggo/pull/472)
 - Do nothing on document_view insertion conflicts [#474](https://github.com/p2panda/aquadoggo/pull/474)
+- Only over-write `http_port` when cli arg is passed [#489](https://github.com/p2panda/aquadoggo/pull/489)
 
 ### Open Sauce
 

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -147,7 +147,9 @@ impl TryFrom<Cli> for Configuration {
             None
         };
 
-        config.http_port = cli.http_port.unwrap_or(2020);
+        if let Some(http_port) = cli.http_port {
+            config.http_port = http_port
+        }
 
         config.network = NetworkConfiguration {
             autonat: cli.autonat.unwrap_or(false),


### PR DESCRIPTION
## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
