### PR TITLE
Enable deletion of dangling `document_views` and related `document_view_fields` from db 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce peer sampling to the replication service [#463](https://github.com/p2panda/aquadoggo/pull/463)
 - Only replicate and materialize configured "supported schema" [#569](https://github.com/p2panda/aquadoggo/pull/469)
 - Parse supported schema ids from `config.toml` [#473](https://github.com/p2panda/aquadoggo/pull/473)
+- Add method to store for pruning document views [#491](https://github.com/p2panda/aquadoggo/pull/491)
 
 ### Changed
 

--- a/aquadoggo/migrations/20220510022755_create-documents.sql
+++ b/aquadoggo/migrations/20220510022755_create-documents.sql
@@ -1,5 +1,11 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
+CREATE TABLE IF NOT EXISTS document_views (
+    document_view_id            TEXT            NOT NULL UNIQUE,
+    schema_id                   TEXT            NOT NULL,
+    PRIMARY KEY (document_view_id)
+);
+
 CREATE TABLE IF NOT EXISTS document_view_fields (
     document_view_id              TEXT            NOT NULL,
     operation_id                  TEXT            NOT NULL,
@@ -8,12 +14,6 @@ CREATE TABLE IF NOT EXISTS document_view_fields (
 );
 
 CREATE INDEX idx_document_view_fields ON document_view_fields (document_view_id, operation_id, name);
-
-CREATE TABLE IF NOT EXISTS document_views (
-    document_view_id            TEXT            NOT NULL UNIQUE,
-    schema_id                   TEXT            NOT NULL,
-    PRIMARY KEY (document_view_id)
-);
 
 CREATE TABLE IF NOT EXISTS documents (
     document_id                 TEXT            NOT NULL UNIQUE,

--- a/aquadoggo/migrations/20220510022755_create-documents.sql
+++ b/aquadoggo/migrations/20220510022755_create-documents.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS document_view_fields (
     document_view_id              TEXT            NOT NULL,
     operation_id                  TEXT            NOT NULL,
     name                          TEXT            NOT NULL,
-    FOREIGN KEY(operation_id)     REFERENCES      operations_v1(operation_id),
     FOREIGN KEY(document_view_id) REFERENCES      document_views(document_view_id) ON DELETE CASCADE
 );
 

--- a/aquadoggo/migrations/20220510022755_create-documents.sql
+++ b/aquadoggo/migrations/20220510022755_create-documents.sql
@@ -1,10 +1,11 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 
 CREATE TABLE IF NOT EXISTS document_view_fields (
-    document_view_id            TEXT            NOT NULL,
-    operation_id                TEXT            NOT NULL,
-    name                        TEXT            NOT NULL,
-    FOREIGN KEY(operation_id)   REFERENCES      operations_v1(operation_id)
+    document_view_id              TEXT            NOT NULL,
+    operation_id                  TEXT            NOT NULL,
+    name                          TEXT            NOT NULL,
+    FOREIGN KEY(operation_id)     REFERENCES      operations_v1(operation_id),
+    FOREIGN KEY(document_view_id) REFERENCES      document_views(document_view_id) ON DELETE CASCADE
 );
 
 CREATE INDEX idx_document_view_fields ON document_view_fields (document_view_id, operation_id, name);

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -387,17 +387,17 @@ impl SqlStore {
             "
             SELECT 
                 document_views.document_view_id, 
-                documents.document_view_id as current_view 
+                documents.document_view_id
             FROM 
                 document_views
             LEFT JOIN 
                 documents 
             ON 
-                current_view = document_views.document_view_id
+                documents.document_view_id = document_views.document_view_id
             WHERE 
                 document_views.document_id = $1
             AND 
-                current_view IS NULL
+                documents.document_view_id IS NULL
             ",
         )
         .bind(document_id.as_str())

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -397,7 +397,7 @@ impl SqlStore {
             WHERE 
                 document_views.document_id = $1
             AND 
-                current_view ISNULL
+                current_view IS NULL
             ",
         )
         .bind(document_id.as_str())

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -369,6 +369,7 @@ impl SqlStore {
     /// Iterate over all views of a document and delete any which:
     /// - are not the current view
     /// - _and_ no document field exists in the database which contains a pinned relation to this view
+    #[allow(dead_code)]
     async fn prune_document_views(
         &self,
         document_id: &DocumentId,
@@ -607,7 +608,7 @@ mod tests {
     use p2panda_rs::document::{DocumentBuilder, DocumentId, DocumentViewFields, DocumentViewId};
     use p2panda_rs::identity::KeyPair;
     use p2panda_rs::operation::traits::AsOperation;
-    use p2panda_rs::operation::{Operation, OperationId, OperationValue};
+    use p2panda_rs::operation::{Operation, OperationId};
     use p2panda_rs::storage_provider::traits::{DocumentStore, OperationStore};
     use p2panda_rs::test_utils::constants;
     use p2panda_rs::test_utils::fixtures::{


### PR DESCRIPTION
- [x] add fk relation with cascading delete between `document_view_fields` and `document_views`
- [x] introduce method to `DocumentStore` which takes a `DocumentId` and deletes any unpinned+not current views  

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
