### PR TITLE
"prune" materializer task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Serve static files from `blobs` directory [#480](https://github.com/p2panda/aquadoggo/pull/480)
 - Add method to store for pruning document views [#491](https://github.com/p2panda/aquadoggo/pull/491)
 - Introduce `BlobStore` [#484](https://github.com/p2panda/aquadoggo/pull/484)
+- `prune` materialization task [#484](https://github.com/p2panda/aquadoggo/pull/496)
 
 ### Changed
 

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -473,7 +473,7 @@ impl SqlStore {
 
         let effected_child_relations: Vec<DocumentId> = effected_child_relations
             .iter()
-            .map(|view_id_string| view_id_string.parse().unwrap())
+            .map(|document_id| document_id.parse().unwrap())
             .collect();
 
         Ok(effected_child_relations)

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -370,6 +370,10 @@ impl SqlStore {
     /// Iterate over all views of a document and delete any which:
     /// - are not the current view
     /// - _and_ no document field exists in the database which contains a pinned relation to this view
+    /// 
+    /// Returns the document ids of any document which were related to in a pinned relation of the
+    /// deleted views. It's useful to return these documents as they themselves may now be
+    /// dangling and require pruning. 
     pub async fn prune_document_views(
         &self,
         document_id: &DocumentId,

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -706,9 +706,7 @@ mod tests {
     use p2panda_rs::test_utils::fixtures::{
         key_pair, operation, random_document_id, random_document_view_id, random_operation_id,
     };
-    use p2panda_rs::test_utils::memory_store::helpers::{
-        populate_store, PopulateStoreConfig,
-    };
+    use p2panda_rs::test_utils::memory_store::helpers::{populate_store, PopulateStoreConfig};
     use p2panda_rs::WithId;
     use rstest::rstest;
 
@@ -1275,12 +1273,12 @@ mod tests {
             assert!(historic_document_view.is_some());
 
             // Create another document, which has a pinned relation to the parent document created
-            // above. Now the relation graph looks like this 
+            // above. Now the relation graph looks like this
             //
             // GrandParent --> Parent --> Child1
-            //                      \                     
+            //                      \
             //                        --> Child2
-            //  
+            //
             let (schema_for_grand_parent, grand_parent_document_view_ids) =
                 add_schema_and_documents(
                     &mut node,

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -451,10 +451,10 @@ impl SqlStore {
                     WHERE
                         operation_fields_v1.field_type IN ('pinned_relation', 'pinned_relation_list')
                     AND 
-                        -- Only select the the values from the one document view we're interested in.
                         document_view_fields.document_view_id = $1
                     AND 
-                        -- And only for the views which are not the current.
+                        -- As we joined above on document_view_id, this field is NULL when 
+                        -- the document view is not the current one for the document.     
                         documents.document_view_id IS NULL
                 )
                 "

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -496,41 +496,6 @@ impl SqlStore {
 
         Ok(effected_child_relations)
     }
-
-    pub async fn get_pinned_children_view_ids(
-        &self,
-        document_view_id: &DocumentViewId,
-    ) -> Result<Vec<DocumentViewId>, DocumentStorageError> {
-        let document_view_ids: Vec<String> = query_scalar(
-            "
-            SELECT DISTINCT
-                operation_fields_v1.value 
-            FROM
-                operation_fields_v1
-            LEFT JOIN 
-                document_view_fields
-            ON
-                document_view_fields.operation_id = operation_fields_v1.operation_id
-            AND
-                document_view_fields.name = operation_fields_v1.name
-            WHERE
-                operation_fields_v1.field_type IN ('pinned_relation', 'pinned_relation_list')
-            AND 
-                document_view_fields.document_view_id = $1
-            ",
-        )
-        .bind(document_view_id.to_string())
-        .fetch_all(&self.pool)
-        .await
-        .map_err(|err| DocumentStorageError::FatalStorageError(err.to_string()))?;
-
-        let document_view_ids: Vec<DocumentViewId> = document_view_ids
-            .iter()
-            .map(|view_id_string| view_id_string.parse().unwrap())
-            .collect();
-
-        Ok(document_view_ids)
-    }
 }
 
 // Helper method for getting rows from the `document_view_fields` table.

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -8,7 +8,7 @@ use tokio::task;
 use crate::bus::{ServiceMessage, ServiceSender};
 use crate::context::Context;
 use crate::manager::{ServiceReadySender, Shutdown};
-use crate::materializer::tasks::{dependency_task, reduce_task, schema_task, prune_task};
+use crate::materializer::tasks::{dependency_task, prune_task, reduce_task, schema_task};
 use crate::materializer::worker::{Factory, Task, TaskStatus};
 use crate::materializer::TaskInput;
 

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -8,7 +8,7 @@ use tokio::task;
 use crate::bus::{ServiceMessage, ServiceSender};
 use crate::context::Context;
 use crate::manager::{ServiceReadySender, Shutdown};
-use crate::materializer::tasks::{dependency_task, reduce_task, schema_task};
+use crate::materializer::tasks::{dependency_task, reduce_task, schema_task, prune_task};
 use crate::materializer::worker::{Factory, Task, TaskStatus};
 use crate::materializer::TaskInput;
 
@@ -38,6 +38,7 @@ pub async fn materializer_service(
     factory.register("reduce", pool_size, reduce_task);
     factory.register("dependency", pool_size, dependency_task);
     factory.register("schema", pool_size, schema_task);
+    factory.register("prune", pool_size, prune_task);
 
     // Get a listener for error signal from factory
     let on_error = factory.on_error();

--- a/aquadoggo/src/materializer/tasks/dependency.rs
+++ b/aquadoggo/src/materializer/tasks/dependency.rs
@@ -988,8 +988,9 @@ mod tests {
                 .await
                 .unwrap()
                 .expect("Should have returned new tasks");
-            assert_eq!(tasks.len(), 1);
-            assert_eq!(tasks[0].worker_name(), &String::from("dependency"));
+            assert_eq!(tasks.len(), 2);
+            assert_eq!(tasks[0].worker_name(), &String::from("prune"));
+            assert_eq!(tasks[1].worker_name(), &String::from("dependency"));
 
             // We should have now a materialized latest post and comment document but not the
             // pinned historical version of the post, where the comment was pointing at!
@@ -1019,7 +1020,7 @@ mod tests {
 
             // 2. The "dependency" task followed materialising the "post" found a reverse relation
             //    to a "comment" document .. it dispatches another "dependency" task for it
-            let tasks = dependency_task(node_b.context.clone(), tasks[0].input().clone())
+            let tasks = dependency_task(node_b.context.clone(), tasks[1].input().clone())
                 .await
                 .unwrap();
             assert_eq!(

--- a/aquadoggo/src/materializer/tasks/mod.rs
+++ b/aquadoggo/src/materializer/tasks/mod.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 mod dependency;
+mod prune;
 mod reduce;
 mod schema;
 
 pub use dependency::dependency_task;
+pub use prune::prune_task;
 pub use reduce::reduce_task;
 pub use schema::schema_task;

--- a/aquadoggo/src/materializer/tasks/prune.rs
+++ b/aquadoggo/src/materializer/tasks/prune.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use log::debug;
+use p2panda_rs::storage_provider::traits::OperationStore;
+
+use crate::context::Context;
+use crate::materializer::worker::{TaskError, TaskResult};
+use crate::materializer::{Task, TaskInput};
+
+pub async fn prune_task(context: Context, input: TaskInput) -> TaskResult<TaskInput> {
+    debug!("Working on {}", input);
+
+    match input {
+        TaskInput::DocumentId(id) => {
+            // This task is concerned with a document which has been reduced and may now have
+            // dangling views. We want to check for this and delete any views which are no longer
+            // needed.
+            let pruned_document_view_ids = context
+                .store
+                .prune_document_views(&id)
+                .await
+                .map_err(|err| TaskError::Critical(err.to_string()))?;
+
+            debug!("Removed document views: {pruned_document_view_ids:#?}");
+            let mut prune_next_documents = vec![];
+            for document_view_id in pruned_document_view_ids {
+                let document_id = context
+                    .store
+                    .get_document_id_by_operation_id(document_view_id.graph_tips().first().unwrap())
+                    .await
+                    .map_err(|err| TaskError::Critical(err.to_string()))?;
+                if let Some(document_id) = document_id {
+                    prune_next_documents.push(document_id);
+                };
+            }
+
+            prune_next_documents.dedup();
+            let next_tasks: Vec<Task<TaskInput>> = prune_next_documents
+                .iter()
+                .map(|document_id| {
+                    debug!("Issue prune task for document: {document_id:#?}");
+                    Task::new("prune", TaskInput::DocumentId(document_id.to_owned()))
+                })
+                .collect();
+
+            if next_tasks.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(next_tasks))
+            }
+        }
+        _ => return Err(TaskError::Critical("Invalid task input".into())),
+    }
+}

--- a/aquadoggo/src/materializer/tasks/prune.rs
+++ b/aquadoggo/src/materializer/tasks/prune.rs
@@ -41,3 +41,186 @@ pub async fn prune_task(context: Context, input: TaskInput) -> TaskResult<TaskIn
         _ => Err(TaskError::Critical("Invalid task input".into())),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use p2panda_rs::document::DocumentId;
+    use p2panda_rs::identity::KeyPair;
+    use p2panda_rs::storage_provider::traits::DocumentStore;
+    use p2panda_rs::test_utils::fixtures::key_pair;
+    use rstest::rstest;
+
+    use crate::materializer::tasks::prune_task;
+    use crate::materializer::{Task, TaskInput};
+    use crate::test_utils::{add_schema_and_documents, test_runner, update_document, TestNode};
+
+    #[rstest]
+    fn prunes_document_views(key_pair: KeyPair) {
+        test_runner(|mut node: TestNode| async move {
+            // Publish some documents which we will later point relations at.
+            let (child_schema, child_document_view_ids) = add_schema_and_documents(
+                &mut node,
+                "schema_for_child",
+                vec![
+                    vec![("uninteresting_field", 1.into(), None)],
+                    vec![("uninteresting_field", 2.into(), None)],
+                ],
+                &key_pair,
+            )
+            .await;
+
+            // Create some parent documents which contain a pinned relation list pointing to the
+            // children created above.
+            let (parent_schema, parent_document_view_ids) = add_schema_and_documents(
+                &mut node,
+                "schema_for_parent",
+                vec![vec![
+                    ("name", "parent".into(), None),
+                    (
+                        "children",
+                        child_document_view_ids.clone().into(),
+                        Some(child_schema.id().to_owned()),
+                    ),
+                ]],
+                &key_pair,
+            )
+            .await;
+
+            // Convert view id to document id.
+            let parent_document_id: DocumentId = parent_document_view_ids[0]
+                .clone()
+                .to_string()
+                .parse()
+                .unwrap();
+
+            // Update the parent document so that there are now two views stored in the db, one
+            // current and one dangling.
+            let updated_parent_view_id = update_document(
+                &mut node,
+                parent_schema.id(),
+                vec![("name", "Parent".into())],
+                &parent_document_view_ids[0],
+                &key_pair,
+            )
+            .await;
+
+            // Get the historic (dangling) view to check it's actually there.
+            let historic_document_view = node
+                .context
+                .store
+                .get_document_by_view_id(&parent_document_view_ids[0].clone())
+                .await
+                .unwrap();
+
+            // It is there...
+            assert!(historic_document_view.is_some());
+
+            // Create another document, which has a pinned relation to the parent document created
+            // above. Now the relation graph looks like this
+            //
+            // GrandParent --> Parent --> Child1
+            //                      \
+            //                        --> Child2
+            //
+            let (schema_for_grand_parent, grand_parent_document_view_ids) =
+                add_schema_and_documents(
+                    &mut node,
+                    "schema_for_grand_parent",
+                    vec![vec![
+                        ("name", "grand parent".into(), None),
+                        (
+                            "child",
+                            parent_document_view_ids[0].clone().into(),
+                            Some(parent_schema.id().to_owned()),
+                        ),
+                    ]],
+                    &key_pair,
+                )
+                .await;
+
+            // Convert view id to document id.
+            let grand_parent_document_id: DocumentId = grand_parent_document_view_ids[0]
+                .clone()
+                .to_string()
+                .parse()
+                .unwrap();
+
+            // Update the grand parent document to a new view, leaving the previous one dangling.
+            //
+            // Note: this method _does not_ dispatch "prune" tasks.
+            update_document(
+                &mut node,
+                schema_for_grand_parent.id(),
+                vec![
+                    ("name", "Grand Parent".into()),
+                    ("child", updated_parent_view_id.into()),
+                ],
+                &grand_parent_document_view_ids[0],
+                &key_pair,
+            )
+            .await;
+
+            // Get the historic (dangling) view to make sure it exists.
+            let historic_document_view = node
+                .context
+                .store
+                .get_document_by_view_id(&grand_parent_document_view_ids[0].clone())
+                .await
+                .unwrap();
+
+            // It does...
+            assert!(historic_document_view.is_some());
+
+            // Now prune dangling views for the grand parent document. This method deletes any
+            // dangling views (not pinned, not current) from the database for this document. It
+            // returns the document ids of any documents which may have views which have become
+            // "un-pinned" as a result of this view being removed. In this case, that's the
+            // document id of the "parent" document.
+            let next_tasks = prune_task(
+                node.context.clone(),
+                TaskInput::DocumentId(grand_parent_document_id),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+            // One new prune task is issued.
+            assert_eq!(next_tasks.len(), 1);
+            // It is the parent (which this grand parent relates to) as we expect.
+            assert_eq!(
+                next_tasks[0],
+                Task::new("prune", TaskInput::DocumentId(parent_document_id))
+            );
+
+            // Check the historic view has been deleted.
+            let historic_document_view = node
+                .context
+                .store
+                .get_document_by_view_id(&grand_parent_document_view_ids[0].clone())
+                .await
+                .unwrap();
+
+            // It has...
+            assert!(historic_document_view.is_none());
+
+            // Now prune dangling views for the parent document.
+            let next_tasks = prune_task(node.context.clone(), next_tasks[0].input().to_owned())
+                .await
+                .unwrap();
+
+            // No more tasks should be issued.
+            assert!(next_tasks.is_none());
+
+            // Check the historic view has been deleted.
+            let historic_document_view = node
+                .context
+                .store
+                .get_document_by_view_id(&parent_document_view_ids[0].clone())
+                .await
+                .unwrap();
+
+            // It has.
+            assert!(historic_document_view.is_none());
+        });
+    }
+}

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -518,7 +518,7 @@ mod tests {
             for document_id in &document_ids {
                 let input = TaskInput::DocumentId(document_id.clone());
                 let tasks = reduce_task(node.context.clone(), input).await.unwrap();
-                assert!(tasks.is_none());
+                assert_eq!(tasks.unwrap().len(), 1);
             }
 
             for document_id in &document_ids {
@@ -545,16 +545,16 @@ mod tests {
     #[rstest]
     #[case(
         populate_store_config(3, 1, 1, false, doggo_schema(), doggo_fields(), doggo_fields()),
-        true
+        vec!["prune".to_string(), "dependency".to_string()]
     )]
     // This document is deleted, it shouldn't spawn a dependency task.
     #[case(
         populate_store_config(3, 1, 1, true, doggo_schema(), doggo_fields(), doggo_fields()),
-        false
+        vec!["prune".to_string()]
     )]
-    fn returns_dependency_task_inputs(
+    fn returns_correct_dependency_and_prune_tasks(
         #[case] config: PopulateStoreConfig,
-        #[case] is_next_task: bool,
+        #[case] expected_worker_names: Vec<String>,
     ) {
         test_runner(move |node: TestNode| async move {
             // Populate the store with some entries and operations but DON'T materialise any
@@ -565,9 +565,16 @@ mod tests {
                 .expect("There should be at least one document id");
 
             let input = TaskInput::DocumentId(document_id.clone());
-            let next_task_inputs = reduce_task(node.context.clone(), input).await.unwrap();
+            let next_tasks = reduce_task(node.context.clone(), input)
+                .await
+                .expect("Ok result")
+                .expect("Some tasks returned");
 
-            assert_eq!(next_task_inputs.is_some(), is_next_task);
+            assert_eq!(next_tasks.len(), expected_worker_names.len());
+
+            for (index, worker_name) in expected_worker_names.iter().enumerate() {
+                assert_eq!(next_tasks[index].worker_name(), worker_name);
+            }
         });
     }
 

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -264,15 +264,17 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
                 ))
             }
 
-            debug!(
-                "Dispatch dependency task for view with id: {}",
-                document.view_id()
-            );
+            if !document.is_deleted() {
+                debug!(
+                    "Dispatch dependency task for view with id: {}",
+                    document.view_id()
+                );
 
-            tasks.push(Task::new(
-                "dependency",
-                TaskInput::DocumentViewId(document.view_id().to_owned()),
-            ));
+                tasks.push(Task::new(
+                    "dependency",
+                    TaskInput::DocumentViewId(document.view_id().to_owned()),
+                ));
+            }
 
             Ok(Some(tasks))
         }

--- a/aquadoggo/src/test_utils/mod.rs
+++ b/aquadoggo/src/test_utils/mod.rs
@@ -13,6 +13,6 @@ pub use db::{drop_database, initialize_db, initialize_sqlite_db};
 pub use helpers::{build_document, doggo_fields, doggo_schema, schema_from_fields};
 pub use node::{
     add_document, add_schema, add_schema_and_documents, populate_and_materialize,
-    populate_store_config, TestNode,
+    populate_store_config, update_document, TestNode,
 };
 pub use runner::{test_runner, test_runner_with_manager, TestNodeManager};

--- a/aquadoggo/src/test_utils/node.rs
+++ b/aquadoggo/src/test_utils/node.rs
@@ -97,7 +97,7 @@ pub async fn populate_and_materialize(
         // Create reduce task input.
         let input = TaskInput::DocumentId(document_id);
         // Run reduce task and collect returned dependency tasks.
-        let mut next_tasks = reduce_task(node.context.clone(), input.clone())
+        let next_tasks = reduce_task(node.context.clone(), input.clone())
             .await
             .expect("Reduce document");
 


### PR DESCRIPTION
Introduces a "prune" materialization task which:
- is issued whenever a "reduce" task completes when the input was a `DocumentId` (this is a new current view)
- the "prune" task looks at the updated document and deletes any rows from the `document_views` and `document_view_fields` table where: they are not the current view AND they are not targeted from a pinned relation of any other document

I also had to make some changes to `prune_document_views` method which was introduced onto the store in a previous PR cos it was not doing what it's supposed to....

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
