### PR TITLE
`blob_v1` and `blob_piece_v1` dependency replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Task for automatic garbage collection of unused documents and views [#500](https://github.com/p2panda/aquadoggo/pull/500)
 - Blobs directory configuration [#549](https://github.com/p2panda/aquadoggo/pull/549)
 - Integrate `Bytes` operation value [554](https://github.com/p2panda/aquadoggo/pull/554/)
+- Implement dependency replication for `blob_v1` and `blob_piece_v1` documents [#514](https://github.com/p2panda/aquadoggo/pull/514)
 
 ### Changed
 

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -251,9 +251,15 @@ impl SqlStore {
                 FROM 
                     document_view_fields
                 LEFT JOIN 
-                    {OPERATION_FIELDS}
+                    operation_fields_v1
+                ON
+                    document_view_fields.operation_id = operation_fields_v1.operation_id
+                AND
+                    document_view_fields.name = operation_fields_v1.name
                 LEFT JOIN 
-                    {DOCUMENT_VIEWS}
+                    document_views
+                ON
+                    document_view_fields.document_view_id = document_views.document_view_id
                 WHERE
                     operation_fields_v1.field_type IN ('pinned_relation', 'pinned_relation_list', 'relation_list', 'relation')
                 AND 

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -229,6 +229,51 @@ impl SqlStore {
 
         Ok(())
     }
+
+    pub async fn get_blob_child_relations(
+        &self,
+        document_id: &DocumentId,
+    ) -> Result<Vec<DocumentId>, SqlStoreError> {
+        let document_ids: Vec<String> = query_scalar(&format!(
+            "
+            SELECT DISTINCT 
+                document_views.document_id
+            FROM
+                document_views
+            WHERE 
+                document_views.schema_id = 'blob_v1' 
+            AND 
+                document_views.document_view_id 
+            IN (
+                SELECT
+                    operation_fields_v1.value
+                FROM 
+                    document_view_fields
+                LEFT JOIN 
+                    {OPERATION_FIELDS}
+                LEFT JOIN 
+                    {DOCUMENT_VIEWS}
+                WHERE
+                    operation_fields_v1.field_type IN ('pinned_relation', 'pinned_relation_list', 'relation_list', 'relation')
+                AND 
+                    document_views.document_id = $1
+            )
+            "
+        ))
+        .bind(document_id.as_str())
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|err| SqlStoreError::Transaction(err.to_string()))?;
+
+        Ok(document_ids
+            .iter()
+            .map(|document_id_str| {
+                document_id_str
+                    .parse::<DocumentId>()
+                    .expect("Document Id's coming from the store should be valid")
+            })
+            .collect())
+    }
 }
 
 /// Throws an error when database does not contain all related blob pieces yet.

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -230,6 +230,7 @@ impl SqlStore {
         Ok(())
     }
 
+    /// Get ids for all blob documents which are related to from any view of the passed document.
     pub async fn get_blob_child_relations(
         &self,
         document_id: &DocumentId,

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -235,7 +235,7 @@ impl SqlStore {
         &self,
         document_id: &DocumentId,
     ) -> Result<Vec<DocumentId>, SqlStoreError> {
-        let document_ids: Vec<String> = query_scalar(&format!(
+        let document_ids: Vec<String> = query_scalar(
             "
             SELECT DISTINCT 
                 document_views.document_id
@@ -266,7 +266,7 @@ impl SqlStore {
                     document_views.document_id = $1
             )
             "
-        ))
+        )
         .bind(document_id.as_str())
         .fetch_all(&self.pool)
         .await

--- a/aquadoggo/src/db/stores/entry.rs
+++ b/aquadoggo/src/db/stores/entry.rs
@@ -189,7 +189,6 @@ impl SqlStore {
         &self,
         document_ids: &[DocumentId],
     ) -> Result<Vec<(PublicKey, Vec<(LogId, SeqNum)>)>, EntryStorageError> {
-        
         // If no document ids were passed then don't query the database. Instead return an empty
         // vec now already.
         if document_ids.is_empty() {

--- a/aquadoggo/src/db/stores/entry.rs
+++ b/aquadoggo/src/db/stores/entry.rs
@@ -189,6 +189,13 @@ impl SqlStore {
         &self,
         document_ids: &[DocumentId],
     ) -> Result<Vec<(PublicKey, Vec<(LogId, SeqNum)>)>, EntryStorageError> {
+        
+        // If no document ids were passed then don't query the database. Instead return an empty
+        // vec now already.
+        if document_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
         let document_ids_str: String = document_ids
             .iter()
             .map(|document_id| format!("'{}'", document_id.as_str()))

--- a/aquadoggo/src/db/stores/entry.rs
+++ b/aquadoggo/src/db/stores/entry.rs
@@ -10,7 +10,6 @@ use p2panda_rs::entry::{EncodedEntry, Entry, LogId, SeqNum};
 use p2panda_rs::hash::Hash;
 use p2panda_rs::identity::PublicKey;
 use p2panda_rs::operation::EncodedOperation;
-use p2panda_rs::schema::SchemaId;
 use p2panda_rs::storage_provider::error::EntryStorageError;
 use p2panda_rs::storage_provider::traits::EntryStore;
 use sqlx::{query, query_as};

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -17,7 +17,7 @@ use crate::schema::SchemaProvider;
 #[derive(Debug, Clone)]
 pub struct SyncIngest {
     tx: ServiceSender,
-    schema_provider: SchemaProvider,
+    pub schema_provider: SchemaProvider,
 }
 
 impl SyncIngest {

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -695,7 +695,6 @@ mod tests {
         test_runner(move |node: TestNode| async move {
             let mode = Mode::LogHeight;
             let (tx, _rx) = broadcast::channel(8);
-            let schema_provider = SchemaProvider::default();
             let ingest = SyncIngest::new(SchemaProvider::default(), tx);
 
             // Sanity check: Id of peer A is < id of peer B.

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -90,7 +90,14 @@ where
         mode: &Mode,
         local: bool,
     ) -> Vec<Message> {
-        let mut session = Session::new(session_id, target_set, mode, local, SUPPORT_LIVE_MODE);
+        let mut session = Session::new(
+            session_id,
+            target_set,
+            mode,
+            local,
+            SUPPORT_LIVE_MODE,
+            self.ingest.schema_provider.clone(),
+        );
         let initial_messages = session.initial_messages(&self.store).await;
 
         if let Some(sessions) = self.sessions.get_mut(remote_peer) {
@@ -111,7 +118,14 @@ where
         mode: &Mode,
         local: bool,
     ) {
-        let session = Session::new(session_id, target_set, mode, local, SUPPORT_LIVE_MODE);
+        let session = Session::new(
+            session_id,
+            target_set,
+            mode,
+            local,
+            SUPPORT_LIVE_MODE,
+            self.ingest.schema_provider.clone(),
+        );
 
         if let Some(sessions) = self.sessions.get_mut(remote_peer) {
             sessions.push(session);
@@ -681,6 +695,7 @@ mod tests {
         test_runner(move |node: TestNode| async move {
             let mode = Mode::LogHeight;
             let (tx, _rx) = broadcast::channel(8);
+            let schema_provider = SchemaProvider::default();
             let ingest = SyncIngest::new(SchemaProvider::default(), tx);
 
             // Sanity check: Id of peer A is < id of peer B.

--- a/aquadoggo/src/replication/strategies/log_height.rs
+++ b/aquadoggo/src/replication/strategies/log_height.rs
@@ -313,6 +313,7 @@ mod tests {
     };
     use p2panda_rs::schema::{Schema, SchemaId};
     use p2panda_rs::test_utils::fixtures::key_pair;
+    use p2panda_rs::test_utils::generate_random_bytes;
     use p2panda_rs::test_utils::memory_store::helpers::{send_to_store, PopulateStoreConfig};
     use rstest::rstest;
     use tokio::sync::broadcast;
@@ -605,7 +606,14 @@ mod tests {
     ) {
         test_runner_with_manager(move |manager: TestNodeManager| async move {
             let mut node_a = manager.create().await;
-            let document_view_id = add_blob(&mut node_a, "Hello World!", &key_pair).await;
+            let document_view_id = add_blob(
+                &mut node_a,
+                &generate_random_bytes(10),
+                5,
+                "text/plain".into(),
+                &key_pair,
+            )
+            .await;
 
             let (schema, _) = add_schema_and_documents(
                 &mut node_a,
@@ -654,7 +662,14 @@ mod tests {
     ) {
         test_runner_with_manager(move |manager: TestNodeManager| async move {
             let mut node_a = manager.create().await;
-            let document_view_id = add_blob(&mut node_a, "Hello World!", &key_pair).await;
+            let document_view_id = add_blob(
+                &mut node_a,
+                &generate_random_bytes(10),
+                2,
+                "text/plain".into(),
+                &key_pair,
+            )
+            .await;
 
             let (schema, _) = add_schema_and_documents(
                 &mut node_a,

--- a/aquadoggo/src/replication/strategies/log_height.rs
+++ b/aquadoggo/src/replication/strategies/log_height.rs
@@ -5,11 +5,13 @@ use std::collections::HashMap;
 use anyhow::Result;
 use async_trait::async_trait;
 use log::trace;
+use p2panda_rs::document::traits::AsDocument;
 use p2panda_rs::document::DocumentId;
 use p2panda_rs::entry::traits::{AsEncodedEntry, AsEntry};
 use p2panda_rs::entry::{LogId, SeqNum};
 use p2panda_rs::identity::PublicKey;
-use p2panda_rs::storage_provider::traits::OperationStore;
+use p2panda_rs::schema::{Schema, SchemaId};
+use p2panda_rs::storage_provider::traits::{DocumentStore, OperationStore};
 use p2panda_rs::Human;
 
 use crate::db::types::StorageEntry;
@@ -18,8 +20,26 @@ use crate::replication::errors::ReplicationError;
 use crate::replication::strategies::diff_log_heights;
 use crate::replication::traits::Strategy;
 use crate::replication::{LogHeights, Message, Mode, SchemaIdSet, StrategyResult};
+use crate::schema::SchemaProvider;
 
 type SortedIndex = i32;
+
+fn has_blob_relation(schema: &Schema) -> bool {
+    for (_, field_type) in schema.fields().iter() {
+        match field_type {
+            p2panda_rs::schema::FieldType::Relation(schema_id)
+            | p2panda_rs::schema::FieldType::RelationList(schema_id)
+            | p2panda_rs::schema::FieldType::PinnedRelation(schema_id)
+            | p2panda_rs::schema::FieldType::PinnedRelationList(schema_id) => {
+                if schema_id == &SchemaId::Blob(1) {
+                    return true;
+                }
+            }
+            _ => (),
+        }
+    }
+    false
+}
 
 /// Retrieve entries from the store, group the result by document id and then sub-order them by
 /// their sorted index.
@@ -66,18 +86,78 @@ async fn retrieve_entries(
 
 #[derive(Clone, Debug)]
 pub struct LogHeightStrategy {
+    schema_provider: SchemaProvider,
     target_set: SchemaIdSet,
     received_remote_have: bool,
     sent_have: bool,
 }
 
 impl LogHeightStrategy {
-    pub fn new(target_set: &SchemaIdSet) -> Self {
+    pub fn new(target_set: &SchemaIdSet, schema_provider: SchemaProvider) -> Self {
         Self {
+            schema_provider,
             target_set: target_set.clone(),
             received_remote_have: false,
             sent_have: false,
         }
+    }
+
+    async fn included_document_ids(&self, store: &SqlStore) -> (Vec<DocumentId>, Vec<DocumentId>) {
+        let wants_blobs = self.target_set().contains(&SchemaId::Blob(1));
+        let wants_blob_pieces = self.target_set().contains(&SchemaId::BlobPiece(1));
+        let mut all_blob_documents_with_dependencies_met = vec![];
+        let mut all_non_blob_documents = vec![];
+        for schema_id in self.target_set().iter() {
+            // If the schema is `blob_v1` or `blob_piece_v1` we don't take any action and just
+            // move onto the next loop as these types of documents are only included as part of
+            // other application documents.
+            if schema_id == &SchemaId::Blob(1) || schema_id == &SchemaId::BlobPiece(1) {
+                continue;
+            }
+
+            let has_blob_relation = match self.schema_provider.get(schema_id).await {
+                Some(schema) => has_blob_relation(&schema),
+                None => false,
+            };
+
+            let schema_documents: Vec<DocumentId> = store
+                .get_documents_by_schema(schema_id)
+                .await
+                .unwrap()
+                .iter()
+                .map(|document| document.id())
+                .cloned()
+                .collect();
+
+            let mut schema_blob_documents = vec![];
+
+            if wants_blobs && has_blob_relation {
+                for document_id in &schema_documents {
+                    let blob_documents = store.get_blob_child_relations(document_id).await.unwrap();
+                    println!("{blob_documents:?}");
+                    schema_blob_documents.extend(blob_documents)
+                }
+            }
+
+            for blob_id in schema_blob_documents {
+                let include_blob = if wants_blob_pieces {
+                    let result = store.get_blob(&blob_id).await;
+                    result.is_ok()
+                } else {
+                    true
+                };
+
+                if include_blob {
+                    all_blob_documents_with_dependencies_met.push(blob_id);
+                }
+            }
+            all_non_blob_documents.extend(schema_documents);
+        }
+
+        (
+            all_non_blob_documents,
+            all_blob_documents_with_dependencies_met,
+        )
     }
 
     // Calculate the heights of all logs which contain contributions to documents in the current
@@ -85,26 +165,18 @@ impl LogHeightStrategy {
     async fn local_log_heights(
         &self,
         store: &SqlStore,
+        included_documents: &[DocumentId],
     ) -> HashMap<PublicKey, Vec<(LogId, SeqNum)>> {
-        let mut log_heights: HashMap<PublicKey, Vec<(LogId, SeqNum)>> = HashMap::new();
+        println!("{included_documents:?}");
+        // For every schema id in the target set retrieve log heights for all contributing authors
+        let document_log_heights = store
+            .get_document_log_heights(included_documents)
+            .await
+            .expect("Fatal database error")
+            .into_iter()
+            .collect();
 
-        for schema_id in self.target_set().iter() {
-            // For every schema id in the target set retrieve log heights for all contributing authors
-            let schema_logs = store
-                .get_log_heights(schema_id)
-                .await
-                .expect("Fatal database error")
-                .into_iter();
-
-            // Then merge them into any existing records for the author
-            for (public_key, logs) in schema_logs {
-                let mut author_logs = log_heights.get(&public_key).cloned().unwrap_or(vec![]);
-                author_logs.extend(logs);
-                author_logs.sort();
-                log_heights.insert(public_key, author_logs);
-            }
-        }
-        log_heights
+        document_log_heights
     }
 
     // Prepare entry responses based on a remotes log heights. The response contains all entries
@@ -116,8 +188,13 @@ impl LogHeightStrategy {
         store: &SqlStore,
         remote_log_heights: &[LogHeights],
     ) -> Vec<Message> {
+        let (document_ids, blob_ids) = self.included_document_ids(store).await;
+        let mut all_document_ids = vec![];
+        all_document_ids.extend(document_ids);
+        all_document_ids.extend(blob_ids.clone());
+
         // Get local log heights for the configured target set.
-        let local_log_heights = self.local_log_heights(store).await;
+        let local_log_heights = self.local_log_heights(store, &all_document_ids).await;
 
         // Compare local and remote log heights to determine what they need from us.
         let remote_needs = diff_log_heights(
@@ -155,7 +232,12 @@ impl Strategy for LogHeightStrategy {
     }
 
     async fn initial_messages(&mut self, store: &SqlStore) -> StrategyResult {
-        let log_heights = self.local_log_heights(store).await;
+        let (document_ids, blob_ids) = self.included_document_ids(store).await;
+        let mut all_document_ids = vec![];
+        all_document_ids.extend(document_ids);
+        all_document_ids.extend(blob_ids);
+
+        let log_heights = self.local_log_heights(store, &all_document_ids).await;
         self.sent_have = true;
 
         StrategyResult {
@@ -212,7 +294,8 @@ mod tests {
     use p2panda_rs::operation::{
         EncodedOperation, OperationAction, OperationBuilder, OperationValue,
     };
-    use p2panda_rs::schema::Schema;
+    use p2panda_rs::schema::{Schema, SchemaId};
+    use p2panda_rs::test_utils::fixtures::key_pair;
     use p2panda_rs::test_utils::memory_store::helpers::{send_to_store, PopulateStoreConfig};
     use rstest::rstest;
     use tokio::sync::broadcast;
@@ -223,8 +306,8 @@ mod tests {
     use crate::replication::strategies::log_height::{retrieve_entries, SortedIndex};
     use crate::replication::{LogHeightStrategy, LogHeights, Message, SchemaIdSet};
     use crate::test_utils::{
-        populate_and_materialize, populate_store_config, test_runner_with_manager, TestNode,
-        TestNodeManager,
+        add_blob, add_schema_and_documents, populate_and_materialize, populate_store_config,
+        test_runner_with_manager, TestNode, TestNodeManager,
     };
 
     // Helper for retrieving operations ordered as expected for replication and testing the result.
@@ -407,7 +490,6 @@ mod tests {
             let schema = config.schema.clone();
             let target_set = SchemaIdSet::new(&vec![schema.id().to_owned()]);
 
-            let strategy_a = LogHeightStrategy::new(&target_set);
             let mut node_a = manager.create().await;
             populate_and_materialize(&mut node_a, &config).await;
 
@@ -415,7 +497,8 @@ mod tests {
             let schema_provider = node_b.context.schema_provider.clone();
             let _ = schema_provider.update(schema).await;
             let (tx, _) = broadcast::channel(50);
-            let ingest = SyncIngest::new(schema_provider, tx);
+            let ingest = SyncIngest::new(schema_provider.clone(), tx);
+            let strategy_a = LogHeightStrategy::new(&target_set, schema_provider.clone());
 
             let entry_responses: Vec<(EncodedEntry, Option<EncodedOperation>)> = strategy_a
                 .entry_responses(&node_a.context.store, &[])
@@ -452,11 +535,14 @@ mod tests {
         test_runner_with_manager(move |manager: TestNodeManager| async move {
             let target_set = SchemaIdSet::new(&vec![config.schema.id().to_owned()]);
 
-            let strategy_a = LogHeightStrategy::new(&target_set);
             let mut node_a = manager.create().await;
-            let (key_pairs, _) = populate_and_materialize(&mut node_a, &config).await;
+            let (key_pairs, document_ids) = populate_and_materialize(&mut node_a, &config).await;
+            let strategy_a =
+                LogHeightStrategy::new(&target_set, node_a.context.schema_provider.clone());
 
-            let log_heights = strategy_a.local_log_heights(&node_a.context.store).await;
+            let log_heights = strategy_a
+                .local_log_heights(&node_a.context.store, &document_ids)
+                .await;
 
             let expected_log_heights = key_pairs
                 .into_iter()
@@ -470,6 +556,59 @@ mod tests {
                     )
                 })
                 .collect();
+
+            assert_eq!(log_heights, expected_log_heights);
+        });
+    }
+
+    #[rstest]
+    #[case(vec![], vec![(LogId::new(5), SeqNum::new(1).unwrap())])]
+    #[case(vec![SchemaId::Blob(1)], vec![(LogId::new(2), SeqNum::new(1).unwrap()), (LogId::new(5), SeqNum::new(1).unwrap())])]
+    #[case(vec![SchemaId::Blob(1), SchemaId::BlobPiece(1)], vec![(LogId::new(2), SeqNum::new(1).unwrap()), (LogId::new(5), SeqNum::new(1).unwrap())])]
+    fn calculates_log_heights_with_complete_blobs(
+        #[case] target_set_extension: Vec<SchemaId>,
+        key_pair: KeyPair,
+        #[case] expected_log_heights: Vec<(LogId, SeqNum)>,
+    ) {
+        test_runner_with_manager(move |manager: TestNodeManager| async move {
+            let mut node_a = manager.create().await;
+            let document_view_id = add_blob(&mut node_a, "Hello World!", &key_pair).await;
+
+            let (schema, document_view_ids) = add_schema_and_documents(
+                &mut node_a,
+                "img",
+                vec![vec![(
+                    "relation_to_blob",
+                    document_view_id.into(),
+                    Some(SchemaId::Blob(1)),
+                )]],
+                &key_pair,
+            )
+            .await;
+
+            let mut target_set_schema = vec![schema.id().to_owned()];
+            target_set_schema.extend(target_set_extension);
+            let target_set = SchemaIdSet::new(&target_set_schema);
+            let _ = node_a.context.schema_provider.update(schema).await;
+
+            let strategy_a =
+                LogHeightStrategy::new(&target_set, node_a.context.schema_provider.clone());
+
+            let (document_ids, blob_ids) = strategy_a
+                .included_document_ids(&node_a.context.store)
+                .await;
+            let mut included_documents = vec![];
+            included_documents.extend(document_ids);
+            included_documents.extend(blob_ids.clone());
+
+            let log_heights = strategy_a
+                .local_log_heights(&node_a.context.store, &included_documents)
+                .await;
+
+            let expected_log_heights =
+                vec![(key_pair.public_key(), expected_log_heights.to_owned())]
+                    .into_iter()
+                    .collect();
 
             assert_eq!(log_heights, expected_log_heights);
         });

--- a/aquadoggo/src/replication/strategies/log_height.rs
+++ b/aquadoggo/src/replication/strategies/log_height.rs
@@ -191,8 +191,7 @@ impl LogHeightStrategy {
         store: &SqlStore,
         included_documents: &[DocumentId],
     ) -> HashMap<PublicKey, Vec<(LogId, SeqNum)>> {
-        println!("{included_documents:?}");
-        // For every schema id in the target set retrieve log heights for all contributing authors
+        // For every included document calculate the heights of any contributing logs.
         store
             .get_document_log_heights(included_documents)
             .await

--- a/aquadoggo/src/replication/strategies/log_height.rs
+++ b/aquadoggo/src/replication/strategies/log_height.rs
@@ -668,7 +668,7 @@ mod tests {
             )
             .await;
 
-            let target_set = TargetSet::new(&target_set_schema);
+            let target_set = SchemaIdSet::new(&target_set_schema);
             let _ = node_a.context.schema_provider.update(schema).await;
 
             let strategy_a =

--- a/aquadoggo/src/replication/strategies/log_height.rs
+++ b/aquadoggo/src/replication/strategies/log_height.rs
@@ -580,19 +580,21 @@ mod tests {
     }
 
     #[rstest]
-    #[case(vec![], vec![(LogId::new(5), SeqNum::new(1).unwrap())])]
+    // In the test we add the schema id of the `img` document to the target which is why this
+    // seemingly empty target set returns log heights....
+    #[case(vec![], vec![(LogId::new(5), SeqNum::new(1).unwrap())])] // LogId 5 is where the img document lives
     #[case(
         vec![SchemaId::Blob(1)],
         vec![
-            (LogId::new(2), SeqNum::new(1).unwrap()),
+            (LogId::new(2), SeqNum::new(1).unwrap()), // LogId 2 is where the blob document lives
             (LogId::new(5), SeqNum::new(1).unwrap())
         ]
     )]
     #[case(
         vec![SchemaId::Blob(1), SchemaId::BlobPiece(1)],
         vec![
-            (LogId::new(0), SeqNum::new(1).unwrap()),
-            (LogId::new(1), SeqNum::new(1).unwrap()),
+            (LogId::new(0), SeqNum::new(1).unwrap()), // LogId 0 is where a blob piece lives
+            (LogId::new(1), SeqNum::new(1).unwrap()), // LogId 1 is where a blob piece lives
             (LogId::new(2), SeqNum::new(1).unwrap()),
             (LogId::new(5), SeqNum::new(1).unwrap())
         ]

--- a/aquadoggo/src/replication/strategies/log_height.rs
+++ b/aquadoggo/src/replication/strategies/log_height.rs
@@ -103,16 +103,16 @@ impl LogHeightStrategy {
     }
 
     /// Calculate the documents which should be included in this replication session.
-    /// 
+    ///
     /// This is based on the schema ids included in the target set and any document dependencies
     /// which we have on our local node. Documents which are of type `blob_v1` are only included
     /// if the `blob_v1` schema is included in the target set _and_ the blob document is related
     /// to from another document (also of a schema included in the target set). The same is true
     /// of `blob_piece_v1` documents. These are only included if a blob document is also included
     /// which relates to them.
-    /// 
+    ///
     /// For example, a target set including the schema id `[img_0020, blob_v1]` would look at all
-    /// `img_0020` documents and only include blobs which they relate to. 
+    /// `img_0020` documents and only include blobs which they relate to.
     async fn included_document_ids(&self, store: &SqlStore) -> Vec<DocumentId> {
         let wants_blobs = self.target_set().contains(&SchemaId::Blob(1));
         let wants_blob_pieces = self.target_set().contains(&SchemaId::BlobPiece(1));
@@ -152,7 +152,6 @@ impl LogHeightStrategy {
                     schema_blob_documents.extend(blob_documents)
                 }
             }
-
 
             // If `blob_piece_v1` is included in the target set.
             if wants_blob_pieces && has_blob_relation {
@@ -194,14 +193,12 @@ impl LogHeightStrategy {
     ) -> HashMap<PublicKey, Vec<(LogId, SeqNum)>> {
         println!("{included_documents:?}");
         // For every schema id in the target set retrieve log heights for all contributing authors
-        let document_log_heights = store
+        store
             .get_document_log_heights(included_documents)
             .await
             .expect("Fatal database error")
             .into_iter()
-            .collect();
-
-        document_log_heights
+            .collect()
     }
 
     // Prepare entry responses based on a remotes log heights. The response contains all entries
@@ -585,18 +582,18 @@ mod tests {
     #[rstest]
     #[case(vec![], vec![(LogId::new(5), SeqNum::new(1).unwrap())])]
     #[case(
-        vec![SchemaId::Blob(1)], 
+        vec![SchemaId::Blob(1)],
         vec![
-            (LogId::new(2), SeqNum::new(1).unwrap()), 
+            (LogId::new(2), SeqNum::new(1).unwrap()),
             (LogId::new(5), SeqNum::new(1).unwrap())
         ]
     )]
     #[case(
-        vec![SchemaId::Blob(1), SchemaId::BlobPiece(1)], 
+        vec![SchemaId::Blob(1), SchemaId::BlobPiece(1)],
         vec![
-            (LogId::new(0), SeqNum::new(1).unwrap()), 
-            (LogId::new(1), SeqNum::new(1).unwrap()), 
-            (LogId::new(2), SeqNum::new(1).unwrap()), 
+            (LogId::new(0), SeqNum::new(1).unwrap()),
+            (LogId::new(1), SeqNum::new(1).unwrap()),
+            (LogId::new(2), SeqNum::new(1).unwrap()),
             (LogId::new(5), SeqNum::new(1).unwrap())
         ]
     )]

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -35,6 +35,17 @@
 #     "schema_definition_v1",
 #     "schema_field_definition_v1",
 #
+#     # To replicate documents which represent BLOBs include the following two
+#     # built-in schema ids. This does not instruct your node to replicate any 
+#     # BLOBs it finds on the network, but only those which are dependencies of
+#     # other documents you already have. 
+#     #
+#     # If you only want to replicate the meta data, but not the binary content
+#     # then only include the `blob_v1`.
+#
+#     "blob_v1",
+#     "blob_piece_v1",
+#
 #     # Once you discover new schemas and want to start replicating their
 #     # documents, then add their schema ids to this list as well. It's also
 #     # possible to create and load schemas directly onto your node using the

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -35,14 +35,13 @@
 #     "schema_definition_v1",
 #     "schema_field_definition_v1",
 #
-#     # To replicate documents which represent BLOBs include the following two
-#     # built-in schema ids. This does not instruct your node to replicate any 
-#     # BLOBs it finds on the network, but only those which are dependencies of
-#     # other documents you already have. 
+#     # To replicate documents which represent blobs (binary files) include the
+#     # following two built-in schema ids. This does not instruct your node to
+#     # replicate any blobs it finds on the network, but only those which are
+#     # dependencies of # other documents you already have.
 #     #
 #     # If you only want to replicate the meta data, not the binary content,
 #     # then only include the `blob_v1`.
-#
 #     "blob_v1",
 #     "blob_piece_v1",
 #

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -40,7 +40,7 @@
 #     # BLOBs it finds on the network, but only those which are dependencies of
 #     # other documents you already have. 
 #     #
-#     # If you only want to replicate the meta data, but not the binary content
+#     # If you only want to replicate the meta data, not the binary content,
 #     # then only include the `blob_v1`.
 #
 #     "blob_v1",


### PR DESCRIPTION
`blob_v1` and `blob_piece_v1` documents should only be replicated if they are related to from another document which is included because of schema specified in the target set. For example:

- `TargetSet([img_0020, blob_v1])` would included all `img_0020` documents and any `blob_v1` documents they relate to
- `TargetSet([img_0020, blob_v1, blob_piece_v1])` would included all `img_0020` documents and any `blob_v1` documents they relate to, and any `blob_piece_v1` documents _they_ relate to
- `TargetSet([img_0020])` would included all `img_0020` documents and nothing else
- `TargetSet([blob_v1, blob_piece_v1])` would not include anything

Next step is to add a config flag which adds the correct blob system schema to the target set for you: https://github.com/p2panda/aquadoggo/issues/564 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
