### PR TITLE
Announce supported schema ids in network before replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only replicate and materialize configured "supported schema" [#569](https://github.com/p2panda/aquadoggo/pull/469)
 - Parse supported schema ids from `config.toml` [#473](https://github.com/p2panda/aquadoggo/pull/473)
 - Fix relayed connections, add DCUtR Holepunching and reduce CLI args [#502](https://github.com/p2panda/aquadoggo/pull/502)
+- Target set announcements in network [#515](https://github.com/p2panda/aquadoggo/pull/515)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only replicate and materialize configured "supported schema" [#569](https://github.com/p2panda/aquadoggo/pull/469)
 - Parse supported schema ids from `config.toml` [#473](https://github.com/p2panda/aquadoggo/pull/473)
 - Fix relayed connections, add DCUtR Holepunching and reduce CLI args [#502](https://github.com/p2panda/aquadoggo/pull/502)
-- Target set announcements in network [#515](https://github.com/p2panda/aquadoggo/pull/515)
+- Announce supported schema ids in network before replication [#515](https://github.com/p2panda/aquadoggo/pull/515)
 
 ### Changed
 

--- a/aquadoggo/src/bus.rs
+++ b/aquadoggo/src/bus.rs
@@ -3,8 +3,7 @@
 use p2panda_rs::operation::OperationId;
 
 use crate::manager::Sender;
-use crate::network::Peer;
-use crate::replication::SyncMessage;
+use crate::network::{Peer, PeerMessage};
 
 /// Sender for cross-service communication bus.
 pub type ServiceSender = Sender<ServiceMessage>;
@@ -21,11 +20,11 @@ pub enum ServiceMessage {
     /// Node closed a connection to another node.
     PeerDisconnected(Peer),
 
-    /// Node sent a message to remote node for replication.
-    SentReplicationMessage(Peer, SyncMessage),
+    /// Node sent a message to remote node.
+    SentMessage(Peer, PeerMessage),
 
     /// Node received a message from remote node for replication.
-    ReceivedReplicationMessage(Peer, SyncMessage),
+    ReceivedMessage(Peer, PeerMessage),
 
     /// Replication protocol failed with an critical error.
     ReplicationFailed(Peer),

--- a/aquadoggo/src/bus.rs
+++ b/aquadoggo/src/bus.rs
@@ -23,7 +23,7 @@ pub enum ServiceMessage {
     /// Node sent a message to remote node.
     SentMessage(Peer, PeerMessage),
 
-    /// Node received a message from remote node for replication.
+    /// Node received a message from remote node.
     ReceivedMessage(Peer, PeerMessage),
 
     /// Replication protocol failed with an critical error.

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -10,6 +10,6 @@ mod swarm;
 mod transport;
 
 pub use config::NetworkConfiguration;
-pub use peers::Peer;
+pub use peers::{Peer, PeerMessage};
 pub use service::network_service;
 pub use shutdown::ShutdownHandler;

--- a/aquadoggo/src/network/peers/handler.rs
+++ b/aquadoggo/src/network/peers/handler.rs
@@ -15,8 +15,7 @@ use libp2p::swarm::{
 use log::warn;
 use thiserror::Error;
 
-use crate::network::peers::{Codec, CodecError, Protocol};
-use crate::replication::SyncMessage;
+use crate::network::peers::{Codec, CodecError, PeerMessage, Protocol};
 
 /// The time a connection is maintained to a peer without being in live mode and without
 /// send/receiving a message from. Connections that idle beyond this timeout are disconnected.
@@ -89,7 +88,7 @@ pub struct Handler {
     outbound_substream_establishing: bool,
 
     /// Queue of messages that we want to send to the remote.
-    send_queue: VecDeque<SyncMessage>,
+    send_queue: VecDeque<PeerMessage>,
 
     /// Last time we've observed inbound or outbound messaging activity.
     last_io_activity: Instant,
@@ -140,7 +139,7 @@ impl Handler {
 #[derive(Debug)]
 pub enum HandlerFromBehaviour {
     /// Message to send on outbound stream.
-    Message(SyncMessage),
+    Message(PeerMessage),
 
     /// Protocol failed with a critical error.
     CriticalError,
@@ -152,7 +151,7 @@ pub enum HandlerFromBehaviour {
 #[derive(Debug)]
 pub enum HandlerToBehaviour {
     /// Message received on the inbound stream.
-    Message(SyncMessage),
+    Message(PeerMessage),
 }
 
 #[derive(Debug, Error)]
@@ -181,7 +180,7 @@ enum OutboundSubstreamState {
     WaitingOutput(Stream),
 
     /// Waiting to send a message to the remote.
-    PendingSend(Stream, SyncMessage),
+    PendingSend(Stream, PeerMessage),
 
     /// Waiting to flush the substream so that the data arrives to the remote.
     PendingFlush(Stream),

--- a/aquadoggo/src/network/peers/message.rs
+++ b/aquadoggo/src/network/peers/message.rs
@@ -6,7 +6,6 @@ use crate::replication::{AnnouncementMessage, SyncMessage};
 
 /// p2panda protocol messages which can be sent over the wire.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(untagged)]
 pub enum PeerMessage {
     /// Announcement of peers about the schema ids they are interest in.
     Announce(AnnouncementMessage),

--- a/aquadoggo/src/network/peers/message.rs
+++ b/aquadoggo/src/network/peers/message.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use serde::{Deserialize, Serialize};
+
+use crate::replication::SyncMessage;
+
+/// p2panda protocol messages which can be sent over the wire.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PeerMessage {
+    /// Announcement of peers about the schema ids they are interest in.
+    // Announce(AnnounceMessage),
+
+    /// Replication status and data exchange.
+    SyncMessage(SyncMessage),
+}

--- a/aquadoggo/src/network/peers/message.rs
+++ b/aquadoggo/src/network/peers/message.rs
@@ -6,6 +6,7 @@ use crate::replication::{AnnouncementMessage, SyncMessage};
 
 /// p2panda protocol messages which can be sent over the wire.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum PeerMessage {
     /// Announcement of peers about the schema ids they are interest in.
     Announce(AnnouncementMessage),

--- a/aquadoggo/src/network/peers/message.rs
+++ b/aquadoggo/src/network/peers/message.rs
@@ -2,14 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::replication::SyncMessage;
+use crate::replication::{AnnouncementMessage, SyncMessage};
 
 /// p2panda protocol messages which can be sent over the wire.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PeerMessage {
     /// Announcement of peers about the schema ids they are interest in.
-    // Announce(AnnounceMessage),
+    Announce(AnnouncementMessage),
 
     /// Replication status and data exchange.
     SyncMessage(SyncMessage),

--- a/aquadoggo/src/network/peers/mod.rs
+++ b/aquadoggo/src/network/peers/mod.rs
@@ -2,10 +2,12 @@
 
 mod behaviour;
 mod handler;
+mod message;
 mod peer;
 mod protocol;
 
 pub use behaviour::{Behaviour, Event};
 pub use handler::Handler;
+pub use message::PeerMessage;
 pub use peer::Peer;
 pub use protocol::{Codec, CodecError, Protocol, PROTOCOL_NAME};

--- a/aquadoggo/src/network/peers/protocol.rs
+++ b/aquadoggo/src/network/peers/protocol.rs
@@ -7,13 +7,13 @@ use futures::{future, AsyncRead, AsyncWrite, Future};
 use libp2p::core::UpgradeInfo;
 use libp2p::{InboundUpgrade, OutboundUpgrade};
 
-use crate::replication::SyncMessage;
+use crate::network::peers::PeerMessage;
 
 pub const PROTOCOL_NAME: &str = "/p2p/p2panda/1.0.0";
 
 pub type CodecError = CborCodecError;
 
-pub type Codec = CborCodec<SyncMessage, SyncMessage>;
+pub type Codec = CborCodec<PeerMessage, PeerMessage>;
 
 #[derive(Clone, Debug)]
 pub struct Protocol;

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -344,11 +344,11 @@ impl EventLoop {
     /// Handle an incoming message via the communication bus from other services.
     async fn handle_service_message(&mut self, message: ServiceMessage) {
         match message {
-            ServiceMessage::SentReplicationMessage(peer, sync_message) => self
+            ServiceMessage::SentMessage(peer, peer_message) => self
                 .swarm
                 .behaviour_mut()
                 .peers
-                .send_message(peer, sync_message),
+                .send_message(peer, peer_message),
             ServiceMessage::ReplicationFailed(peer) => {
                 self.swarm.behaviour_mut().peers.handle_critical_error(peer);
             }
@@ -368,10 +368,7 @@ impl EventLoop {
             }
             peers::Event::MessageReceived(peer, message) => {
                 // Inform other services about received messages from peer
-                self.send_service_message(ServiceMessage::ReceivedReplicationMessage(
-                    *peer,
-                    message.clone(),
-                ))
+                self.send_service_message(ServiceMessage::ReceivedMessage(*peer, message.clone()))
             }
         }
     }

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -20,6 +20,8 @@ pub fn now() -> u64 {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Announcement {
     /// This contains a list of schema ids this peer allowed to support.
+    // @TODO: `TargetSet` is not a good name anymore in this context. See related issue:
+    // https://github.com/p2panda/aquadoggo/issues/527
     pub supported_schema_ids: TargetSet,
 
     /// Timestamp of this announcement. Helps to understand if we can override the previous
@@ -142,13 +144,13 @@ mod tests {
     use p2panda_rs::serde::{deserialize_into, serialize_from, serialize_value};
     use rstest::rstest;
 
-    use crate::replication::SchemaIdSet;
+    use crate::replication::TargetSet;
     use crate::test_utils::helpers::random_target_set;
 
     use super::{Announcement, AnnouncementMessage};
 
     #[rstest]
-    fn serialize(#[from(random_target_set)] supported_schema_ids: SchemaIdSet) {
+    fn serialize(#[from(random_target_set)] supported_schema_ids: TargetSet) {
         let announcement = Announcement::new(supported_schema_ids.clone());
         assert_eq!(
             serialize_from(AnnouncementMessage::new(announcement.clone())),
@@ -157,7 +159,7 @@ mod tests {
     }
 
     #[rstest]
-    fn deserialize(#[from(random_target_set)] supported_schema_ids: SchemaIdSet) {
+    fn deserialize(#[from(random_target_set)] supported_schema_ids: TargetSet) {
         assert_eq!(
             deserialize_into::<AnnouncementMessage>(&serialize_value(cbor!([
                 0,

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -2,7 +2,14 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use p2panda_rs::Validate;
+use serde::de::Visitor;
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Serialize};
+
 use crate::replication::TargetSet;
+
+const ANNOUNCEMENT_MESSAGE_VERSION: u64 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Announcement {
@@ -25,5 +32,69 @@ impl Announcement {
             timestamp,
             target_set,
         }
+    }
+}
+
+/// Message which can be used to send announcements over the wire.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AnnouncementMessage(Announcement);
+
+impl Serialize for AnnouncementMessage {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(3))?;
+        seq.serialize_element(&ANNOUNCEMENT_MESSAGE_VERSION)?;
+        seq.serialize_element(&self.0.timestamp)?;
+        seq.serialize_element(&self.0.target_set)?;
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AnnouncementMessage {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct MessageVisitor;
+
+        impl<'de> Visitor<'de> for MessageVisitor {
+            type Value = AnnouncementMessage;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("p2panda announce message")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let version: u64 = seq.next_element()?.ok_or_else(|| {
+                    serde::de::Error::custom("missing version in announce message")
+                })?;
+                if version != ANNOUNCEMENT_MESSAGE_VERSION {
+                    return Err(serde::de::Error::custom("invalid announce message version"));
+                }
+
+                let timestamp: u64 = seq.next_element()?.ok_or_else(|| {
+                    serde::de::Error::custom("missing timestamp in announce message")
+                })?;
+
+                let target_set: TargetSet = seq.next_element()?.ok_or_else(|| {
+                    serde::de::Error::custom("missing target set in announce message")
+                })?;
+                target_set.validate().map_err(|_| {
+                    serde::de::Error::custom("invalid target set in announce message")
+                })?;
+
+                Ok(AnnouncementMessage(Announcement {
+                    target_set,
+                    timestamp,
+                }))
+            }
+        }
+
+        deserializer.deserialize_seq(MessageVisitor)
     }
 }

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -9,6 +9,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::replication::{TargetSet, REPLICATION_PROTOCOL_VERSION};
 
+/// u64 timestamp from UNIX epoch until now.
+pub fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("System time invalid, operation system time configured before UNIX epoch")
+        .as_secs()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Announcement {
     /// This contains a list of schema ids this peer is interested in.
@@ -21,13 +29,8 @@ pub struct Announcement {
 
 impl Announcement {
     pub fn new(target_set: TargetSet) -> Self {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("System time invalid, operation system time configured before UNIX epoch")
-            .as_secs();
-
         Self {
-            timestamp,
+            timestamp: now(),
             target_set,
         }
     }

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -152,7 +152,7 @@ mod tests {
         let announcement = Announcement::new(target_set.clone());
         assert_eq!(
             serialize_from(AnnouncementMessage::new(announcement.clone())),
-            serialize_value(cbor!([1, announcement.timestamp, target_set]))
+            serialize_value(cbor!([0, 1, announcement.timestamp, target_set]))
         );
     }
 
@@ -160,7 +160,7 @@ mod tests {
     fn deserialize(#[from(random_target_set)] target_set: TargetSet) {
         assert_eq!(
             deserialize_into::<AnnouncementMessage>(&serialize_value(cbor!([
-                1, 12345678, target_set
+                0, 1, 12345678, target_set
             ])))
             .unwrap(),
             AnnouncementMessage::new(Announcement {
@@ -171,12 +171,14 @@ mod tests {
     }
 
     #[rstest]
-    #[should_panic(expected = "missing protocol version in announce message")]
+    #[should_panic(expected = "missing message type in announce message")]
     #[case::missing_version(cbor!([]))]
+    #[should_panic(expected = "missing protocol version in announce message")]
+    #[case::missing_version(cbor!([0]))]
     #[should_panic(expected = "missing timestamp in announce message")]
-    #[case::missing_timestamp(cbor!([122]))]
+    #[case::missing_timestamp(cbor!([0, 122]))]
     #[should_panic(expected = "too many fields for announce message")]
-    #[case::too_many_fields(cbor!([1, 0, ["schema_field_definition_v1"], "too much"]))]
+    #[case::too_many_fields(cbor!([0, 1, 0, ["schema_field_definition_v1"], "too much"]))]
     fn deserialize_invalid_messages(#[case] cbor: Result<Value, Error>) {
         // Check the cbor is valid
         assert!(cbor.is_ok());

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -7,11 +7,11 @@ use crate::replication::TargetSet;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Announcement {
     /// This contains a list of schema ids this peer is interested in.
-    target_set: TargetSet,
+    pub target_set: TargetSet,
 
     /// Timestamp of this announcement. Helps to understand if we can override the previous
     /// announcement with a newer one.
-    timestamp: u64,
+    pub timestamp: u64,
 }
 
 impl Announcement {

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -37,7 +37,7 @@ impl Announcement {
 
 /// Message which can be used to send announcements over the wire.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct AnnouncementMessage(Announcement);
+pub struct AnnouncementMessage(pub Announcement);
 
 impl Serialize for AnnouncementMessage {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -7,9 +7,7 @@ use serde::de::Visitor;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 
-use crate::replication::TargetSet;
-
-const ANNOUNCEMENT_MESSAGE_VERSION: u64 = 1;
+use crate::replication::{TargetSet, REPLICATION_PROTOCOL_VERSION};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Announcement {
@@ -45,7 +43,7 @@ impl Serialize for AnnouncementMessage {
         S: serde::Serializer,
     {
         let mut seq = serializer.serialize_seq(Some(3))?;
-        seq.serialize_element(&ANNOUNCEMENT_MESSAGE_VERSION)?;
+        seq.serialize_element(&REPLICATION_PROTOCOL_VERSION)?;
         seq.serialize_element(&self.0.timestamp)?;
         seq.serialize_element(&self.0.target_set)?;
         seq.end()
@@ -73,7 +71,7 @@ impl<'de> Deserialize<'de> for AnnouncementMessage {
                 let version: u64 = seq.next_element()?.ok_or_else(|| {
                     serde::de::Error::custom("missing version in announce message")
                 })?;
-                if version != ANNOUNCEMENT_MESSAGE_VERSION {
+                if version != REPLICATION_PROTOCOL_VERSION {
                     return Err(serde::de::Error::custom("invalid announce message version"));
                 }
 

--- a/aquadoggo/src/replication/announcement.rs
+++ b/aquadoggo/src/replication/announcement.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::replication::TargetSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Announcement {
+    /// This contains a list of schema ids this peer is interested in.
+    target_set: TargetSet,
+
+    /// Timestamp of this announcement. Helps to understand if we can override the previous
+    /// announcement with a newer one.
+    timestamp: u64,
+}
+
+impl Announcement {
+    pub fn new(target_set: TargetSet) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("System time invalid, operation system time configured before UNIX epoch")
+            .as_secs();
+
+        Self {
+            timestamp,
+            target_set,
+        }
+    }
+}

--- a/aquadoggo/src/replication/errors.rs
+++ b/aquadoggo/src/replication/errors.rs
@@ -56,9 +56,6 @@ pub enum IngestError {
 
 #[derive(Error, Debug)]
 pub enum TargetSetError {
-    #[error("Target set does not contain any schema ids")]
-    ZeroSchemaIds,
-
     #[error("Target set contains unsorted or duplicate schema ids")]
     UnsortedSchemaIds,
 }

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -51,15 +51,14 @@ impl SyncIngest {
 
         // If the node has been configured with a whitelist of supported schema ids, check that the
         // sent operation follows one of our supported schema
-        if self.schema_provider.is_whitelist_active() {
-            if self
+        if self.schema_provider.is_whitelist_active()
+            && self
                 .schema_provider
                 .supported_schema_ids()
                 .await
                 .contains(plain_operation.schema_id())
-            {
-                return Err(IngestError::UnsupportedSchema);
-            }
+        {
+            return Err(IngestError::UnsupportedSchema);
         }
 
         // Retrieve the schema if it has been materialized on the node.

--- a/aquadoggo/src/replication/ingest.rs
+++ b/aquadoggo/src/replication/ingest.rs
@@ -49,10 +49,15 @@ impl SyncIngest {
 
         let plain_operation = decode_operation(encoded_operation)?;
 
-        // If the node has been configured with supported_schema_ids, check that the sent
-        // operation follows one of our supported schema.
-        if let Some(supported_schema_ids) = self.schema_provider.supported_schema_ids() {
-            if supported_schema_ids.contains(plain_operation.schema_id()) {
+        // If the node has been configured with a whitelist of supported schema ids, check that the
+        // sent operation follows one of our supported schema
+        if self.schema_provider.is_whitelist_active() {
+            if self
+                .schema_provider
+                .supported_schema_ids()
+                .await
+                .contains(plain_operation.schema_id())
+            {
                 return Err(IngestError::UnsupportedSchema);
             }
         }

--- a/aquadoggo/src/replication/manager.rs
+++ b/aquadoggo/src/replication/manager.rs
@@ -520,8 +520,8 @@ mod tests {
     use tokio::sync::broadcast;
 
     use crate::replication::errors::{DuplicateSessionRequestError, ReplicationError};
-    use crate::replication::message::{Message, HAVE_TYPE, SYNC_DONE_TYPE};
-    use crate::replication::{Mode, SyncIngest, SyncMessage, TargetSet};
+    use crate::replication::message::Message;
+    use crate::replication::{Mode, SyncIngest, SyncMessage, TargetSet, HAVE_TYPE, SYNC_DONE_TYPE};
     use crate::schema::SchemaProvider;
     use crate::test_utils::helpers::random_target_set;
     use crate::test_utils::{

--- a/aquadoggo/src/replication/message.rs
+++ b/aquadoggo/src/replication/message.rs
@@ -247,7 +247,7 @@ mod tests {
                 51,
                 Message::SyncRequest(Mode::SetReconciliation, target_set.clone())
             )),
-            serialize_value(cbor!([0, 51, 1, target_set]))
+            serialize_value(cbor!([1, 51, 1, target_set]))
         );
 
         assert_eq!(
@@ -274,7 +274,7 @@ mod tests {
     #[rstest]
     fn deserialize(#[from(random_target_set)] target_set: TargetSet, public_key: PublicKey) {
         assert_eq!(
-            deserialize_into::<SyncMessage>(&serialize_value(cbor!([0, 12, 0, target_set])))
+            deserialize_into::<SyncMessage>(&serialize_value(cbor!([1, 12, 0, target_set])))
                 .unwrap(),
             SyncMessage::new(
                 12,

--- a/aquadoggo/src/replication/message.rs
+++ b/aquadoggo/src/replication/message.rs
@@ -307,6 +307,8 @@ mod tests {
     #[case::unknown_message_type(cbor!([122, 0]))]
     #[should_panic(expected = "missing session id in replication message")]
     #[case::only_message_type(cbor!([0]))]
+    #[should_panic(expected = "empty target set in sync request")]
+    #[case::only_message_type(cbor!([0, 0, 0, []]))]
     #[should_panic(expected = "too many fields for replication message")]
     #[case::too_many_fields(cbor!([0, 0, 0, ["schema_field_definition_v1"], "too much"]))]
     fn deserialize_invalid_messages(#[case] cbor: Result<Value, Error>) {

--- a/aquadoggo/src/replication/message.rs
+++ b/aquadoggo/src/replication/message.rs
@@ -13,12 +13,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::replication::{Mode, SessionId, TargetSet};
 
-pub const SYNC_REQUEST_TYPE: MessageType = 0;
-pub const ENTRY_TYPE: MessageType = 8;
-pub const SYNC_DONE_TYPE: MessageType = 9;
+pub const ANNOUNCE_TYPE: MessageType = 0;
+pub const SYNC_REQUEST_TYPE: MessageType = 1;
+pub const SYNC_DONE_TYPE: MessageType = 2;
+pub const ENTRY_TYPE: MessageType = 3;
 pub const HAVE_TYPE: MessageType = 10;
 
 pub type MessageType = u64;
+
+pub type Timestamp = u64;
 
 pub type LiveMode = bool;
 
@@ -26,19 +29,21 @@ pub type LogHeights = (PublicKey, Vec<(LogId, SeqNum)>);
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Message {
+    Announce(Timestamp, TargetSet),
     SyncRequest(Mode, TargetSet),
+    Have(Vec<LogHeights>),
     Entry(EncodedEntry, Option<EncodedOperation>),
     SyncDone(LiveMode),
-    Have(Vec<LogHeights>),
 }
 
 impl Message {
     pub fn message_type(&self) -> MessageType {
         match self {
+            Message::Announce(_, _) => ANNOUNCE_TYPE,
             Message::SyncRequest(_, _) => SYNC_REQUEST_TYPE,
+            Message::Have(_) => HAVE_TYPE,
             Message::Entry(_, _) => ENTRY_TYPE,
             Message::SyncDone(_) => SYNC_DONE_TYPE,
-            Message::Have(_) => HAVE_TYPE,
         }
     }
 }
@@ -98,10 +103,21 @@ impl Serialize for SyncMessage {
         };
 
         match self.message() {
+            Message::Announce(timestamp, target_set) => {
+                let mut seq = serialize_header(serializer.serialize_seq(Some(4))?)?;
+                seq.serialize_element(timestamp)?;
+                seq.serialize_element(target_set)?;
+                seq.end()
+            }
             Message::SyncRequest(mode, target_set) => {
                 let mut seq = serialize_header(serializer.serialize_seq(Some(4))?)?;
                 seq.serialize_element(mode)?;
                 seq.serialize_element(target_set)?;
+                seq.end()
+            }
+            Message::Have(log_heights) => {
+                let mut seq = serialize_header(serializer.serialize_seq(Some(3))?)?;
+                seq.serialize_element(log_heights)?;
                 seq.end()
             }
             Message::Entry(entry_bytes, operation_bytes) => {
@@ -113,11 +129,6 @@ impl Serialize for SyncMessage {
             Message::SyncDone(live_mode) => {
                 let mut seq = serialize_header(serializer.serialize_seq(Some(3))?)?;
                 seq.serialize_element(live_mode)?;
-                seq.end()
-            }
-            Message::Have(log_heights) => {
-                let mut seq = serialize_header(serializer.serialize_seq(Some(3))?)?;
-                seq.serialize_element(log_heights)?;
                 seq.end()
             }
         }
@@ -150,7 +161,17 @@ impl<'de> Deserialize<'de> for SyncMessage {
                     serde::de::Error::custom("missing session id in replication message")
                 })?;
 
-                let message = if message_type == SYNC_REQUEST_TYPE {
+                let message = if message_type == ANNOUNCE_TYPE {
+                    let timestamp: Timestamp = seq.next_element()?.ok_or_else(|| {
+                        serde::de::Error::custom("missing timestamp in announce message")
+                    })?;
+
+                    let target_set: TargetSet = seq.next_element()?.ok_or_else(|| {
+                        serde::de::Error::custom("missing target set in announce message")
+                    })?;
+
+                    Ok(Message::Announce(timestamp, target_set))
+                } else if message_type == SYNC_REQUEST_TYPE {
                     let mode: Mode = seq.next_element()?.ok_or_else(|| {
                         serde::de::Error::custom("missing mode in sync request message")
                     })?;

--- a/aquadoggo/src/replication/message.rs
+++ b/aquadoggo/src/replication/message.rs
@@ -11,14 +11,10 @@ use serde::de::Visitor;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};
 
-use crate::replication::{Mode, SessionId, TargetSet};
-
-pub const SYNC_REQUEST_TYPE: MessageType = 0;
-pub const ENTRY_TYPE: MessageType = 8;
-pub const SYNC_DONE_TYPE: MessageType = 9;
-pub const HAVE_TYPE: MessageType = 10;
-
-pub type MessageType = u64;
+use crate::replication::{
+    MessageType, Mode, SessionId, TargetSet, ENTRY_TYPE, HAVE_TYPE, SYNC_DONE_TYPE,
+    SYNC_REQUEST_TYPE,
+};
 
 pub type LiveMode = bool;
 

--- a/aquadoggo/src/replication/message.rs
+++ b/aquadoggo/src/replication/message.rs
@@ -23,9 +23,9 @@ pub type LogHeights = (PublicKey, Vec<(LogId, SeqNum)>);
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Message {
     SyncRequest(Mode, TargetSet),
-    Have(Vec<LogHeights>),
     Entry(EncodedEntry, Option<EncodedOperation>),
     SyncDone(LiveMode),
+    Have(Vec<LogHeights>),
 }
 
 impl Message {
@@ -232,7 +232,7 @@ mod tests {
                 51,
                 Message::SyncRequest(Mode::SetReconciliation, target_set.clone())
             )),
-            serialize_value(cbor!([0, 51, 1, target_set]))
+            serialize_value(cbor!([1, 51, 1, target_set]))
         );
 
         assert_eq!(
@@ -259,7 +259,7 @@ mod tests {
     #[rstest]
     fn deserialize(#[from(random_target_set)] target_set: TargetSet, public_key: PublicKey) {
         assert_eq!(
-            deserialize_into::<SyncMessage>(&serialize_value(cbor!([0, 12, 0, target_set])))
+            deserialize_into::<SyncMessage>(&serialize_value(cbor!([1, 12, 0, target_set])))
                 .unwrap(),
             SyncMessage::new(
                 12,
@@ -302,11 +302,11 @@ mod tests {
     #[should_panic(expected = "unknown message type 122 in replication message")]
     #[case::unknown_message_type(cbor!([122, 0]))]
     #[should_panic(expected = "missing session id in replication message")]
-    #[case::only_message_type(cbor!([0]))]
+    #[case::only_message_type(cbor!([1]))]
     #[should_panic(expected = "empty target set in sync request")]
-    #[case::only_message_type(cbor!([0, 0, 0, []]))]
+    #[case::only_message_type(cbor!([1, 0, 0, []]))]
     #[should_panic(expected = "too many fields for replication message")]
-    #[case::too_many_fields(cbor!([0, 0, 0, ["schema_field_definition_v1"], "too much"]))]
+    #[case::too_many_fields(cbor!([1, 0, 0, ["schema_field_definition_v1"], "too much"]))]
     fn deserialize_invalid_messages(#[case] cbor: Result<Value, Error>) {
         // Check the cbor is valid
         assert!(cbor.is_ok());

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+mod announcement;
 pub mod errors;
 mod ingest;
 mod manager;
@@ -11,6 +12,7 @@ mod strategies;
 mod target_set;
 pub mod traits;
 
+pub use announcement::Announcement;
 pub use ingest::SyncIngest;
 pub use manager::SyncManager;
 pub use message::{LiveMode, LogHeights, Message, SyncMessage};

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -12,7 +12,7 @@ mod strategies;
 mod target_set;
 pub mod traits;
 
-pub use announcement::{Announcement, AnnouncementMessage};
+pub use announcement::{now, Announcement, AnnouncementMessage};
 pub use ingest::SyncIngest;
 pub use manager::SyncManager;
 pub use message::{LiveMode, LogHeights, Message, SyncMessage};

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -22,5 +22,14 @@ pub use session::{Session, SessionId, SessionState};
 pub use strategies::{LogHeightStrategy, SetReconciliationStrategy, StrategyResult};
 pub use target_set::TargetSet;
 
+pub type MessageType = u64;
+
+// Integers indicating message type for wire message format.
+pub const ANNOUNCE_TYPE: MessageType = 0;
+pub const SYNC_REQUEST_TYPE: MessageType = 1;
+pub const SYNC_DONE_TYPE: MessageType = 2;
+pub const ENTRY_TYPE: MessageType = 3;
+pub const HAVE_TYPE: MessageType = 10;
+
 /// Currently supported p2panda replication protocol version.
 pub const REPLICATION_PROTOCOL_VERSION: u64 = 1;

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -27,8 +27,8 @@ pub type MessageType = u64;
 // Integers indicating message type for wire message format.
 pub const ANNOUNCE_TYPE: MessageType = 0;
 pub const SYNC_REQUEST_TYPE: MessageType = 1;
-pub const SYNC_DONE_TYPE: MessageType = 2;
-pub const ENTRY_TYPE: MessageType = 3;
+pub const ENTRY_TYPE: MessageType = 2;
+pub const SYNC_DONE_TYPE: MessageType = 3;
 pub const HAVE_TYPE: MessageType = 10;
 
 /// Currently supported p2panda replication protocol version.

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -12,7 +12,7 @@ mod strategies;
 mod target_set;
 pub mod traits;
 
-pub use announcement::Announcement;
+pub use announcement::{Announcement, AnnouncementMessage};
 pub use ingest::SyncIngest;
 pub use manager::SyncManager;
 pub use message::{LiveMode, LogHeights, Message, SyncMessage};

--- a/aquadoggo/src/replication/mod.rs
+++ b/aquadoggo/src/replication/mod.rs
@@ -21,3 +21,6 @@ pub use service::replication_service;
 pub use session::{Session, SessionId, SessionState};
 pub use strategies::{LogHeightStrategy, SetReconciliationStrategy, StrategyResult};
 pub use target_set::TargetSet;
+
+/// Currently supported p2panda replication protocol version.
+pub const REPLICATION_PROTOCOL_VERSION: u64 = 1;

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -389,6 +389,7 @@ impl ConnectionManager {
                 PeerMessage::SyncMessage(message) => {
                     self.on_replication_message(peer, message).await;
                 }
+                PeerMessage::Announce(announcement) => todo!(),
             },
             _ => (), // Ignore all other messages
         }

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -195,7 +195,12 @@ impl ConnectionManager {
 
     /// Update announcement state of a remote peer.
     async fn on_announcement_message(&mut self, peer: Peer, message: AnnouncementMessage) {
-        let incoming_announcement = message.0;
+        // Check if this node supports our replication protocol version
+        if !message.is_version_supported() {
+            return;
+        }
+
+        let incoming_announcement = message.announcement();
 
         match self.peers.get_mut(&peer) {
             Some(status) => match &status.announcement {
@@ -382,7 +387,7 @@ impl ConnectionManager {
 
             self.send_service_message(ServiceMessage::SentMessage(
                 *peer,
-                PeerMessage::Announce(AnnouncementMessage(local_announcement.clone())),
+                PeerMessage::Announce(AnnouncementMessage::new(local_announcement.clone())),
             ));
         }
     }

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -22,8 +22,8 @@ use crate::network::identity::to_libp2p_peer_id;
 use crate::network::{Peer, PeerMessage};
 use crate::replication::errors::ReplicationError;
 use crate::replication::{
-    Announcement, Message, Mode, Session, SessionId, SyncIngest, SyncManager, SyncMessage,
-    TargetSet,
+    Announcement, AnnouncementMessage, Message, Mode, Session, SessionId, SyncIngest, SyncManager,
+    SyncMessage, TargetSet,
 };
 use crate::schema::SchemaProvider;
 
@@ -339,7 +339,8 @@ impl ConnectionManager {
         }
     }
 
-    async fn announce(&self) {
+    /// Send our local announcement state to all peers which are not informed yet.
+    async fn announce(&mut self) {
         let local_announcement = self
             .announcement
             .as_ref()
@@ -350,8 +351,10 @@ impl ConnectionManager {
                 continue;
             }
 
-            // @TODO
-            // self.send_service_message(ServiceMessage::SentMessage(*peer, message));
+            self.send_service_message(ServiceMessage::SentMessage(
+                *peer,
+                PeerMessage::Announce(AnnouncementMessage(local_announcement.clone())),
+            ));
         }
     }
 

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -194,8 +194,8 @@ impl ConnectionManager {
     }
 
     /// Update announcement state of a remote peer.
-    async fn on_announcement_message(&mut self, peer: Peer, announcement: AnnouncementMessage) {
-        let incoming_announcement = announcement.0;
+    async fn on_announcement_message(&mut self, peer: Peer, message: AnnouncementMessage) {
+        let incoming_announcement = message.0;
 
         match self.peers.get_mut(&peer) {
             Some(status) => match &status.announcement {
@@ -414,8 +414,8 @@ impl ConnectionManager {
                 PeerMessage::SyncMessage(message) => {
                     self.on_replication_message(peer, message).await;
                 }
-                PeerMessage::Announce(announcement) => {
-                    self.on_announcement_message(peer, announcement).await;
+                PeerMessage::Announce(message) => {
+                    self.on_announcement_message(peer, message).await;
                 }
             },
             _ => (), // Ignore all other messages

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::collections::HashMap;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::Result;
 use libp2p::PeerId;
@@ -22,7 +22,8 @@ use crate::network::identity::to_libp2p_peer_id;
 use crate::network::Peer;
 use crate::replication::errors::ReplicationError;
 use crate::replication::{
-    Message, Mode, Session, SessionId, SyncIngest, SyncManager, SyncMessage, TargetSet,
+    Announcement, Message, Mode, Session, SessionId, SyncIngest, SyncManager, SyncMessage,
+    TargetSet,
 };
 use crate::schema::SchemaProvider;
 
@@ -61,30 +62,6 @@ pub async fn replication_service(
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct Announcement {
-    /// This contains a list of schema ids this peer is interested in.
-    target_set: TargetSet,
-
-    /// Timestamp of this announcement. Helps to understand if we can override the previous
-    /// announcement with a newer one.
-    timestamp: u64,
-}
-
-impl Announcement {
-    pub fn new(target_set: TargetSet) -> Self {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("System time invalid, operation system time configured before UNIX epoch")
-            .as_secs();
-
-        Self {
-            timestamp,
-            target_set,
-        }
-    }
 }
 
 /// Statistics about successful and failed replication sessions for each connected peer.

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -172,9 +172,18 @@ impl ConnectionManager {
             }
             None => {
                 self.peers.insert(peer, PeerStatus::new(peer));
-                self.update_sessions().await;
+                self.on_update().await;
             }
         }
+    }
+
+    /// Routines which get executed on every scheduler beat and newly established connection.
+    async fn on_update(&mut self) {
+        // Inform new peers about our supported protocol version and schema ids
+        self.announce().await;
+
+        // Check if we can establish replication sessions with peers
+        self.update_sessions().await;
     }
 
     /// Handle a peer connection closing.
@@ -471,8 +480,7 @@ impl ConnectionManager {
 
                 // Announcement & replication schedule is due
                 Some(_) = self.scheduler.next() => {
-                    self.announce().await;
-                    self.update_sessions().await
+                    self.on_update().await;
                 }
             }
         }

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use anyhow::Result;
 use libp2p::PeerId;
 use log::{debug, info, trace, warn};
-use p2panda_rs::{Human, Validate};
+use p2panda_rs::Human;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use tokio::task;
@@ -284,11 +284,6 @@ impl ConnectionManager {
     async fn update_sessions(&mut self) {
         // Determine the target set our node is interested in
         let target_set = self.target_set().await;
-
-        if let Err(err) = target_set.validate() {
-            warn!("Not initiating replication: {err}");
-            return;
-        }
 
         // Iterate through all currently connected peers
         let mut attempt_peers: Vec<Peer> = self

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -66,8 +66,21 @@ pub async fn replication_service(
 /// Statistics about successful and failed replication sessions for each connected peer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PeerStatus {
+    /// Connectivity information like libp2p peer id and connection id.
     peer: Peer,
+
+    /// Last known announcement of this peer. This contains a list of schema ids this peer is
+    /// interested in.
+    announcement: Option<TargetSet>,
+
+    /// Timestamp of the last known announcement. Helps to understand if we can override the
+    /// previous announcement with a newer one.
+    announcement_timestamp: u64,
+
+    /// Number of successful replication sessions.
     successful_count: usize,
+
+    /// Number of failed replication sessions.
     failed_count: usize,
 }
 
@@ -75,6 +88,8 @@ impl PeerStatus {
     pub fn new(peer: Peer) -> Self {
         Self {
             peer,
+            announcement: None,
+            announcement_timestamp: 0,
             successful_count: 0,
             failed_count: 0,
         }

--- a/aquadoggo/src/replication/service.rs
+++ b/aquadoggo/src/replication/service.rs
@@ -247,7 +247,7 @@ impl ConnectionManager {
             let local_target_set = &self
                 .announcement
                 .as_ref()
-                .expect("Our announcement needs to be set latest when we call 'update_sessions'")
+                .expect("Announcement state needs to be set with 'update_announcement'")
                 .target_set;
 
             // If this node has been configured with a whitelist of schema ids then we check the
@@ -337,7 +337,7 @@ impl ConnectionManager {
         let local_target_set = &self
             .announcement
             .as_ref()
-            .expect("Our announcement needs to be set latest when we call 'update_sessions'")
+            .expect("Announcement state needs to be set with 'update_announcement'")
             .target_set;
 
         // Iterate through all currently connected peers
@@ -402,7 +402,7 @@ impl ConnectionManager {
         let local_announcement = self
             .announcement
             .as_ref()
-            .expect("Our announcement needs to be set latest when we call 'update_sessions'");
+            .expect("Announcement state needs to be set with 'update_announcement'");
 
         for (peer, status) in &self.peers {
             if status.sent_our_announcement_timestamp < local_announcement.timestamp {
@@ -618,6 +618,7 @@ mod tests {
             let schema_provider = SchemaProvider::new(vec![], Some(vec![]));
             let mut manager =
                 ConnectionManager::new(&schema_provider, &node.context.store, &tx, local_peer_id);
+            manager.update_announcement().await;
 
             let remote_peer = Peer::new(remote_peer_id, ConnectionId::new_unchecked(1));
 

--- a/aquadoggo/src/replication/target_set.rs
+++ b/aquadoggo/src/replication/target_set.rs
@@ -41,6 +41,10 @@ impl TargetSet {
         self.0.contains(schema_id)
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     fn from_untrusted(schema_ids: Vec<SchemaId>) -> Result<Self, TargetSetError> {
         // Create target set with potentially invalid data
         let target_set = Self(schema_ids);

--- a/aquadoggo/src/replication/target_set.rs
+++ b/aquadoggo/src/replication/target_set.rs
@@ -57,6 +57,13 @@ impl TargetSet {
         self.0.contains(schema_id)
     }
 
+    /// Returns true if both target sets know about the same elements.
+    pub fn is_valid_set(&self, target_set: &TargetSet) -> bool {
+        self.iter()
+            .find(|schema_id| !target_set.contains(schema_id))
+            .is_none()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -178,6 +185,7 @@ mod tests {
         #[from(random_document_view_id)] document_view_id_2: DocumentViewId,
         #[from(random_document_view_id)] document_view_id_3: DocumentViewId,
     ) {
+        // Correctly calculates intersections
         let schema_id_1 =
             SchemaId::new_application(&SchemaName::new("messages").unwrap(), &document_view_id_1);
         let schema_id_2 =
@@ -192,6 +200,14 @@ mod tests {
             TargetSet::from_intersection(&set_1, &set_2),
             TargetSet::new(&[schema_id_2.clone()])
         );
+
+        // Correctly verifies if both target sets know about all given elements
+        assert!(TargetSet::new(&[schema_id_2.clone()])
+            .is_valid_set(&TargetSet::new(&[schema_id_2.clone()])));
+        assert!(TargetSet::new(&[schema_id_3.clone(), schema_id_2.clone()])
+            .is_valid_set(&TargetSet::new(&[schema_id_2.clone()])));
+        assert!(!TargetSet::new(&[schema_id_1.clone()])
+            .is_valid_set(&TargetSet::new(&[schema_id_2.clone(), schema_id_1.clone()])));
     }
 
     #[rstest]

--- a/aquadoggo/src/replication/target_set.rs
+++ b/aquadoggo/src/replication/target_set.rs
@@ -57,11 +57,9 @@ impl TargetSet {
         self.0.contains(schema_id)
     }
 
-    /// Returns true if both target sets know about the same elements.
+    /// Returns true if there are no unknown elements in external target set.
     pub fn is_valid_set(&self, target_set: &TargetSet) -> bool {
-        self.iter()
-            .find(|schema_id| !target_set.contains(schema_id))
-            .is_none()
+        !target_set.iter().any(|schema_id| !self.contains(schema_id))
     }
 
     pub fn is_empty(&self) -> bool {

--- a/aquadoggo/src/replication/target_set.rs
+++ b/aquadoggo/src/replication/target_set.rs
@@ -60,11 +60,6 @@ impl Validate for TargetSet {
     type Error = TargetSetError;
 
     fn validate(&self) -> Result<(), Self::Error> {
-        // Check if at least one schema id is given
-        if self.0.is_empty() {
-            return Err(TargetSetError::ZeroSchemaIds);
-        };
-
         let mut prev_schema_id: Option<&SchemaId> = None;
         let mut initial_system_schema = true;
 

--- a/aquadoggo/src/schema/schema_provider.rs
+++ b/aquadoggo/src/schema/schema_provider.rs
@@ -113,12 +113,19 @@ impl SchemaProvider {
     }
 
     /// Returns a list of all supported schema ids.
+    ///
+    /// If no whitelist was set it returns the list of all currently known schema ids. If a
+    /// whitelist was set it directly returns the list itself.
     pub async fn supported_schema_ids(&self) -> Vec<SchemaId> {
-        self.all()
-            .await
-            .iter()
-            .map(|schema| schema.id().to_owned())
-            .collect()
+        match &self.supported_schema_ids {
+            Some(schema_ids) => schema_ids.clone(),
+            None => self
+                .all()
+                .await
+                .iter()
+                .map(|schema| schema.id().to_owned())
+                .collect(),
+        }
     }
 
     /// Returns true if a whitelist of supported schema ids was provided through user

--- a/aquadoggo_cli/src/schemas.rs
+++ b/aquadoggo_cli/src/schemas.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use anyhow::{anyhow, Result};
-use p2panda_rs::schema::SchemaId;
 use std::fs::File;
 use std::io::Read;
+
+use anyhow::{anyhow, Result};
+use p2panda_rs::schema::SchemaId;
 use toml::Table;
 
 pub fn read_schema_ids_from_file(file: &mut File) -> Result<Vec<SchemaId>> {
@@ -14,29 +15,4 @@ pub fn read_schema_ids_from_file(file: &mut File) -> Result<Vec<SchemaId>> {
         "No \"supported_schema_ids\" field found config file"
     ))?;
     Ok(value.clone().try_into::<Vec<SchemaId>>()?)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::fs::{create_dir_all, File};
-    use std::io::Write;
-
-    use tempfile::TempDir;
-
-    use super::read_schema_ids_from_file;
-
-    #[test]
-    fn reads_schema_ids_from_file() {
-        let tmp_dir = TempDir::new().unwrap();
-        let mut tmp_path = tmp_dir.path().to_owned();
-        tmp_path.push("schema.toml");
-
-        create_dir_all(tmp_path.parent().unwrap()).unwrap();
-        let mut file = File::create(&tmp_path).unwrap();
-        file.write_all("schemas = [\"plant_0020c11ab63099193a8c8516cc00f88bfc8cdd657b94a99fef2fce86aaaede84f87d\"]".as_bytes()).unwrap();
-
-        let result = read_schema_ids_from_file(&mut file);
-        println!("{result:?}");
-        assert!(result.is_ok());
-    }
 }


### PR DESCRIPTION
This PR introduces our concept of "Announcements" (read more here: https://p2panda.org/specification/replication/#1-announcement).

There's a specification change involved: We need to give `Announce` messages their own message type. I've took `0` for them and changed the ones for `SyncRequest`, `SyncDone` and `Entry` as well. Related PR: https://github.com/p2panda/handbook/pull/290

Closes #405 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
