### PR TITLE
Networking: multiple relays, dial known nodes, allow&block-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse supported schema ids from `config.toml` [#473](https://github.com/p2panda/aquadoggo/pull/473)
 - Fix relayed connections, add DCUtR Holepunching and reduce CLI args [#502](https://github.com/p2panda/aquadoggo/pull/502)
 - Announce supported schema ids in network before replication [#515](https://github.com/p2panda/aquadoggo/pull/515)
-- Improved configuration API with "config.toml" file, environment vars and command line arguments [#519](https://github.com/p2panda/aquadoggo/pull/519)
+- Allow & block lists, direct dial known peers, connect to multiple relays [#542](https://github.com/p2panda/aquadoggo/pull/524)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "http",
  "hyper",
  "libp2p",
+ "libp2p-allow-block-list",
  "libp2p-quic",
  "libp2p-swarm-test",
  "lipmaa-link 0.2.2",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -49,6 +49,7 @@ libp2p = { version = "0.52.2", features = [
     "yamux",
     "tcp",
 ] }
+libp2p-allow-block-list = "0.2.0"
 libp2p-quic = { version = "0.9.2-alpha", features = ["tokio"] }
 lipmaa-link = "0.2.2"
 log = "0.4.19"

--- a/aquadoggo/src/network/behaviour.rs
+++ b/aquadoggo/src/network/behaviour.rs
@@ -3,7 +3,6 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use futures::stream::All;
 use libp2p::identity::Keypair;
 use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::swarm::NetworkBehaviour;
@@ -169,14 +168,15 @@ impl P2pandaBehaviour {
         // Always create behaviour to manage peer connections and handle p2panda messaging
         let peers = peers::Behaviour::new();
 
-        let allowed_peers = if let Some(allowed_peer_ids) = &network_config.allowed_peers {
-            let mut allowed_peers = allow_block_list::Behaviour::default();
-            for peer_id in allowed_peer_ids {
-                allowed_peers.allow_peer(*peer_id)
+        let allowed_peers = match &network_config.allow_peer_ids {
+            crate::AllowList::Wildcard => None,
+            crate::AllowList::Set(allow_peer_ids) => {
+                let mut allowed_peers = allow_block_list::Behaviour::default();
+                for peer_id in allow_peer_ids {
+                    allowed_peers.allow_peer(*peer_id)
+                }
+                Some(allowed_peers)
             }
-            Some(allowed_peers)
-        } else {
-            None
         };
 
         Ok(Self {

--- a/aquadoggo/src/network/behaviour.rs
+++ b/aquadoggo/src/network/behaviour.rs
@@ -87,7 +87,7 @@ impl P2pandaBehaviour {
 
         // Create an identify server behaviour with default configuration if a rendezvous server
         // address has been provided or the rendezvous server flag is set
-        let identify = if network_config.relay_address.is_some() || network_config.relay_mode {
+        let identify = if !network_config.relay_addresses.is_empty() || network_config.relay_mode {
             debug!("Identify network behaviour enabled");
             Some(identify::Behaviour::new(identify::Config::new(
                 format!("{NODE_NAMESPACE}/1.0.0"),
@@ -116,7 +116,7 @@ impl P2pandaBehaviour {
 
         // Create a rendezvous client behaviour with default configuration if a rendezvous server
         // address has been provided
-        let rendezvous_client = if network_config.relay_address.is_some() {
+        let rendezvous_client = if !network_config.relay_addresses.is_empty() {
             debug!("Rendezvous client network behaviour enabled");
             Some(rendezvous::client::Behaviour::new(key_pair))
         } else {

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use libp2p::connection_limits::ConnectionLimits;
+use libp2p::{connection_limits::ConnectionLimits, PeerId};
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
 
@@ -41,6 +41,8 @@ pub struct NetworkConfiguration {
     /// traffic as an intermediary between us and other nodes. The node will contact each server
     /// and register our IP address for other peers.
     pub relay_addresses: Vec<Multiaddr>,
+
+    pub allowed_peers: Option<Vec<PeerId>>,
 
     /// Notify handler buffer size.
     ///
@@ -99,6 +101,7 @@ impl Default for NetworkConfiguration {
             quic_port: 2022,
             relay_mode: false,
             relay_addresses: Vec::new(),
+            allowed_peers: None,
         }
     }
 }

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -2,13 +2,14 @@
 
 use libp2p::Multiaddr;
 use libp2p::{connection_limits::ConnectionLimits, PeerId};
-use serde::{Deserialize, Serialize};
+
+use crate::AllowList;
 
 /// The namespace used by the `identify` network behaviour.
 pub const NODE_NAMESPACE: &str = "aquadoggo";
 
 /// Network config for the node.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone)]
 pub struct NetworkConfiguration {
     /// QUIC port for node-to-node communication.
     pub quic_port: u16,
@@ -42,7 +43,12 @@ pub struct NetworkConfiguration {
     /// and register our IP address for other peers.
     pub relay_addresses: Vec<Multiaddr>,
 
-    pub allowed_peers: Option<Vec<PeerId>>,
+    /// List of peers which can connect to our node.
+    ///
+    /// If set then only peers (identified by their peer id) contained in this list will be able
+    /// to connect to our node (via a relay or directly). When not set then there are no
+    /// restrictions on which nodes can connect to ours.
+    pub allow_peer_ids: AllowList<PeerId>,
 
     /// Notify handler buffer size.
     ///
@@ -101,7 +107,7 @@ impl Default for NetworkConfiguration {
             quic_port: 2022,
             relay_mode: false,
             relay_addresses: Vec::new(),
-            allowed_peers: None,
+            allow_peer_ids: AllowList::<PeerId>::Wildcard,
         }
     }
 }

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use libp2p::{connection_limits::ConnectionLimits, PeerId};
 use libp2p::Multiaddr;
+use libp2p::{connection_limits::ConnectionLimits, PeerId};
 use serde::{Deserialize, Serialize};
 
 /// The namespace used by the `identify` network behaviour.

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -31,7 +31,7 @@ pub struct NetworkConfiguration {
     /// static IP address through an VPS.
     pub relay_mode: bool,
 
-    /// Address of a peer which can act as a relay/rendezvous server.
+    /// Addresses of a peers which can act as a relay/rendezvous server.
     ///
     /// Relays help discover other nodes on the internet (also known as "rendesvouz" or "bootstrap"
     /// server) and help establishing direct p2p connections when node is behind a firewall or NAT
@@ -40,7 +40,7 @@ pub struct NetworkConfiguration {
     /// When a direct connection is not possible the relay will help to redirect the (encrypted)
     /// traffic as an intermediary between us and other nodes. The node will contact each server
     /// and register our IP address for other peers.
-    pub relay_address: Option<Multiaddr>,
+    pub relay_addresses: Vec<Multiaddr>,
 
     /// Notify handler buffer size.
     ///
@@ -98,7 +98,7 @@ impl Default for NetworkConfiguration {
             per_connection_event_buffer_size: 8,
             quic_port: 2022,
             relay_mode: false,
-            relay_address: None,
+            relay_addresses: Vec::new(),
         }
     }
 }

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -50,6 +50,13 @@ pub struct NetworkConfiguration {
     /// restrictions on which nodes can connect to ours.
     pub allow_peer_ids: AllowList<PeerId>,
 
+    /// List of peers which can connect to our node.
+    ///
+    /// If set then only peers (identified by their peer id) contained in this list will be able
+    /// to connect to our node (via a relay or directly). When not set then there are no
+    /// restrictions on which nodes can connect to ours.
+    pub block_peer_ids: AllowList<PeerId>,
+
     /// Notify handler buffer size.
     ///
     /// Defines the buffer size for events sent from a network protocol handler to the connection
@@ -108,6 +115,7 @@ impl Default for NetworkConfiguration {
             relay_mode: false,
             relay_addresses: Vec::new(),
             allow_peer_ids: AllowList::<PeerId>::Wildcard,
+            block_peer_ids: AllowList::<PeerId>::Wildcard,
         }
     }
 }

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -152,6 +152,18 @@ pub async fn network_service(
         }
     }
 
+    // Dial all nodes we want to directly connect to.
+    for direct_node_address in &network_config.direct_node_addresses {
+        info!("Connecting to node at: {direct_node_address}");
+        let opts = DialOpts::unknown_peer_id()
+            .address(direct_node_address.clone())
+            .build();
+        match swarm.dial(opts) {
+            Ok(_) => (),
+            Err(err) => debug!("Error dialing node: {:?}", err),
+        };
+    }
+
     info!("Network service ready!");
 
     // Spawn main event loop handling all p2panda and libp2p network events.

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -124,7 +124,7 @@ pub async fn network_service(
         // First restart the "peers" behaviour in order to handle the expected messages
         swarm.behaviour_mut().peers.enable();
 
-        for (relay_peer_id, _) in &connected_relays {
+        for relay_peer_id in connected_relays.keys() {
             let opts = DialOpts::peer_id(*relay_peer_id)
                 .condition(PeerCondition::Always) // There is an existing connection, so we force dial here.
                 .build();

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::num::NonZeroU8;
 use std::time::Duration;
@@ -19,7 +20,7 @@ use crate::context::Context;
 use crate::manager::{ServiceReadySender, Shutdown};
 use crate::network::behaviour::{Event, P2pandaBehaviour};
 use crate::network::config::NODE_NAMESPACE;
-use crate::network::{identity, peers, swarm, utils, NetworkConfiguration, ShutdownHandler};
+use crate::network::{identity, peers, swarm, utils, ShutdownHandler};
 
 /// Network service which handles all networking logic for a p2panda node.
 ///
@@ -37,7 +38,7 @@ pub async fn network_service(
     tx: ServiceSender,
     tx_ready: ServiceReadySender,
 ) -> Result<()> {
-    let mut network_config = context.config.network.clone();
+    let network_config = &context.config.network;
     let key_pair = identity::to_libp2p_key_pair(&context.key_pair);
     let local_peer_id = key_pair.public().to_peer_id();
 
@@ -46,7 +47,7 @@ pub async fn network_service(
     // The swarm can be initiated with or without "relay" capabilities.
     let mut swarm = if network_config.relay_mode {
         info!("Networking service initializing with relay capabilities...");
-        let mut swarm = swarm::build_relay_swarm(&network_config, key_pair).await?;
+        let mut swarm = swarm::build_relay_swarm(network_config, key_pair).await?;
 
         // Start listening on tcp address.
         let listen_addr_tcp = Multiaddr::empty()
@@ -57,7 +58,7 @@ pub async fn network_service(
         swarm
     } else {
         info!("Networking service initializing...");
-        swarm::build_client_swarm(&network_config, key_pair).await?
+        swarm::build_client_swarm(network_config, key_pair).await?
     };
 
     // Start listening on QUIC address. Pick a random one if the given is taken already.
@@ -77,32 +78,100 @@ pub async fn network_service(
         swarm.listen_on(random_port_addr)?;
     }
 
-    // If a relay node address was provided, then connect and performing necessary setup before we
+    // If relay node addresses were provided, then connect to each and perform necessary setup before we
     // run the main event loop.
-    if let Some(relay_address) = network_config.relay_address.clone() {
-        info!("Connecting to relay node at: {relay_address}");
-        connect_to_relay(&mut swarm, &mut network_config, relay_address).await?;
+    let mut connected_relays = HashMap::new();
+    if !network_config.relay_addresses.is_empty() {
+        // First we need to stop the "peers" behaviour.
+        //
+        // We do this so that the connections we create during initialization do not trigger
+        // replication sessions, which could leave the node in a strange state.
+        swarm.behaviour_mut().peers.disable();
+
+        for mut relay_address in network_config.relay_addresses.clone() {
+            // Attempt to connect to the relay node, we give this a 5 second timeout so as not to
+            // get stuck if one relay is unreachable.
+            info!("Connecting to relay node at: {relay_address}");
+            if let Ok(result) = tokio::time::timeout(
+                Duration::from_secs(5),
+                connect_to_relay(&mut swarm, &mut relay_address),
+            )
+            .await
+            {
+                match result {
+                    // If the connection is successful then add this node to our map of connected relays.
+                    Ok((relay_peer_id, relay_address)) => {
+                        connected_relays.insert(relay_peer_id, relay_address);
+                    }
+                    Err(_) => info!("Failed to connect to relay node"),
+                }
+            } else {
+                info!("Relay connection attempt failed: connection timeout")
+            };
+        }
+
+        // Finally we want to dial any relay nodes we connected to _again_, this time in order to
+        // initiate replication with it, which will happen automatically once the connection succeeds.
+        // And then begin discovering peers in `NODE_NAMESPACE` on each relay node in order to begin
+        // replicating with them too.
+        //
+        // @TODO: This is a workaround since we don't have a way yet to start replication _not_ at the
+        // same time the connection gets successfully established. We should fix this and remove the
+        // second, potentially redundant dial.
+        //
+        // See related issue: https://github.com/p2panda/aquadoggo/issues/507
+
+        // First restart the "peers" behaviour in order to handle the expected messages
+        swarm.behaviour_mut().peers.enable();
+
+        for (relay_peer_id, _) in &connected_relays {
+            let opts = DialOpts::peer_id(*relay_peer_id)
+                .condition(PeerCondition::Always) // There is an existing connection, so we force dial here.
+                .build();
+            match swarm.dial(opts) {
+                Ok(_) => (),
+                Err(err) => debug!("Error dialing peer: {:?}", err),
+            };
+
+            // Now request to discover other peers in `NODE_NAMESPACE`.
+            info!("Discovering peers in namespace \"{NODE_NAMESPACE}\"",);
+            swarm
+                .behaviour_mut()
+                .rendezvous_client
+                .as_mut()
+                .expect("Relay client exists as we a relay address was provided")
+                .discover(
+                    Some(
+                        rendezvous::Namespace::new(NODE_NAMESPACE.to_string())
+                            .expect("Valid namespace"),
+                    ),
+                    None,
+                    None,
+                    *relay_peer_id,
+                );
+        }
     }
 
     info!("Network service ready!");
 
     // Spawn main event loop handling all p2panda and libp2p network events.
-    spawn_event_loop(swarm, local_peer_id, network_config, shutdown, tx, tx_ready).await
+    spawn_event_loop(
+        swarm,
+        local_peer_id,
+        connected_relays,
+        shutdown,
+        tx,
+        tx_ready,
+    )
+    .await
 }
 
 /// Connect to a relay node, confirm exchange identity information and wait to listen on our
 /// circuit relay address.
 pub async fn connect_to_relay(
     swarm: &mut Swarm<P2pandaBehaviour>,
-    network_config: &mut NetworkConfiguration,
-    mut relay_address: Multiaddr,
-) -> Result<()> {
-    // First we need to stop the "peers" behaviour.
-    //
-    // We do this so that the connections we create during initialization do not trigger
-    // replication sessions, which could leave the node in a strange state.
-    swarm.behaviour_mut().peers.disable();
-
+    relay_address: &mut Multiaddr,
+) -> Result<(PeerId, Multiaddr)> {
     // Connect to the relay server. Not for the reservation or relayed connection, but to (a) learn
     // our local public address and (b) enable a freshly started relay to learn its public address.
     swarm.dial(relay_address.clone())?;
@@ -139,7 +208,6 @@ pub async fn connect_to_relay(
 
                 // Update values on the config.
                 learned_relay_peer_id = Some(peer_id);
-                network_config.relay_address = Some(relay_address.clone());
 
                 // All done, we've learned our external address successfully.
                 learned_observed_addr = true;
@@ -215,41 +283,7 @@ pub async fn connect_to_relay(
         }
     }
 
-    // Now request to discover other peers in `NODE_NAMESPACE`.
-    info!("Discovering peers in namespace \"{NODE_NAMESPACE}\"",);
-    swarm
-        .behaviour_mut()
-        .rendezvous_client
-        .as_mut()
-        .expect("Relay client exists as we a relay address was provided")
-        .discover(
-            Some(rendezvous::Namespace::new(NODE_NAMESPACE.to_string()).expect("Valid namespace")),
-            None,
-            None,
-            relay_peer_id,
-        );
-
-    // Finally we want to dial the relay node _again_, this time in order to initiate replication
-    // with it, which will happen automatically once the connection succeeds.
-    //
-    // @TODO: This is a workaround since we don't have a way yet to start replication _not_ at the
-    // same time the connection gets successfully established. We should fix this and remove the
-    // second, potentially redundant dial.
-    //
-    // See related issue: https://github.com/p2panda/aquadoggo/issues/507
-
-    // First restart the "peers" behaviour in order to handle the expected messages
-    swarm.behaviour_mut().peers.enable();
-
-    let opts = DialOpts::peer_id(relay_peer_id)
-        .condition(PeerCondition::Always) // There is an existing connection, so we force dial here.
-        .build();
-    match swarm.dial(opts) {
-        Ok(_) => (),
-        Err(err) => debug!("Error dialing peer: {:?}", err),
-    };
-
-    Ok(())
+    Ok((relay_peer_id, relay_address.clone()))
 }
 
 /// Main loop polling the async swarm event stream and incoming service messages stream.
@@ -258,7 +292,7 @@ struct EventLoop {
     local_peer_id: PeerId,
     tx: ServiceSender,
     rx: BroadcastStream<ServiceMessage>,
-    network_config: NetworkConfiguration,
+    relay_addresses: HashMap<PeerId, Multiaddr>,
     shutdown_handler: ShutdownHandler,
     learned_port: bool,
 }
@@ -268,7 +302,7 @@ impl EventLoop {
         swarm: Swarm<P2pandaBehaviour>,
         local_peer_id: PeerId,
         tx: ServiceSender,
-        network_config: NetworkConfiguration,
+        relay_addresses: HashMap<PeerId, Multiaddr>,
         shutdown_handler: ShutdownHandler,
     ) -> Self {
         Self {
@@ -276,7 +310,7 @@ impl EventLoop {
             local_peer_id,
             rx: BroadcastStream::new(tx.subscribe()),
             tx,
-            network_config,
+            relay_addresses,
             shutdown_handler,
             learned_port: false,
         }
@@ -386,16 +420,20 @@ impl EventLoop {
 
     async fn handle_rendezvous_client_events(&mut self, event: &rendezvous::client::Event) {
         match event {
-            rendezvous::client::Event::Discovered { registrations, .. } => {
+            rendezvous::client::Event::Discovered {
+                registrations,
+                rendezvous_node,
+                ..
+            } => {
                 info!("Discovered peers registered at rendezvous: {registrations:?}",);
 
                 for registration in registrations {
                     for address in registration.record.addresses() {
                         let peer_id = registration.record.peer_id();
                         if peer_id != self.local_peer_id {
-                            if let Some(relay_address) = &self.network_config.relay_address {
-                                info!("Add new peer to address book: {} {}", peer_id, address);
+                            info!("Add new peer to address book: {} {}", peer_id, address);
 
+                            if let Some(relay_address) = self.relay_addresses.get(rendezvous_node) {
                                 let peer_circuit_address = relay_address
                                     .clone()
                                     .with(Protocol::P2pCircuit)
@@ -405,7 +443,9 @@ impl EventLoop {
                                     Ok(_) => (),
                                     Err(err) => debug!("Error dialing peer: {:?}", err),
                                 };
-                            }
+                            } else {
+                                debug!("Discovered peer from unknown relay node")
+                            };
                         }
                     }
                 }
@@ -459,7 +499,7 @@ impl EventLoop {
 pub async fn spawn_event_loop(
     swarm: Swarm<P2pandaBehaviour>,
     local_peer_id: PeerId,
-    network_config: NetworkConfiguration,
+    relay_addresses: HashMap<PeerId, Multiaddr>,
     shutdown: Shutdown,
     tx: ServiceSender,
     tx_ready: ServiceReadySender,
@@ -471,7 +511,7 @@ pub async fn spawn_event_loop(
         swarm,
         local_peer_id,
         tx,
-        network_config,
+        relay_addresses,
         shutdown_handler.clone(),
     );
     let handle = task::spawn(event_loop.run());

--- a/aquadoggo/src/network/transport.rs
+++ b/aquadoggo/src/network/transport.rs
@@ -46,7 +46,7 @@ pub async fn build_client_transport(
 
 // Build the transport stack to be used by nodes with relay capabilities.
 pub async fn build_relay_transport(key_pair: &Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
-    let tcp_transport = tcp::async_io::Transport::new(tcp::Config::new().port_reuse(true))
+    let tcp_transport = tcp::tokio::Transport::new(tcp::Config::new().port_reuse(true))
         .upgrade(Version::V1)
         .authenticate(NoiseConfig::new(key_pair).unwrap())
         .multiplex(YamuxConfig::default());

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -140,6 +140,17 @@ direct_node_addresses = [
     # "192.0.2.2:3000",
 ]
 
+# List of peers which can connect to our node.
+#
+# If set then only peers (identified by their peer id) contained in this list will be able
+# to connect to our node (via a relay or directly). When not set then there are no
+# restrictions on which nodes can connect to ours.
+#
+# WARNING: When set to wildcard "*", your node will accept connections requests from any peers.
+# This is useful for experimentation and local development or settings where access to the network
+# is secured via other means.
+allow_peer_ids = "*"
+
 # ﾟ･｡+☆
 # RELAY
 # ﾟ･｡+☆

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -144,7 +144,7 @@ direct_node_addresses = [
 # RELAY
 # ﾟ･｡+☆
 
-# Address of a relay.
+# Address of a relays.
 #
 # A relay helps discover other nodes on the internet (also known as
 # "rendesvouz" or "bootstrap" server) and helps establishing direct p2p
@@ -163,7 +163,10 @@ direct_node_addresses = [
 # nodes with which you will then exchange data with. If in doubt, use the list
 # of known node addresses instead and only connect to trusted nodes.
 #
-# relay_address = "192.0.2.16:2022"
+relay_addresses = [
+    #"192.0.2.16:2022",
+    #"192.0.2.17:2022",
+]
 
 # Set to true if node should also function as a relay. Defaults to false.
 #

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -149,7 +149,16 @@ direct_node_addresses = [
 # WARNING: When set to wildcard "*", your node will accept connections requests from any peers.
 # This is useful for experimentation and local development or settings where access to the network
 # is secured via other means.
+#
 allow_peer_ids = "*"
+
+# List of peers which will be blocked from connecting to our node.
+#
+# If set then any peers (identified by their peer id) contained in this list will be blocked
+# from connecting to our node (via a relay or directly). When an empty list is provided then there
+# are no restrictions on which nodes can connect to ours.
+#
+block_peer_ids = []
 
 # ﾟ･｡+☆
 # RELAY

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -157,7 +157,7 @@ struct Cli {
     #[serde(skip_serializing_if = "Option::is_none")]
     direct_node_addresses: Option<Vec<SocketAddr>>,
 
-    /// Address of a relay.
+    /// Addresses of a relays.
     ///
     /// A relay helps discover other nodes on the internet (also known as "rendesvouz" or
     /// "bootstrap" server) and helps establishing direct p2p connections when node is behind a
@@ -166,9 +166,9 @@ struct Cli {
     /// WARNING: This will potentially expose your IP address on the network. Do only connect to
     /// trusted relays or make sure your IP address is hidden via a VPN or proxy if you're
     /// concerned about leaking your IP.
-    #[arg(short = 'r', long, value_name = "IP:PORT")]
+    #[arg(short = 'r', long, value_name = "IP:PORT IP:PORT, ...", num_args = 0..)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    relay_address: Option<SocketAddr>,
+    relay_addresses: Option<Vec<SocketAddr>>,
 
     /// Enable if node should also function as a relay. Disabled by default.
     ///
@@ -224,7 +224,7 @@ pub struct Configuration {
     pub private_key: Option<PathBuf>,
     pub mdns: bool,
     pub direct_node_addresses: Vec<SocketAddr>,
-    pub relay_address: Option<SocketAddr>,
+    pub relay_addresses: Vec<SocketAddr>,
     pub relay_mode: bool,
 }
 
@@ -240,7 +240,7 @@ impl Default for Configuration {
             private_key: None,
             mdns: true,
             direct_node_addresses: vec![],
-            relay_address: None,
+            relay_addresses: vec![],
             relay_mode: false,
         }
     }
@@ -284,7 +284,11 @@ impl TryFrom<Configuration> for NodeConfiguration {
                     .map(to_multiaddress)
                     .collect(),
                 relay_mode: value.relay_mode,
-                relay_address: value.relay_address.map(to_multiaddress),
+                relay_addresses: value
+                    .relay_addresses
+                    .into_iter()
+                    .map(to_multiaddress)
+                    .collect(),
                 ..Default::default()
             },
         })

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -13,7 +13,7 @@ use directories::ProjectDirs;
 use figment::providers::{Env, Format, Serialized, Toml};
 use figment::Figment;
 use libp2p::multiaddr::Protocol;
-use libp2p::Multiaddr;
+use libp2p::{Multiaddr, PeerId};
 use p2panda_rs::schema::SchemaId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -170,6 +170,10 @@ struct Cli {
     #[serde(skip_serializing_if = "Option::is_none")]
     relay_addresses: Option<Vec<SocketAddr>>,
 
+    #[arg(short = 'a', long, value_name = "PEER_ID PEER_ID, ...", num_args = 0..)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    allowed_peers: Option<Vec<PeerId>>,
+
     /// Enable if node should also function as a relay. Disabled by default.
     ///
     /// Other nodes can use relays to aid discovery and establishing connectivity.
@@ -226,6 +230,7 @@ pub struct Configuration {
     pub direct_node_addresses: Vec<SocketAddr>,
     pub relay_addresses: Vec<SocketAddr>,
     pub relay_mode: bool,
+    pub allowed_peers: Option<Vec<PeerId>>,
 }
 
 impl Default for Configuration {
@@ -242,6 +247,7 @@ impl Default for Configuration {
             direct_node_addresses: vec![],
             relay_addresses: vec![],
             relay_mode: false,
+            allowed_peers: None,
         }
     }
 }
@@ -289,6 +295,7 @@ impl TryFrom<Configuration> for NodeConfiguration {
                     .into_iter()
                     .map(to_multiaddress)
                     .collect(),
+                allowed_peers: value.allowed_peers,
                 ..Default::default()
             },
         })


### PR DESCRIPTION
- [x] client nodes don't need to listen on tcp
- [x] handle connecting to multiple relay nodes (w/ config changes)
- [x] dial known direct nodes at startup
- [x] introduce allow-list of trusted peers
- [x] introduce block-list of un-trusted peers

## 📋 Checklist

- [x] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
