### PR TITLE
Improve log level user interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rework networking service [#502](https://github.com/p2panda/aquadoggo/pull/502)
 - Deduplicate peer connections when initiating replication sessions [#525](https://github.com/p2panda/aquadoggo/pull/525)
 - Improve consistency and documentation of configuration API [#528](https://github.com/p2panda/aquadoggo/pull/528)
+- Improve log level config and user interface [#539](https://github.com/p2panda/aquadoggo/pull/539)
 
 ### Fixed
 

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -220,6 +220,17 @@ struct Cli {
     )]
     #[serde(skip_serializing_if = "Option::is_none")]
     relay_mode: Option<bool>,
+
+    /// Set log verbosity. Use this for learning more about how your node behaves or for debugging.
+    ///
+    /// Possible log levels are: ERROR, WARN, INFO, DEBUG, TRACE. They are scoped to "aquadoggo" by
+    /// default.
+    ///
+    /// If you want to adjust the scope for deeper inspection use a filter value, for example
+    /// "=TRACE" for logging _everything_ or "aquadoggo=INFO,libp2p=DEBUG" etc.
+    #[arg(short = 'l', long, value_name = "LEVEL")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    log_level: Option<String>,
 }
 
 /// Clap converts wildcard symbols from command line arguments (for example --supported-schema-ids
@@ -250,6 +261,7 @@ where
 /// Configuration derived from environment variables and .toml file.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Configuration {
+    pub log_level: String,
     pub allow_schema_ids: UncheckedAllowList,
     pub database_url: String,
     pub database_max_connections: u32,
@@ -268,6 +280,7 @@ pub struct Configuration {
 impl Default for Configuration {
     fn default() -> Self {
         Self {
+            log_level: "off".into(),
             allow_schema_ids: UncheckedAllowList::Wildcard,
             database_url: "sqlite::memory:".into(),
             database_max_connections: 32,

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -8,17 +8,23 @@ use std::convert::TryInto;
 
 use anyhow::Context;
 use aquadoggo::{AllowList, Configuration, Node};
-use log::warn;
+use env_logger::WriteStyle;
+use log::{warn, LevelFilter};
 
 use crate::config::{load_config, print_config};
 use crate::key_pair::{generate_ephemeral_key_pair, generate_or_load_key_pair};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
-
     // Load configuration from command line arguments, environment variables and .toml file
     let (config_file_path, config) = load_config().context("Could not load configuration")?;
+
+    // Configure log level
+    let mut builder = env_logger::Builder::new();
+    builder
+        .filter(Some("aquadoggo"), LevelFilter::Info)
+        .write_style(WriteStyle::Always)
+        .init();
 
     // Convert to `aquadoggo` configuration format and check for invalid inputs
     let node_config = config


### PR DESCRIPTION
```bash
# Set aquadoggo=INFO
LOG_LEVEL=info aquadoggo

# .. same, but via command line argument
aquadoggo --log-level info

# Set _all_ to INFO
aquadoggo --log-level "=info"

# ... etc.
aquadoggo --log-level "aquadoggo=INFO,libp2p=DEBUG"

# One can also set the value in config.toml (haven't included it in the template since using it there seems unlikely)
```

Closes: #537, #536, #534 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
