### PR TITLE
Build a byte buffer over paginated pieces when assembling blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - HTTP routes to serve files with correct content type headers [#544](https://github.com/p2panda/aquadoggo/pull/544)
+- Build a byte buffer over paginated pieces when assembling blobs [#547](https://github.com/p2panda/aquadoggo/pull/547)
 
 ## [0.5.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "axum",
  "bamboo-rs-core-ed25519-yasmf",
  "bs58 0.4.0",
+ "bytes",
  "ciborium",
  "ctor",
  "deadqueue",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -27,6 +27,7 @@ asynchronous-codec = { version = "0.6.2", features = ["cbor"] }
 axum = { version = "0.6.10", features = ["headers"] }
 bamboo-rs-core-ed25519-yasmf = "0.1.1"
 bs58 = "0.4.0"
+bytes = "1.4.0"
 deadqueue = { version = "0.2.3", default-features = false, features = [
     "unlimited",
 ] }

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -15,6 +15,7 @@ use crate::db::query::{Filter, Order, Pagination, PaginationField, Select};
 use crate::db::stores::query::{Query, RelationList};
 use crate::db::SqlStore;
 
+/// Number of blob pieces requested per database query iteration.
 const BLOB_QUERY_PAGE_SIZE: u64 = 10;
 
 pub type BlobData = Vec<u8>;

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -166,13 +166,13 @@ async fn document_to_blob_data(
     // Get the length of the blob
     let expected_length = match blob.get("length").unwrap() {
         OperationValue::Integer(length) => *length as usize,
-        _ => panic!(), // We should never hit this as we already validated that this is a blob document
+        _ => unreachable!(), // We already validated that this is a blob document
     };
 
     // Get the number of pieces in the blob
     let expected_num_pieces = match blob.get("pieces").unwrap() {
         OperationValue::PinnedRelationList(list) => list.len(),
-        _ => panic!(), // We should never hit this as we already validated that this is a blob document
+        _ => unreachable!(), // We already validated that this is a blob document
     };
 
     // Now collect all existing pieces for the blob.


### PR DESCRIPTION
This removes the maximum limit of allowed blob pieces (for now, we might want to have it back with some sort of configuration interface). This touched upon the pagination logic used to iterate over all pieces, so I decided to just paginate through it in a classic manner, page by page.

On top this uses now the `BytesMut` struct to efficiently assemble the blob pieces. For the future we might want to do this instead https://github.com/p2panda/aquadoggo/issues/548 to avoid keeping very large blobs in memory.

Closes: #546 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
