### PR TITLE
Stream blob data in chunks to files to not occupy too much memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - HTTP routes to serve files with correct content type headers [#544](https://github.com/p2panda/aquadoggo/pull/544)
 - Build a byte buffer over paginated pieces when assembling blobs [#547](https://github.com/p2panda/aquadoggo/pull/547)
+- Stream blob data in chunks to files to not occupy too much memory [#551](https://github.com/p2panda/aquadoggo/pull/551)
 
 ## [0.5.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,7 @@ dependencies = [
  "async-graphql",
  "async-graphql-axum",
  "async-recursion",
+ "async-stream",
  "async-trait",
  "asynchronous-codec",
  "axum",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -22,6 +22,7 @@ proptests = []
 anyhow = "1.0.62"
 async-graphql = { version = "5.0.6", features = ["dynamic-schema"] }
 async-graphql-axum = "5.0.6"
+async-stream = "0.3.5"
 async-trait = "0.1.64"
 asynchronous-codec = { version = "0.6.2", features = ["cbor"] }
 axum = { version = "0.6.10", features = ["headers"] }

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -23,15 +23,16 @@ const BLOB_QUERY_PAGE_SIZE: u64 = 10;
 
 pub type BlobData = Vec<u8>;
 
-/// Gets blob data from the database in chunks (via pagination) and populates a stream with it.
+/// Gets blob data from the database in chunks (via pagination) and populates a readable stream
+/// with it.
 ///
-/// This stream can then be further used to move data into a file etc. which helps dealing with
-/// large blobs which should not occupy the systems memory. We only move small chunks at a time and
-/// keep the memory-footprint managable.
+/// This stream can further be used to write data into a file etc. This helps dealing with large
+/// blobs as only little system memory is occupied per reading and writing step. We only move small
+/// chunks at a time and keep the memory-footprint managable.
 ///
-/// Currently the BLOB_QUERY_PAGE_SIZE is set to 10 which would be the multiplier of the
-/// MAX_BLOB_PIECE_LENGTH. With 10 * 256kb we would occupy an approximate maximum of 2.56mb memory
-/// at a time.
+/// Currently the BLOB_QUERY_PAGE_SIZE is set to 10 which is the multiplier of the
+/// MAX_BLOB_PIECE_LENGTH. With 10 * 256kb we occupy an approximate maximum of 2.56mb memory at a
+/// time. If these values make sense needs to be re-visited, but it is a start!
 #[derive(Debug)]
 pub struct BlobStream {
     store: SqlStore,

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -8,7 +8,7 @@ use p2panda_rs::document::DocumentViewId;
 use p2panda_rs::operation::OperationValue;
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::storage_provider::traits::DocumentStore;
-use tokio::fs::File;
+use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 
 use crate::context::Context;
@@ -84,13 +84,18 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
         // Write the blob to the filesystem
         info!("Creating blob at path {}", blob_view_path.display());
 
-        let mut file = File::create(&blob_view_path).await.map_err(|err| {
-            TaskError::Critical(format!(
-                "Could not create blob file @ {}: {}",
-                blob_view_path.display(),
-                err
-            ))
-        })?;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&blob_view_path)
+            .await
+            .map_err(|err| {
+                TaskError::Critical(format!(
+                    "Could not create blob file @ {}: {}",
+                    blob_view_path.display(),
+                    err
+                ))
+            })?;
 
         let stream = blob_stream.read_all();
         pin_mut!(stream);

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -97,9 +97,11 @@ fn show_warnings(config: &Configuration, is_temporary_blobs_path: bool) {
     }
 
     if config.database_url != "sqlite::memory:" && is_temporary_blobs_path {
-        warn!("Your database is persisted but blobs _are not_ which might result in unrecoverable
+        warn!(
+            "Your database is persisted but blobs _are not_ which might result in unrecoverable
         data inconsistency (blob operations are stored but the files themselves are _not_). It is
         recommended to either set both values (`database_url` and `blobs_base_path`) to an
-        temporary value or set both to persist all data.");
+        temporary value or set both to persist all data."
+        );
     }
 }


### PR DESCRIPTION
Establishes a stream from reading binary blob data from the database (via pagination) into writing the file on the file system. This allows for (parallely) handling very large blobs without occupying too much of memory.

Closes: https://github.com/p2panda/aquadoggo/issues/548

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
