### PR TITLE
Integrate `Bytes` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `BlobStore` [#484](https://github.com/p2panda/aquadoggo/pull/484)
 - Task for automatic garbage collection of unused documents and views [#500](https://github.com/p2panda/aquadoggo/pull/500)
 - Blobs directory configuration [#549](https://github.com/p2panda/aquadoggo/pull/549)
+- Integrate `Bytes` operation value [554](https://github.com/p2panda/aquadoggo/pull/554/)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,8 +278,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -290,8 +290,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -407,8 +407,8 @@ dependencies = [
  "async-graphql-parser",
  "darling",
  "proc-macro-crate",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "thiserror",
 ]
@@ -502,8 +502,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -524,8 +524,8 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -541,8 +541,8 @@ version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -945,8 +945,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1128,7 +1128,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.31",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1186,8 +1186,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "strsim",
  "syn 1.0.109",
 ]
@@ -1199,7 +1199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
- "quote 1.0.31",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1320,8 +1320,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1363,8 +1363,8 @@ dependencies = [
  "Inflector",
  "darling",
  "proc-macro-crate",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "thiserror",
 ]
@@ -1417,8 +1417,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1629,8 +1629,8 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -2629,8 +2629,8 @@ checksum = "c4d5ec2a3df00c7836d7696c136274c9c59705bac69133253696a6c932cd1d74"
 dependencies = [
  "heck",
  "proc-macro-warning",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -3117,7 +3117,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.1"
-source = "git+https://github.com/p2panda/p2panda?rev=219f03f3e6f5abb54570bf8b4452290252804f9f#219f03f3e6f5abb54570bf8b4452290252804f9f"
+source = "git+https://github.com/p2panda/p2panda?rev=7187f9f2396c73c1bad9736ada4d9ae097deb785#7187f9f2396c73c1bad9736ada4d9ae097deb785"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",
@@ -3237,9 +3237,9 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2",
  "proc-macro2-diagnostics",
- "quote 1.0.31",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -3286,8 +3286,8 @@ checksum = "99d490fe7e8556575ff6911e45567ab95e71617f43781e5c05490dc8d75c965c"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -3317,8 +3317,8 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -3407,18 +3407,9 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70550716265d1ec349c41f70dd4f964b4fd88394efe4405f0c1da679c4799a07"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -3436,8 +3427,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
  "version_check",
  "yansi",
@@ -3461,8 +3452,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3488,13 +3479,13 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3575,20 +3566,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -3861,8 +3843,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -3874,8 +3856,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
  "unicode-ident",
@@ -3887,7 +3869,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b29d3117bce27ea307d1fb7ce12c64ba11b3fd04311a42d32bc5f0072e6e3d4d"
 dependencies = [
- "quote 1.0.31",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -3898,7 +3880,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
- "quote 1.0.31",
+ "quote",
  "rand 0.8.5",
  "rustc_version",
  "syn 1.0.109",
@@ -4122,8 +4104,8 @@ version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -4277,8 +4259,8 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4421,8 +4403,8 @@ dependencies = [
  "either",
  "heck",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "sha2 0.10.7",
  "sqlx-core",
  "sqlx-rt",
@@ -4477,23 +4459,12 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -4503,8 +4474,8 @@ version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -4520,10 +4491,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
- "unicode-xid 0.2.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4584,8 +4555,8 @@ version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -4657,8 +4628,8 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -4811,8 +4782,8 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -4970,12 +4941,6 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -5123,8 +5088,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
@@ -5147,7 +5112,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.31",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -5157,8 +5122,8 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -5485,7 +5450,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.31",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.1"
-source = "git+https://github.com/p2panda/p2panda?rev=8377056617b64e898e9980e8ad84d258ca0442a1#8377056617b64e898e9980e8ad84d258ca0442a1"
+source = "git+https://github.com/p2panda/p2panda?rev=a3267adb742fce6d1e149a6380d1cbe24b147aab#a3267adb742fce6d1e149a6380d1cbe24b147aab"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",
@@ -4088,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
 dependencies = [
  "js-sys",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.1"
-source = "git+https://github.com/p2panda/p2panda?rev=7187f9f2396c73c1bad9736ada4d9ae097deb785#7187f9f2396c73c1bad9736ada4d9ae097deb785"
+source = "git+https://github.com/p2panda/p2panda?rev=be84d7c4e39c1b67125d80468ccf412cf25ae1d7#be84d7c4e39c1b67125d80468ccf412cf25ae1d7"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,7 +3117,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.1"
-source = "git+https://github.com/p2panda/p2panda?rev=a3267adb742fce6d1e149a6380d1cbe24b147aab#a3267adb742fce6d1e149a6380d1cbe24b147aab"
+source = "git+https://github.com/p2panda/p2panda?rev=219f03f3e6f5abb54570bf8b4452290252804f9f#219f03f3e6f5abb54570bf8b4452290252804f9f"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -56,12 +56,13 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "8377056617b64e898e9980e8ad84d258ca0442a1", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a3267adb742fce6d1e149a6380d1cbe24b147aab", features = [
     "storage-provider",
 ] }
 rand = "0.8.5"
 regex = "1.9.3"
 serde = { version = "1.0.152", features = ["derive"] }
+serde_bytes = "0.11.12"
 sqlx = { version = "0.6.1", features = [
     "any",
     "postgres",
@@ -96,7 +97,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "8377056617b64e898e9980e8ad84d258ca0442a1", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a3267adb742fce6d1e149a6380d1cbe24b147aab", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -56,7 +56,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "219f03f3e6f5abb54570bf8b4452290252804f9f", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "7187f9f2396c73c1bad9736ada4d9ae097deb785", features = [
     "storage-provider",
 ] }
 rand = "0.8.5"
@@ -97,12 +97,12 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "219f03f3e6f5abb54570bf8b4452290252804f9f", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "7187f9f2396c73c1bad9736ada4d9ae097deb785", features = [
     "test-utils",
     "storage-provider",
 ] }
-proptest = "1.1.0"
-proptest-derive = "0.3.0"
+proptest = "1.2.0"
+proptest-derive = "0.4.0"
 rand = "0.8.5"
 reqwest = { version = "0.11.11", default-features = false, features = [
     "json",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -56,7 +56,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "7187f9f2396c73c1bad9736ada4d9ae097deb785", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "be84d7c4e39c1b67125d80468ccf412cf25ae1d7", features = [
     "storage-provider",
 ] }
 rand = "0.8.5"
@@ -97,7 +97,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "7187f9f2396c73c1bad9736ada4d9ae097deb785", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "be84d7c4e39c1b67125d80468ccf412cf25ae1d7", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -56,7 +56,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a3267adb742fce6d1e149a6380d1cbe24b147aab", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "219f03f3e6f5abb54570bf8b4452290252804f9f", features = [
     "storage-provider",
 ] }
 rand = "0.8.5"
@@ -97,7 +97,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "a3267adb742fce6d1e149a6380d1cbe24b147aab", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "219f03f3e6f5abb54570bf8b4452290252804f9f", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -448,6 +448,26 @@ mod tests {
                     "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
                         .to_string(),
                 previous: None,
+                name: Some("data".to_string()),
+                field_type: Some("bytes".to_string()),
+                value: None,
+                data: Some(vec![0, 1, 2, 3]),
+                list_index: Some(0),
+                sorted_index: None,
+            },
+            OperationFieldsJoinedRow {
+                public_key: "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96"
+                    .to_string(),
+                document_id: "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
+                    .to_string(),
+                operation_id:
+                    "0020b177ec1bf26dfb3b7010d473e6d44713b29b765b99c6e60ecbfae742de496543"
+                        .to_string(),
+                action: "create".to_string(),
+                schema_id:
+                    "venue_0020c65567ae37efea293e34a9c7d13f8f2bf23dbdc3b5c7b9ab46293111c48fc78b"
+                        .to_string(),
+                previous: None,
                 name: Some("height".to_string()),
                 field_type: Some("float".to_string()),
                 value: Some("3.5".to_string()),
@@ -696,6 +716,10 @@ mod tests {
             &OperationValue::String("bubu".to_string())
         );
         assert_eq!(
+            operation.fields().unwrap().get("data").unwrap(),
+            &OperationValue::Bytes(vec![0, 1, 2, 3])
+        );
+        assert_eq!(
             operation.fields().unwrap().get("age").unwrap(),
             &OperationValue::Integer(28)
         );
@@ -786,35 +810,20 @@ mod tests {
     #[rstest]
     fn operation_values_to_string_vec(schema_id: SchemaId) {
         let expected_list = vec![
-            Some("28".to_string()),
-            None,
-            Some(
-                "0020abababababababababababababababababababababababababababababababab".to_string(),
-            ),
-            Some(
-                "0020cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd".to_string(),
-            ),
-            Some("3.5".to_string()),
-            Some("false".to_string()),
-            Some(
-                "0020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
-            ),
-            Some(
-                "0020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
-            ),
-            Some(
-                "0020cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".to_string(),
-            ),
-            Some(
-                "0020dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string(),
-            ),
-            Some(
-                "0020eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_string(),
-            ),
-            Some(
-                "0020ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string(),
-            ),
-            Some("bubu".to_string()),
+            Some("28".into()),
+            None, // This is an empty relation list
+            Some("0020abababababababababababababababababababababababababababababababab".into()),
+            Some("0020cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd".into()),
+            Some(vec![0, 1, 2, 3].into()),
+            Some("3.5".into()),
+            Some("false".into()),
+            Some("0020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
+            Some("0020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into()),
+            Some("0020cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc".into()),
+            Some("0020dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".into()),
+            Some("0020eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".into()),
+            Some("0020ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".into()),
+            Some("bubu".into()),
         ];
 
         let operation = create_operation(doggo_fields(), schema_id);
@@ -853,58 +862,44 @@ mod tests {
 
     #[test]
     fn parses_document_field_rows() {
+        let document_id =
+            "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0".to_string();
+        let operation_id =
+            "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770".to_string();
+        let document_view_id = operation_id.clone();
+
         let document_field_rows = vec![
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "age".to_string(),
                 list_index: 0,
                 field_type: "int".to_string(),
                 value: Some("28".to_string()),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "height".to_string(),
                 list_index: 0,
                 field_type: "float".to_string(),
                 value: Some("3.5".to_string()),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "is_admin".to_string(),
                 list_index: 0,
                 field_type: "bool".to_string(),
                 value: Some("false".to_string()),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "many_profile_pictures".to_string(),
                 list_index: 0,
                 field_type: "relation_list".to_string(),
@@ -914,14 +909,9 @@ mod tests {
                 ),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "many_profile_pictures".to_string(),
                 list_index: 1,
                 field_type: "relation_list".to_string(),
@@ -931,14 +921,9 @@ mod tests {
                 ),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "many_special_profile_pictures".to_string(),
                 list_index: 0,
                 field_type: "pinned_relation_list".to_string(),
@@ -948,14 +933,9 @@ mod tests {
                 ),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "many_special_profile_pictures".to_string(),
                 list_index: 1,
                 field_type: "pinned_relation_list".to_string(),
@@ -965,14 +945,9 @@ mod tests {
                 ),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "profile_picture".to_string(),
                 list_index: 0,
                 field_type: "relation".to_string(),
@@ -982,14 +957,9 @@ mod tests {
                 ),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "special_profile_picture".to_string(),
                 list_index: 0,
                 field_type: "pinned_relation".to_string(),
@@ -999,28 +969,28 @@ mod tests {
                 ),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "username".to_string(),
                 list_index: 0,
                 field_type: "str".to_string(),
                 value: Some("bubu".to_string()),
             },
             DocumentViewFieldRow {
-                document_id: "0020713b2777f1222660291cb528d220c358920b4beddc1aea9df88a69cec45a10c0"
-                    .to_string(),
-                document_view_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
-                operation_id:
-                    "0020dc8fe1cbacac4d411ae25ea264369a7b2dabdfb617129dec03b6661edd963770"
-                        .to_string(),
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
+                name: "data".to_string(),
+                list_index: 0,
+                field_type: "bytes".to_string(),
+                value: None,
+                data: Some(vec![0, 1, 2, 3]),
+            },
+            DocumentViewFieldRow {
+                document_id: document_id.clone(),
+                document_view_id: document_view_id.clone(),
+                operation_id: operation_id.clone(),
                 name: "an_empty_relation_list".to_string(),
                 list_index: 0,
                 field_type: "pinned_relation_list".to_string(),
@@ -1037,6 +1007,10 @@ mod tests {
         assert_eq!(
             document_fields.get("username").unwrap(),
             &DocumentViewValue::new(&operation_id, &OperationValue::String("bubu".to_string()))
+        );
+        assert_eq!(
+            document_fields.get("data").unwrap(),
+            &DocumentViewValue::new(&operation_id, &OperationValue::Bytes(vec![0, 1, 2, 3]))
         );
         assert_eq!(
             document_fields.get("age").unwrap(),

--- a/aquadoggo/src/db/models/utils.rs
+++ b/aquadoggo/src/db/models/utils.rs
@@ -245,7 +245,7 @@ pub fn parse_value_to_string_vec(value: &OperationValue) -> Vec<Option<String>> 
         }
         OperationValue::Bytes(bytes) => {
             // bytes are stored in the db as hex strings
-            vec![Some(hex::encode(&bytes))]
+            vec![Some(hex::encode(bytes))]
         }
     }
 }

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -434,22 +434,22 @@ mod tests {
             // These are the rows we expect to exist in each table.
             assert_query(&node, "SELECT entry_hash FROM entries", 4).await;
             assert_query(&node, "SELECT operation_id FROM operations_v1", 4).await;
-            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 19).await;
+            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 20).await;
             assert_query(&node, "SELECT log_id FROM logs", 4).await;
             assert_query(&node, "SELECT document_id FROM documents", 4).await;
             assert_query(&node, "SELECT document_id FROM document_views", 4).await;
-            assert_query(&node, "SELECT name FROM document_view_fields", 15).await;
+            assert_query(&node, "SELECT name FROM document_view_fields", 16).await;
 
             let document_id: DocumentId = blob_view_id.to_string().parse().unwrap();
             let result = node.context.store.purge_blob(&document_id).await;
             assert!(result.is_ok(), "{:#?}", result);
             assert_query(&node, "SELECT entry_hash FROM entries", 1).await;
             assert_query(&node, "SELECT operation_id FROM operations_v1", 1).await;
-            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 13).await;
+            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 14).await;
             assert_query(&node, "SELECT log_id FROM logs", 4).await;
             assert_query(&node, "SELECT document_id FROM documents", 1).await;
             assert_query(&node, "SELECT document_id FROM document_views", 1).await;
-            assert_query(&node, "SELECT name FROM document_view_fields", 10).await;
+            assert_query(&node, "SELECT name FROM document_view_fields", 11).await;
 
             let result = node.context.store.purge_blob(&document_id).await;
 

--- a/aquadoggo/src/db/stores/blob.rs
+++ b/aquadoggo/src/db/stores/blob.rs
@@ -208,9 +208,7 @@ async fn document_to_blob_data(
                 .get("data")
                 .expect("Blob piece document without \"data\" field")
             {
-                // @TODO: Use bytes here instead, see related issue:
-                // https://github.com/p2panda/aquadoggo/issues/543
-                OperationValue::String(data_str) => buf.put(data_str.as_bytes()),
+                OperationValue::Bytes(data_str) => buf.put(&data_str[..]),
                 _ => unreachable!(), // We only queried for blob piece documents
             }
         }
@@ -240,6 +238,7 @@ mod tests {
     use p2panda_rs::identity::KeyPair;
     use p2panda_rs::schema::SchemaId;
     use p2panda_rs::test_utils::fixtures::{key_pair, random_document_view_id};
+    use p2panda_rs::test_utils::generate_random_bytes;
     use p2panda_rs::test_utils::memory_store::helpers::PopulateStoreConfig;
     use rstest::rstest;
 
@@ -279,7 +278,7 @@ mod tests {
     #[rstest]
     fn get_blob_errors(key_pair: KeyPair) {
         test_runner(|mut node: TestNode| async move {
-            let blob_data = "Hello, World!".to_string();
+            let blob_data = generate_random_bytes(12);
 
             // Publish a blob containing pieces which aren't in the store.
             let blob_view_id = add_document(
@@ -511,7 +510,7 @@ mod tests {
             let new_blob_pieces = add_document(
                 &mut node,
                 &SchemaId::BlobPiece(1),
-                vec![("data", "more blob data".into())],
+                vec![("data", "more blob data".as_bytes().into())],
                 &key_pair,
             )
             .await;

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -960,6 +960,7 @@ mod tests {
                 "age",
                 "height",
                 "is_admin",
+                "data",
                 "profile_picture",
                 "many_profile_pictures",
                 "special_profile_picture",
@@ -1395,7 +1396,7 @@ mod tests {
                 Some(&document_id.as_str().parse().unwrap()),
             )
             .await;
-            println!("{:#?}", result);
+
             assert!(result.is_err());
 
             let result = next_args(&node.context.store, &public_key, None).await;

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -1320,11 +1320,11 @@ mod tests {
             // expect for each table.
             assert_query(&node, "SELECT entry_hash FROM entries", 2).await;
             assert_query(&node, "SELECT operation_id FROM operations_v1", 2).await;
-            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 26).await;
+            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 28).await;
             assert_query(&node, "SELECT log_id FROM logs", 1).await;
             assert_query(&node, "SELECT document_id FROM documents", 1).await;
             assert_query(&node, "SELECT document_id FROM document_views", 1).await;
-            assert_query(&node, "SELECT name FROM document_view_fields", 10).await;
+            assert_query(&node, "SELECT name FROM document_view_fields", 11).await;
 
             // Purge this document from the database, we now expect all tables to be empty.
             let result = node.context.store.purge_document(&document_id).await;
@@ -1355,11 +1355,11 @@ mod tests {
             // for each table.
             assert_query(&node, "SELECT entry_hash FROM entries", 2).await;
             assert_query(&node, "SELECT operation_id FROM operations_v1", 2).await;
-            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 26).await;
+            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 28).await;
             assert_query(&node, "SELECT log_id FROM logs", 2).await;
             assert_query(&node, "SELECT document_id FROM documents", 2).await;
             assert_query(&node, "SELECT document_id FROM document_views", 2).await;
-            assert_query(&node, "SELECT name FROM document_view_fields", 20).await;
+            assert_query(&node, "SELECT name FROM document_view_fields", 22).await;
 
             // Purge one document from the database, we now expect half the rows to be remaining.
             let result = node.context.store.purge_document(&document_id).await;
@@ -1367,11 +1367,11 @@ mod tests {
 
             assert_query(&node, "SELECT entry_hash FROM entries", 1).await;
             assert_query(&node, "SELECT operation_id FROM operations_v1", 1).await;
-            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 13).await;
+            assert_query(&node, "SELECT operation_id FROM operation_fields_v1", 14).await;
             assert_query(&node, "SELECT log_id FROM logs", 2).await;
             assert_query(&node, "SELECT document_id FROM documents", 1).await;
             assert_query(&node, "SELECT document_id FROM document_views", 1).await;
-            assert_query(&node, "SELECT name FROM document_view_fields", 10).await;
+            assert_query(&node, "SELECT name FROM document_view_fields", 11).await;
         });
     }
 

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -300,7 +300,7 @@ fn bind_arg(value: &OperationValue) -> Vec<BindArgument> {
             .iter()
             .map(|view_id| BindArgument::String(view_id.to_string()))
             .collect(),
-        OperationValue::Bytes(value) => vec![BindArgument::String(hex::encode(&value))],
+        OperationValue::Bytes(value) => vec![BindArgument::String(hex::encode(value))],
     }
 }
 

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -300,6 +300,7 @@ fn bind_arg(value: &OperationValue) -> Vec<BindArgument> {
             .iter()
             .map(|view_id| BindArgument::String(view_id.to_string()))
             .collect(),
+        OperationValue::Bytes(value) => vec![BindArgument::String(hex::encode(&value))],
     }
 }
 

--- a/aquadoggo/src/graphql/input_values/fields_filter.rs
+++ b/aquadoggo/src/graphql/input_values/fields_filter.rs
@@ -10,7 +10,9 @@ use async_graphql::dynamic::{InputObject, InputValue, TypeRef};
 use dynamic_graphql::InputObject;
 use p2panda_rs::schema::{FieldType, Schema};
 
-use crate::graphql::scalars::{DocumentIdScalar, DocumentViewIdScalar, PublicKeyScalar};
+use crate::graphql::scalars::{
+    DocumentIdScalar, DocumentViewIdScalar, HexBytesScalar, PublicKeyScalar,
+};
 use crate::graphql::utils::filter_name;
 
 /// Build a filter input object for a p2panda schema. It can be used to filter collection queries
@@ -41,6 +43,10 @@ pub fn build_filter_input_object(schema: &Schema) -> InputObject {
             FieldType::String => {
                 filter_input =
                     filter_input.field(InputValue::new(name, TypeRef::named("StringFilter")));
+            }
+            FieldType::Bytes => {
+                filter_input =
+                    filter_input.field(InputValue::new(name, TypeRef::named("HexBytesFilter")));
             }
             FieldType::Relation(_) => {
                 filter_input =
@@ -169,6 +175,19 @@ pub struct StringFilter {
     /// Filter for items which don't contain given value.
     #[graphql(name = "notContains")]
     not_contains: Option<String>,
+}
+
+/// A filter input type for bytes field values.
+#[derive(InputObject)]
+#[allow(dead_code)]
+pub struct HexBytesFilter {
+    /// Filter by equal to.
+    #[graphql(name = "eq")]
+    eq: Option<HexBytesScalar>,
+
+    /// Filter by not equal to.
+    #[graphql(name = "notEq")]
+    not_eq: Option<HexBytesScalar>,
 }
 
 /// A filter input type for integer field values.

--- a/aquadoggo/src/graphql/input_values/mod.rs
+++ b/aquadoggo/src/graphql/input_values/mod.rs
@@ -5,7 +5,7 @@ mod meta_filter;
 mod order;
 
 pub use fields_filter::{
-    build_filter_input_object, BooleanFilter, DocumentIdFilter, DocumentViewIdFilter, FloatFilter,
+    build_filter_input_object, BooleanFilter, HexBytesFilter, DocumentIdFilter, DocumentViewIdFilter, FloatFilter,
     IntegerFilter, OwnerFilter, PinnedRelationFilter, PinnedRelationListFilter, RelationFilter,
     RelationListFilter, StringFilter,
 };

--- a/aquadoggo/src/graphql/input_values/mod.rs
+++ b/aquadoggo/src/graphql/input_values/mod.rs
@@ -5,9 +5,9 @@ mod meta_filter;
 mod order;
 
 pub use fields_filter::{
-    build_filter_input_object, BooleanFilter, HexBytesFilter, DocumentIdFilter, DocumentViewIdFilter, FloatFilter,
-    IntegerFilter, OwnerFilter, PinnedRelationFilter, PinnedRelationListFilter, RelationFilter,
-    RelationListFilter, StringFilter,
+    build_filter_input_object, BooleanFilter, DocumentIdFilter, DocumentViewIdFilter, FloatFilter,
+    HexBytesFilter, IntegerFilter, OwnerFilter, PinnedRelationFilter, PinnedRelationListFilter,
+    RelationFilter, RelationListFilter, StringFilter,
 };
 pub use meta_filter::MetaFilterInputObject;
 pub use order::{build_order_enum_value, OrderDirection};

--- a/aquadoggo/src/graphql/queries/collection.rs
+++ b/aquadoggo/src/graphql/queries/collection.rs
@@ -629,7 +629,10 @@ mod tests {
             add_document(
                 &mut node,
                 schema.id(),
-                vec![("bool", false.into()), ("data", vec![4, 5, 6, 7][..].into())],
+                vec![
+                    ("bool", false.into()),
+                    ("data", vec![4, 5, 6, 7][..].into()),
+                ],
                 &key_pair,
             )
             .await;

--- a/aquadoggo/src/graphql/queries/collection.rs
+++ b/aquadoggo/src/graphql/queries/collection.rs
@@ -284,6 +284,7 @@ mod tests {
                     ("artist", "X-ray Spex".into(), None),
                     ("title", "Oh Bondage Up Yours!".into(), None),
                     ("release_year", 1977.into(), None),
+                    ("audio", vec![0, 1, 2, 3][..].into(), None),
                     (
                         "lyrics",
                         vec![
@@ -328,6 +329,7 @@ mod tests {
                     ("artist", "Gang Of Four".into(), None),
                     ("title", "Natural's Not In".into(), None),
                     ("release_year", 1979.into(), None),
+                    ("audio", vec![4, 5, 6, 7][..].into(), None),
                     (
                         "lyrics",
                         vec![
@@ -385,6 +387,7 @@ mod tests {
                     ("artist", "David Bowie".into(), None),
                     ("title", "Speed Of Life".into(), None),
                     ("release_year", 1977.into(), None),
+                    ("audio", vec![8, 9, 10, 11][..].into(), None),
                     (
                         "lyrics",
                         OperationValue::RelationList(RelationList::new(vec![])),
@@ -404,24 +407,30 @@ mod tests {
             "collection": value!({
                 "hasNextPage": false,
                 "totalCount": 2,
-                "endCursor": "31Ch6qa4mdKcxpWJG4X9Wf5iMvSSxmSGg8cyg9teNR6yKmLncZCmyVUaPFjRNoWcxpeASGqrRiJGR8HSqjWBz5HE",
+                "endCursor": "24gc7iHafVKTcfRZfVVV8etkSoJMJVsqs1iYJAuHb8oNp32Vi1PcYw6S5GJ8hNhPmHHbP1weVbACYRctHVz4jXjQ",
                 "documents": [
                     {
-                        "cursor": "273AmFQTk7w6134GhzKUS5tY8qDuaMYBPgbaftZ43G7saiKa73MPapFvjNDixbNjCr5ucNqzNsx2fYdRqRod9U2W",
-                        "fields": { "bool": true, },
+                        "cursor": "24gZVnL75RPvxMVAiuGT2SgCrHneGZgsvEaiCh5g8qgxGBhcunAffueCUTiyuLDamP1G48KYPmRDBBFG43dh3XJ2",
+                        "fields": { 
+                            "bool": true,
+                            "data": "00010203",
+                        },
                         "meta": {
                             "owner": "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96",
-                            "documentId": "00200436216389856afb3f3a7d8cb2d2981be85787aebed02031c72eb9c216406c57",
-                            "viewId": "00200436216389856afb3f3a7d8cb2d2981be85787aebed02031c72eb9c216406c57",
+                            "documentId": "0020223f123be0f9025c591fba1a5800ca64084e837315521d5b65a870e874ed8b4e",
+                            "viewId": "0020223f123be0f9025c591fba1a5800ca64084e837315521d5b65a870e874ed8b4e",
                         }
                     },
                     {
-                        "cursor": "31Ch6qa4mdKcxpWJG4X9Wf5iMvSSxmSGg8cyg9teNR6yKmLncZCmyVUaPFjRNoWcxpeASGqrRiJGR8HSqjWBz5HE",
-                        "fields": { "bool": false, },
+                        "cursor": "24gc7iHafVKTcfRZfVVV8etkSoJMJVsqs1iYJAuHb8oNp32Vi1PcYw6S5GJ8hNhPmHHbP1weVbACYRctHVz4jXjQ",
+                        "fields": { 
+                            "bool": false,
+                            "data": "04050607"
+                        },
                         "meta": {
                             "owner": "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96",
-                            "documentId": "0020de552d81948f220d09127dc42963071d086a142c9547e701674d4cac83f29872",
-                            "viewId": "0020de552d81948f220d09127dc42963071d086a142c9547e701674d4cac83f29872",
+                            "documentId": "0020c7dbed85159bbea8f1c44f1d4d7dfbdded6cd43c09ab1a292089e9530964cab9",
+                            "viewId": "0020c7dbed85159bbea8f1c44f1d4d7dfbdded6cd43c09ab1a292089e9530964cab9",
                         }
                     }
                 ]
@@ -433,7 +442,7 @@ mod tests {
         r#"
             (
                 first: 1,
-                after: "31Ch6qa4mdKcxpWJG4X9Wf5iMvSSxmSGg8cyg9teNR6yKmLncZCmyVUaPFjRNoWcxpeASGqrRiJGR8HSqjWBz5HE",
+                after: "24gc7iHafVKTcfRZfVVV8etkSoJMJVsqs1iYJAuHb8oNp32Vi1PcYw6S5GJ8hNhPmHHbP1weVbACYRctHVz4jXjQ",
                 orderBy: DOCUMENT_ID,
                 orderDirection: ASC,
                 filter: {
@@ -454,6 +463,38 @@ mod tests {
         vec![]
     )]
     #[case(
+        r#"(
+            first: 2,
+            filter: {
+                data: {
+                    eq: "00010203"
+                }
+            }
+        )"#.to_string(),
+        value!({
+            "collection": value!({
+                "hasNextPage": false,
+                "totalCount": 1,
+                "endCursor": "24gZVnL75RPvxMVAiuGT2SgCrHneGZgsvEaiCh5g8qgxGBhcunAffueCUTiyuLDamP1G48KYPmRDBBFG43dh3XJ2",
+                "documents": [
+                    {
+                        "cursor": "24gZVnL75RPvxMVAiuGT2SgCrHneGZgsvEaiCh5g8qgxGBhcunAffueCUTiyuLDamP1G48KYPmRDBBFG43dh3XJ2",
+                        "fields": { 
+                            "bool": true,
+                            "data": "00010203",
+                        },
+                        "meta": {
+                            "owner": "2f8e50c2ede6d936ecc3144187ff1c273808185cfbc5ff3d3748d1ff7353fc96",
+                            "documentId": "0020223f123be0f9025c591fba1a5800ca64084e837315521d5b65a870e874ed8b4e",
+                            "viewId": "0020223f123be0f9025c591fba1a5800ca64084e837315521d5b65a870e874ed8b4e",
+                        }
+                    }
+                ]
+            }),
+        }),
+        vec![]
+    )]
+    #[case(
         r#"(first: 0)"#.to_string(),
         Value::Null,
         vec!["out of range integral type conversion attempted".to_string()]
@@ -469,7 +510,7 @@ mod tests {
         vec!["Invalid value for argument \"after\", expected type \"Cursor\"".to_string()]
     )]
     #[case(
-        r#"(after: "00205406410aefce40c5cbbb04488f50714b7d5657b9f17eed7358da35379bc20331")"#.to_string(),
+        r#"(after: "0020d384b69386867b61acebe6b23d4fac8c1425d5dce339bb3ef7c2218c155b3f9a")"#.to_string(),
         Value::Null,
         vec!["Invalid value for argument \"after\", expected type \"Cursor\"".to_string()]
     )]
@@ -481,12 +522,12 @@ mod tests {
     #[case(
         r#"(orderBy: HELLO)"#.to_string(),
         Value::Null,
-        vec!["Invalid value for argument \"orderBy\", enumeration type \"schema_name_00205406410aefce40c5cbbb04488f50714b7d5657b9f17eed7358da35379bc20331OrderBy\" does not contain the value \"HELLO\"".to_string()]
+        vec!["Invalid value for argument \"orderBy\", enumeration type \"schema_name_0020d384b69386867b61acebe6b23d4fac8c1425d5dce339bb3ef7c2218c155b3f9aOrderBy\" does not contain the value \"HELLO\"".to_string()]
     )]
     #[case(
         r#"(orderBy: "hello")"#.to_string(),
         Value::Null,
-        vec!["Invalid value for argument \"orderBy\", enumeration type \"schema_name_00205406410aefce40c5cbbb04488f50714b7d5657b9f17eed7358da35379bc20331OrderBy\" does not contain the value \"hello\"".to_string()]
+        vec!["Invalid value for argument \"orderBy\", enumeration type \"schema_name_0020d384b69386867b61acebe6b23d4fac8c1425d5dce339bb3ef7c2218c155b3f9aOrderBy\" does not contain the value \"hello\"".to_string()]
     )]
     #[case(
         r#"(orderDirection: HELLO)"#.to_string(),
@@ -511,7 +552,7 @@ mod tests {
     #[case(
         r#"(filter: { hello: { eq: true }})"#.to_string(),
         Value::Null,
-        vec!["Invalid value for argument \"filter\", unknown field \"hello\" of type \"schema_name_00205406410aefce40c5cbbb04488f50714b7d5657b9f17eed7358da35379bc20331Filter\"".to_string()]
+        vec!["Invalid value for argument \"filter\", unknown field \"hello\" of type \"schema_name_0020d384b69386867b61acebe6b23d4fac8c1425d5dce339bb3ef7c2218c155b3f9aFilter\"".to_string()]
     )]
     #[case(
         r#"(filter: { bool: { contains: "hello" }})"#.to_string(),
@@ -570,7 +611,7 @@ mod tests {
             let schema = add_schema(
                 &mut node,
                 "schema_name",
-                vec![("bool", FieldType::Boolean)],
+                vec![("bool", FieldType::Boolean), ("data", FieldType::Bytes)],
                 &key_pair,
             )
             .await;
@@ -579,7 +620,7 @@ mod tests {
             add_document(
                 &mut node,
                 schema.id(),
-                vec![("bool", true.into())],
+                vec![("bool", true.into()), ("data", vec![0, 1, 2, 3][..].into())],
                 &key_pair,
             )
             .await;
@@ -588,7 +629,7 @@ mod tests {
             add_document(
                 &mut node,
                 schema.id(),
-                vec![("bool", false.into())],
+                vec![("bool", false.into()), ("data", vec![4, 5, 6, 7][..].into())],
                 &key_pair,
             )
             .await;
@@ -605,6 +646,7 @@ mod tests {
                         cursor
                         fields {{
                             bool
+                            data
                         }}
                         meta {{
                             owner
@@ -813,6 +855,9 @@ mod tests {
     #[case("(filter: { title: { eq: \"Natural's Not In\" } })", "")]
     #[case("(filter: { title: { notEq: \"Natural's Not In\", in: [ \"Oh Bondage Up Yours!\", \"Speed Of Life\" ] } })", "")]
     #[case("(filter: { title: { notEq: \"Natural's Not In\" }, release_year: { gt: 1978 }, artist: { in: [ \"X-ray Spex\"] } })", "")]
+    #[case("(filter: { audio: { notEq: \"aa\" } })", "")]
+    #[case("(filter: { audio: { eq: \"E8\" } })", "")]
+    #[case("(filter: { audio: { eq: \"\" } })", "")]
     #[case(
         "(orderDirection: DESC, orderBy: title)",
         "(orderDirection: ASC, orderBy: line)"

--- a/aquadoggo/src/graphql/queries/next_args.rs
+++ b/aquadoggo/src/graphql/queries/next_args.rs
@@ -190,7 +190,7 @@ mod tests {
                     "nextArgs": {
                         "logId": "0",
                         "seqNum": "2",
-                        "backlink": "0020597040e2b85b4eaf3955f7aaca8f8fd60f00f77549a5554c8dd4081657f0d231",
+                        "backlink": "002098e61a9d946a1f046bd68414bfcc8fec09ddb3954dccaf184eaf7a7f4eb9cd26",
                         "skiplink": null,
                     }
                 })

--- a/aquadoggo/src/graphql/scalars/hex_bytes_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/hex_bytes_scalar.rs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::fmt::Display;
+
+use dynamic_graphql::{Error, Result, Scalar, ScalarValue, Value};
+use serde::Serialize;
+
+/// Bytes encoded as a hexadecimal string.
+#[derive(Scalar, Clone, Debug, Eq, PartialEq, Serialize)]
+#[graphql(name = "HexBytes", validator(validate))]
+pub struct HexBytesScalar(String);
+
+impl ScalarValue for HexBytesScalar {
+    fn from_value(value: Value) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        match &value {
+            Value::String(value) => {
+                hex::decode(value)?;
+                Ok(HexBytesScalar(value.to_string()))
+            }
+            _ => Err(Error::new(format!("Expected hex string, found: {value}"))),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::Binary(self.0.clone().into())
+    }
+}
+
+impl From<HexBytesScalar> for String {
+    fn from(hash: HexBytesScalar) -> Self {
+        hash.0
+    }
+}
+
+impl From<String> for HexBytesScalar {
+    fn from(vec: String) -> Self {
+        Self(vec)
+    }
+}
+
+impl From<HexBytesScalar> for Value {
+    fn from(entry: HexBytesScalar) -> Self {
+        ScalarValue::to_value(&entry)
+    }
+}
+
+impl Display for HexBytesScalar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hex = hex::encode(&self.0);
+        write!(f, "{}", hex)
+    }
+}
+
+/// Validation method used internally in `async-graphql` to check scalar values passed into the
+/// public api.
+fn validate(value: &Value) -> bool {
+    HexBytesScalar::from_value(value.to_owned()).is_ok()
+}

--- a/aquadoggo/src/graphql/scalars/mod.rs
+++ b/aquadoggo/src/graphql/scalars/mod.rs
@@ -7,24 +7,24 @@
 //!
 //! We use a naming convention of appending the item's GraphQL type (e.g. `Scalar`) when a p2panda
 //! item of the exact same name is being wrapped.
-mod hex_bytes_scalar;
 mod cursor_scalar;
 mod document_id_scalar;
 mod document_view_id_scalar;
 mod encoded_entry_scalar;
 mod encoded_operation_scalar;
 mod entry_hash_scalar;
+mod hex_bytes_scalar;
 mod log_id_scalar;
 mod public_key_scalar;
 mod seq_num_scalar;
 
-pub use hex_bytes_scalar::HexBytesScalar;
 pub use cursor_scalar::CursorScalar;
 pub use document_id_scalar::DocumentIdScalar;
 pub use document_view_id_scalar::DocumentViewIdScalar;
 pub use encoded_entry_scalar::EncodedEntryScalar;
 pub use encoded_operation_scalar::EncodedOperationScalar;
 pub use entry_hash_scalar::EntryHashScalar;
+pub use hex_bytes_scalar::HexBytesScalar;
 pub use log_id_scalar::LogIdScalar;
 pub use public_key_scalar::PublicKeyScalar;
 pub use seq_num_scalar::SeqNumScalar;

--- a/aquadoggo/src/graphql/scalars/mod.rs
+++ b/aquadoggo/src/graphql/scalars/mod.rs
@@ -7,6 +7,7 @@
 //!
 //! We use a naming convention of appending the item's GraphQL type (e.g. `Scalar`) when a p2panda
 //! item of the exact same name is being wrapped.
+mod hex_bytes_scalar;
 mod cursor_scalar;
 mod document_id_scalar;
 mod document_view_id_scalar;
@@ -17,6 +18,7 @@ mod log_id_scalar;
 mod public_key_scalar;
 mod seq_num_scalar;
 
+pub use hex_bytes_scalar::HexBytesScalar;
 pub use cursor_scalar::CursorScalar;
 pub use document_id_scalar::DocumentIdScalar;
 pub use document_view_id_scalar::DocumentViewIdScalar;

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -13,9 +13,9 @@ use tokio::sync::Mutex;
 use crate::bus::ServiceSender;
 use crate::db::SqlStore;
 use crate::graphql::input_values::{
-    build_filter_input_object, build_order_enum_value, BooleanFilter, FloatFilter, IntegerFilter,
-    MetaFilterInputObject, OrderDirection, PinnedRelationFilter, PinnedRelationListFilter,
-    RelationFilter, RelationListFilter, StringFilter,
+    build_filter_input_object, build_order_enum_value, BooleanFilter, FloatFilter, HexBytesFilter,
+    IntegerFilter, MetaFilterInputObject, OrderDirection, PinnedRelationFilter,
+    PinnedRelationListFilter, RelationFilter, RelationListFilter, StringFilter,
 };
 use crate::graphql::mutations::{MutationRoot, Publish};
 use crate::graphql::objects::{
@@ -28,7 +28,8 @@ use crate::graphql::queries::{
 use crate::graphql::responses::NextArguments;
 use crate::graphql::scalars::{
     CursorScalar, DocumentIdScalar, DocumentViewIdScalar, EncodedEntryScalar,
-    EncodedOperationScalar, EntryHashScalar, LogIdScalar, PublicKeyScalar, SeqNumScalar,
+    EncodedOperationScalar, EntryHashScalar, HexBytesScalar, LogIdScalar, PublicKeyScalar,
+    SeqNumScalar,
 };
 use crate::schema::SchemaProvider;
 
@@ -52,6 +53,7 @@ pub async fn build_root_schema(
         .register::<DocumentMeta>()
         // Register input values
         .register::<BooleanFilter>()
+        .register::<HexBytesFilter>()
         .register::<FloatFilter>()
         .register::<IntegerFilter>()
         .register::<MetaFilterInputObject>()
@@ -62,6 +64,7 @@ pub async fn build_root_schema(
         .register::<RelationListFilter>()
         .register::<StringFilter>()
         // Register scalars
+        .register::<HexBytesScalar>()
         .register::<CursorScalar>()
         .register::<DocumentIdScalar>()
         .register::<DocumentViewIdScalar>()

--- a/aquadoggo/src/graphql/tests.rs
+++ b/aquadoggo/src/graphql/tests.rs
@@ -27,6 +27,7 @@ fn scalar_fields() {
                 ("float", FieldType::Float),
                 ("int", FieldType::Integer),
                 ("text", FieldType::String),
+                ("bytes", FieldType::Bytes),
             ],
             &key_pair,
         )
@@ -38,6 +39,7 @@ fn scalar_fields() {
             ("float", (1.0).into()),
             ("int", 1.into()),
             ("text", "yes".into()),
+            ("bytes", vec![0, 1, 2, 3][..].into()),
         ]
         .try_into()
         .unwrap();
@@ -52,7 +54,8 @@ fn scalar_fields() {
                         bool,
                         float,
                         int,
-                        text
+                        text,
+                        bytes
                     }}
                 }},
             }}"#,
@@ -77,6 +80,7 @@ fn scalar_fields() {
                     "float": 1.0,
                     "int": 1,
                     "text": "yes",
+                    "bytes": "00010203",
                 }
             },
         });

--- a/aquadoggo/src/graphql/utils.rs
+++ b/aquadoggo/src/graphql/utils.rs
@@ -61,6 +61,7 @@ pub fn gql_scalar(operation_value: &OperationValue) -> Value {
         OperationValue::Float(value) => value.to_owned().into(),
         OperationValue::Integer(value) => value.to_owned().into(),
         OperationValue::String(value) => value.to_owned().into(),
+        OperationValue::Bytes(value) => value.to_owned().into(),
         _ => panic!("This method is not used for relation types"),
     }
 }
@@ -74,6 +75,7 @@ pub fn graphql_type(field_type: &FieldType) -> TypeRef {
         FieldType::Integer => TypeRef::named(TypeRef::INT),
         FieldType::Float => TypeRef::named(TypeRef::FLOAT),
         FieldType::String => TypeRef::named(TypeRef::STRING),
+        FieldType::Bytes => TypeRef::named("HexBytes"),
         FieldType::Relation(schema_id) => TypeRef::named(schema_id.to_string()),
         FieldType::RelationList(schema_id) => TypeRef::named(collection_name(schema_id)),
         FieldType::PinnedRelation(schema_id) => TypeRef::named(schema_id.to_string()),
@@ -98,6 +100,11 @@ pub fn filter_to_operation_value(
         FieldType::PinnedRelation(_) | FieldType::PinnedRelationList(_) => {
             let document_view_id: DocumentViewId = filter_value.string()?.parse()?;
             document_view_id.into()
+        }
+        FieldType::Bytes => {
+            let hex_string = filter_value.string()?;
+            let bytes = hex::decode(hex_string)?;
+            bytes[..].into()
         }
     };
 

--- a/aquadoggo/src/graphql/utils.rs
+++ b/aquadoggo/src/graphql/utils.rs
@@ -61,7 +61,10 @@ pub fn gql_scalar(operation_value: &OperationValue) -> Value {
         OperationValue::Float(value) => value.to_owned().into(),
         OperationValue::Integer(value) => value.to_owned().into(),
         OperationValue::String(value) => value.to_owned().into(),
-        OperationValue::Bytes(value) => value.to_owned().into(),
+        OperationValue::Bytes(value) => {
+            let hex_string = hex::encode(value);
+            hex_string.into()
+        }
         _ => panic!("This method is not used for relation types"),
     }
 }
@@ -93,6 +96,11 @@ pub fn filter_to_operation_value(
         FieldType::Integer => filter_value.i64()?.into(),
         FieldType::Float => filter_value.f64()?.into(),
         FieldType::String => filter_value.string()?.into(),
+        FieldType::Bytes => {
+            let hex_string = filter_value.string()?;
+            let bytes = hex::decode(hex_string)?;
+            bytes[..].into()
+        }
         // We are only ever dealing with list items here
         FieldType::Relation(_) | FieldType::RelationList(_) => {
             DocumentId::new(&filter_value.string()?.parse()?).into()
@@ -100,11 +108,6 @@ pub fn filter_to_operation_value(
         FieldType::PinnedRelation(_) | FieldType::PinnedRelationList(_) => {
             let document_view_id: DocumentViewId = filter_value.string()?.parse()?;
             document_view_id.into()
-        }
-        FieldType::Bytes => {
-            let hex_string = filter_value.string()?;
-            let bytes = hex::decode(hex_string)?;
-            bytes[..].into()
         }
     };
 

--- a/aquadoggo/src/proptests/document_strategies.rs
+++ b/aquadoggo/src/proptests/document_strategies.rs
@@ -44,6 +44,9 @@ pub enum FieldValue {
     /// String value.
     String(String),
 
+    /// Hex encoded bytes value.
+    Bytes(Vec<u8>),
+
     /// Reference to a document.
     Relation(DocumentAST),
 
@@ -111,6 +114,15 @@ fn values_from_schema(schema: SchemaAST) -> impl Strategy<Value = Vec<DocumentFi
             SchemaFieldType::String => any::<String>()
                 .prop_map(move |value| {
                     let value = FieldValue::String(value);
+                    DocumentFieldValue {
+                        name: field_name.clone(),
+                        value,
+                    }
+                })
+                .boxed(),
+            SchemaFieldType::Bytes => any::<Vec<u8>>()
+                .prop_map(move |value| {
+                    let value = FieldValue::Bytes(value);
                     DocumentFieldValue {
                         name: field_name.clone(),
                         value,

--- a/aquadoggo/src/proptests/filter_strategies.rs
+++ b/aquadoggo/src/proptests/filter_strategies.rs
@@ -8,7 +8,7 @@ use proptest::strategy::{BoxedStrategy, Just, Strategy};
 use proptest_derive::Arbitrary;
 
 use crate::proptests::schema_strategies::{SchemaField, SchemaFieldType};
-use crate::proptests::utils::FieldName;
+use crate::proptests::utils::{FieldName, HexString};
 
 /// Possible values used in filter arguments. `UniqueIdentifier` is a placeholder for values which
 /// can be derived at runtime in order to use identifiers which exist in on the node, these include
@@ -17,6 +17,7 @@ use crate::proptests::utils::FieldName;
 pub enum FilterValue {
     Boolean(bool),
     String(String),
+    Bytes(HexString),
     Integer(i64),
     Float(f64),
     UniqueIdentifier, // This is a placeholder for a document id, document view id or public key which is selected at testing time
@@ -87,6 +88,7 @@ fn application_field_filter_strategy(
         | SchemaFieldType::Integer
         | SchemaFieldType::Float
         | SchemaFieldType::String
+        | SchemaFieldType::Bytes
         | SchemaFieldType::Relation
         | SchemaFieldType::PinnedRelation => generate_simple_field_filter(field.clone())
             .prop_map(|(name, filter)| ((name, filter), Vec::new()))
@@ -218,6 +220,24 @@ fn generate_simple_field_filter(field: SchemaField) -> BoxedStrategy<(FieldName,
                     .prop_map(|(name, value)| (name, Filter::LessThan(value))),
                 value_and_name_strategy
                     .prop_map(|(name, value)| (name, Filter::LessThanOrEqual(value))),
+            ]
+            .boxed()
+        }
+        SchemaFieldType::Bytes => {
+            let field_clone = field.clone();
+            prop_oneof![
+                any::<HexString>()
+                    .prop_map(FilterValue::Bytes)
+                    .prop_map(move |value| (
+                        field.name.clone(),
+                        Filter::Equal(value)
+                    )),
+                any::<HexString>()
+                    .prop_map(FilterValue::Bytes)
+                    .prop_map(move |value| (
+                        field_clone.name.clone(),
+                        Filter::NotEqual(value)
+                    ))
             ]
             .boxed()
         }

--- a/aquadoggo/src/proptests/filter_strategies.rs
+++ b/aquadoggo/src/proptests/filter_strategies.rs
@@ -228,16 +228,10 @@ fn generate_simple_field_filter(field: SchemaField) -> BoxedStrategy<(FieldName,
             prop_oneof![
                 any::<HexString>()
                     .prop_map(FilterValue::Bytes)
-                    .prop_map(move |value| (
-                        field.name.clone(),
-                        Filter::Equal(value)
-                    )),
+                    .prop_map(move |value| (field.name.clone(), Filter::Equal(value))),
                 any::<HexString>()
                     .prop_map(FilterValue::Bytes)
-                    .prop_map(move |value| (
-                        field_clone.name.clone(),
-                        Filter::NotEqual(value)
-                    ))
+                    .prop_map(move |value| (field_clone.name.clone(), Filter::NotEqual(value)))
             ]
             .boxed()
         }

--- a/aquadoggo/src/proptests/schema_strategies.rs
+++ b/aquadoggo/src/proptests/schema_strategies.rs
@@ -64,6 +64,7 @@ pub enum SchemaFieldType {
     Integer,
     Float,
     String,
+    Bytes,
     Relation,
     RelationList,
     PinnedRelation,
@@ -104,6 +105,13 @@ fn schema_field() -> impl Strategy<Value = SchemaField> {
             SchemaField {
                 name: field_name,
                 field_type: SchemaFieldType::String,
+                relation_schema: None,
+            }
+        }),
+        any::<FieldName>().prop_map(|field_name| {
+            SchemaField {
+                name: field_name,
+                field_type: SchemaFieldType::Bytes,
                 relation_schema: None,
             }
         }),

--- a/aquadoggo/src/proptests/tests.rs
+++ b/aquadoggo/src/proptests/tests.rs
@@ -188,7 +188,8 @@ prop_compose! {
 proptest! {
     #![proptest_config(Config {
         cases: 100,
-        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("regressions"))),
+        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("query-regressions"))),
+        max_shrink_iters: 1000,
         .. Config::default()
     })]
     #[test]
@@ -227,7 +228,15 @@ proptest! {
             };
         });
     }
+}
 
+proptest! {
+    #![proptest_config(Config {
+        cases: 100,
+        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("filtering-regressions"))),
+        max_shrink_iters: 100,
+        .. Config::default()
+    })]
     #[test]
     /// Test passing different combinations of filter arguments to the root collection query and
     /// also to fields which contain relation lists. Filter arguments are generated randomly via

--- a/aquadoggo/src/proptests/tests.rs
+++ b/aquadoggo/src/proptests/tests.rs
@@ -187,9 +187,7 @@ prop_compose! {
 
 proptest! {
     #![proptest_config(Config {
-        cases: 100,
-        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("query-regressions"))),
-        max_shrink_iters: 1000,
+        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("regressions"))),
         .. Config::default()
     })]
     #[test]
@@ -228,15 +226,7 @@ proptest! {
             };
         });
     }
-}
 
-proptest! {
-    #![proptest_config(Config {
-        cases: 100,
-        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("filtering-regressions"))),
-        max_shrink_iters: 100,
-        .. Config::default()
-    })]
     #[test]
     /// Test passing different combinations of filter arguments to the root collection query and
     /// also to fields which contain relation lists. Filter arguments are generated randomly via

--- a/aquadoggo/src/proptests/utils.rs
+++ b/aquadoggo/src/proptests/utils.rs
@@ -19,7 +19,7 @@ use super::filter_strategies::{Filter, FilterValue};
 #[derive(Arbitrary, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FieldName(#[proptest(regex = "[A-Za-z]{1}[A-Za-z0-9_]{0,63}")] pub String);
 
-/// A fieldname which will follow the expected regex rules.
+/// A hexadecimal string.
 #[derive(Arbitrary, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HexString(#[proptest(regex = "([a-fA-F0-9]{2}){0,64}")] pub String);
 

--- a/aquadoggo/src/proptests/utils.rs
+++ b/aquadoggo/src/proptests/utils.rs
@@ -257,7 +257,7 @@ pub fn parse_filter(filter_args: &mut Vec<String>, name: &FieldName, filter: &Fi
                 filter_args.push(format!("{name}: {{ eq: {} }}", escape_string_value(value)))
             }
             FilterValue::Bytes(value) => {
-                filter_args.push(format!("{name}: {{ eq: {} }}", value.0))
+                filter_args.push(format!("{name}: {{ eq: \"{}\" }}", value.0))
             }
             FilterValue::Integer(value) => filter_args.push(format!("{name}: {{ eq: {value} }}")),
             FilterValue::Float(value) => filter_args.push(format!("{name}: {{ eq: {value} }}")),
@@ -274,7 +274,7 @@ pub fn parse_filter(filter_args: &mut Vec<String>, name: &FieldName, filter: &Fi
                 escape_string_value(value)
             )),
             FilterValue::Bytes(value) => {
-                filter_args.push(format!("{name}: {{ notEq: {} }}", value.0))
+                filter_args.push(format!("{name}: {{ notEq: \"{}\" }}", value.0))
             }
             FilterValue::Integer(value) => {
                 filter_args.push(format!("{name}: {{ notEq: {value} }}"))

--- a/aquadoggo/src/test_utils/helpers.rs
+++ b/aquadoggo/src/test_utils/helpers.rs
@@ -36,6 +36,7 @@ pub fn doggo_schema() -> Schema {
 pub fn doggo_fields() -> Vec<(&'static str, OperationValue)> {
     vec![
         ("username", OperationValue::String("bubu".to_owned())),
+        ("data", OperationValue::Bytes(vec![0, 1, 2, 3])),
         ("height", OperationValue::Float(3.5)),
         ("age", OperationValue::Integer(28)),
         ("is_admin", OperationValue::Boolean(false)),

--- a/aquadoggo/src/test_utils/node.rs
+++ b/aquadoggo/src/test_utils/node.rs
@@ -346,14 +346,10 @@ pub async fn add_blob_pieces(
 
     let mut blob_pieces_view_ids = Vec::with_capacity(blob_pieces.len());
     for piece in blob_pieces {
-        // @TODO: No need to convert bytes into a string when we introduced our new bytes operation
-        // field type. Related issue: https://github.com/p2panda/aquadoggo/issues/543
-        let byte_str = std::str::from_utf8(piece).expect("Invalid UTF-8 sequence");
-
         let view_id = add_document(
             node,
             &SchemaId::BlobPiece(1),
-            vec![("data", byte_str.into())],
+            vec![("data", piece.into())],
             &key_pair,
         )
         .await;

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -29,7 +29,7 @@ figment = { version = "0.10.10", features = ["toml", "env"] }
 hex = "0.4.3"
 libp2p = "0.52.0"
 log = "0.4.20"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "219f03f3e6f5abb54570bf8b4452290252804f9f" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "7187f9f2396c73c1bad9736ada4d9ae097deb785" }
 path-clean = "1.0.1"
 serde = { version = "1.0.185", features = ["serde_derive"] }
 tempfile = "3.7.0"

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -29,7 +29,7 @@ figment = { version = "0.10.10", features = ["toml", "env"] }
 hex = "0.4.3"
 libp2p = "0.52.0"
 log = "0.4.20"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "8377056617b64e898e9980e8ad84d258ca0442a1" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "219f03f3e6f5abb54570bf8b4452290252804f9f" }
 path-clean = "1.0.1"
 serde = { version = "1.0.185", features = ["serde_derive"] }
 tempfile = "3.7.0"

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -29,7 +29,7 @@ figment = { version = "0.10.10", features = ["toml", "env"] }
 hex = "0.4.3"
 libp2p = "0.52.0"
 log = "0.4.20"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "7187f9f2396c73c1bad9736ada4d9ae097deb785" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "be84d7c4e39c1b67125d80468ccf412cf25ae1d7" }
 path-clean = "1.0.1"
 serde = { version = "1.0.185", features = ["serde_derive"] }
 tempfile = "3.7.0"

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -97,9 +97,11 @@ fn show_warnings(config: &Configuration, is_temporary_blobs_path: bool) {
     }
 
     if config.database_url != "sqlite::memory:" && is_temporary_blobs_path {
-        warn!("Your database is persisted but blobs _are not_ which might result in unrecoverable
+        warn!(
+            "Your database is persisted but blobs _are not_ which might result in unrecoverable
         data inconsistency (blob operations are stored but the files themselves are _not_). It is
         recommended to either set both values (`database_url` and `blobs_base_path`) to an
-        temporary value or set both to persist all data.");
+        temporary value or set both to persist all data."
+        );
     }
 }


### PR DESCRIPTION
_rebased from https://github.com/p2panda/aquadoggo/pull/552_

- store `Bytes` in the database as a hexadecimal string still in the `operation_field_v1` "value" column
  - we considered moving it to a new "bytes_value" field and storing as a `BLOB` but this would break compatibility with Postgres and in any case we are likely to stream the bytes directly to and from the filesystem in a later optimisation 
- in the `GraphQL` api bytes are represented by `HexBytesScalar`

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
