### PR TITLE
Do not panic when blob does not have all pieces yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make sure temporary directory does not run out of scope [#557](https://github.com/p2panda/aquadoggo/pull/557)
 - Deduplicate generated schema field by key in proptests [#558](https://github.com/p2panda/aquadoggo/pull/558)
+- Do not panic when blob does not have all pieces yet [#563](https://github.com/p2panda/aquadoggo/pull/563)
 
 ## [0.5.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,7 +3118,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.1"
-source = "git+https://github.com/p2panda/p2panda?rev=3ee5b0e543ccb24d548e70143b3adf6f1d5e4d01#3ee5b0e543ccb24d548e70143b3adf6f1d5e4d01"
+source = "git+https://github.com/p2panda/p2panda?rev=c0b382c9b31425748bba7c150ec9ad7a784d000c#c0b382c9b31425748bba7c150ec9ad7a784d000c"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -57,7 +57,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "3ee5b0e543ccb24d548e70143b3adf6f1d5e4d01", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "c0b382c9b31425748bba7c150ec9ad7a784d000c", features = [
     "storage-provider",
 ] }
 rand = "0.8.5"
@@ -98,7 +98,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "3ee5b0e543ccb24d548e70143b3adf6f1d5e4d01", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "c0b382c9b31425748bba7c150ec9ad7a784d000c", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/src/db/errors.rs
+++ b/aquadoggo/src/db/errors.rs
@@ -53,11 +53,7 @@ pub enum BlobStoreError {
     #[error("Missing \"pieces\" field on blob document")]
     NotBlobDocument,
 
-    /// Error when no pieces found for existing blob document.
-    #[error("No pieces found for the requested blob")]
-    NoBlobPiecesFound,
-
-    /// Error when some pieces not found for existing blob document.
+    /// Error when some or all pieces not found for existing blob document.
     #[error("Some pieces missing for the requested blob")]
     MissingPieces,
 

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -48,7 +48,8 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
             Ok(vec![document])
         }
 
-        // This task is about an updated blob piece document that may be used in one or more blob documents.
+        // This task is about an updated blob piece document that may be used in one or more blob
+        // documents.
         SchemaId::BlobPiece(_) => get_related_blobs(&input_view_id, &context).await,
         _ => Err(TaskError::Critical(format!(
             "Unknown system schema id: {}",
@@ -108,7 +109,7 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
                 Err(err) => Err(anyhow!(err)),
             }
             .map_err(|err| {
-                TaskError::Critical(format!(
+                TaskError::Failure(format!(
                     "Could not write blob file @ {}: {}",
                     blob_view_path.display(),
                     err

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -72,7 +72,7 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
             .get_blob_by_view_id(blob_document.view_id())
             .await
             // We don't raise a critical error here, as it is possible that this method returns an
-            // error
+            // error, for example when not all blob pieces are available yet for materialisation
             .map_err(|err| TaskError::Failure(err.to_string()))?
             .expect("Blob data exists at this point");
 

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -29,7 +29,7 @@ figment = { version = "0.10.10", features = ["toml", "env"] }
 hex = "0.4.3"
 libp2p = "0.52.0"
 log = "0.4.20"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "3ee5b0e543ccb24d548e70143b3adf6f1d5e4d01" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "c0b382c9b31425748bba7c150ec9ad7a784d000c" }
 path-clean = "1.0.1"
 serde = { version = "1.0.185", features = ["serde_derive"] }
 tempfile = "3.7.0"


### PR DESCRIPTION
This PR fixes a race condition where nodes would sometimes crash when they attempted to materialise a blob where not all pieces are in the database yet (for example during replication). This was solved by:

1. Not failing critically on this error
2. Moving the check if all pieces are given right at the beginning of the method

Closes #562 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
