### PR TITLE
Garbage collect blobs from file system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce `BlobStore` [#484](https://github.com/p2panda/aquadoggo/pull/484)
 - Task for automatic garbage collection of unused documents and views [#500](https://github.com/p2panda/aquadoggo/pull/500)
 - Blobs directory configuration [#549](https://github.com/p2panda/aquadoggo/pull/549)
-- Integrate `Bytes` operation value [554](https://github.com/p2panda/aquadoggo/pull/554/)
+- Integrate `Bytes` operation value [#554](https://github.com/p2panda/aquadoggo/pull/554/)
 - Implement dependency replication for `blob_v1` and `blob_piece_v1` documents [#514](https://github.com/p2panda/aquadoggo/pull/514)
+- Remove deleted/unused blobs from the file system [#571](https://github.com/p2panda/aquadoggo/pull/571)
 
 ### Changed
 

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -401,6 +401,7 @@ impl SqlStore {
         &self,
         document_view_id: &DocumentViewId,
     ) -> Result<Vec<DocumentId>, DocumentStorageError> {
+        // Collect all ids or view ids of children related to from the passed document view.
         let children_ids: Vec<String> = query_scalar(
             "
             SELECT
@@ -440,6 +441,7 @@ impl SqlStore {
             .collect::<Vec<String>>()
             .join(",");
 
+        // Query for any document included in the list of children.
         let document_ids: Vec<String> = query_scalar(&format!(
             "
             SELECT DISTINCT

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -429,6 +429,11 @@ impl SqlStore {
         .await
         .map_err(|err| DocumentStorageError::FatalStorageError(err.to_string()))?;
 
+        // If no children were found return now already with an empty vec.
+        if children_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
         let args = children_ids
             .iter()
             .map(|id| format!("'{id}'"))

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -379,6 +379,8 @@ impl SqlStore {
                 document_views
             WHERE
                 document_views.document_id = $1
+            ORDER BY
+                document_views.document_id
             ",
         )
         .bind(document_id.as_str())
@@ -422,7 +424,7 @@ impl SqlStore {
                     'relation_list'
                 )
             AND
-                document_view_fields.document_view_id = $1;
+                document_view_fields.document_view_id = $1
         ",
         )
         .bind(document_view_id.to_string())
@@ -452,6 +454,8 @@ impl SqlStore {
                 document_views.document_view_id IN ({})
             OR
                 document_views.document_id IN ({})
+            ORDER BY
+                document_views.document_id ASC
             ",
             args, args
         ))

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -503,8 +503,12 @@ impl SqlStore {
     ) -> Result<bool, DocumentStorageError> {
         let document_view_id: Option<String> = query_scalar(
             "
-            SELECT documents.document_view_id FROM documents
-            WHERE documents.document_view_id = $1
+            SELECT 
+                documents.document_view_id 
+            FROM 
+                documents
+            WHERE 
+                documents.document_view_id = $1
             ",
         )
         .bind(document_view_id.to_string())

--- a/aquadoggo/src/materializer/tasks/garbage_collection.rs
+++ b/aquadoggo/src/materializer/tasks/garbage_collection.rs
@@ -92,7 +92,7 @@ pub async fn garbage_collection_task(context: Context, input: TaskInput) -> Task
                 if let SchemaId::Blob(_) = operation.schema_id() {
                     // Purge the blob and all its pieces. This only succeeds if no document refers
                     // to the blob document by either a relation or pinned relation.
-                    context
+                    let _result = context
                         .store
                         .purge_blob(&document_id)
                         .await

--- a/aquadoggo/src/materializer/tasks/garbage_collection.rs
+++ b/aquadoggo/src/materializer/tasks/garbage_collection.rs
@@ -140,7 +140,8 @@ pub async fn garbage_collection_task(context: Context, input: TaskInput) -> Task
                 for view_id in deleted_views {
                     // Delete this blob view from the filesystem also.
                     let blob_view_path = context.config.blobs_base_path.join(view_id.to_string());
-                    remove_file(blob_view_path.clone()).await
+                    remove_file(blob_view_path.clone())
+                        .await
                         .map_err(|err| TaskError::Critical(err.to_string()))?;
                     debug!("Deleted blob view from filesystem: {}", view_id);
                 }

--- a/aquadoggo/src/materializer/tasks/garbage_collection.rs
+++ b/aquadoggo/src/materializer/tasks/garbage_collection.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::fs::remove_file;
+use tokio::fs::remove_file;
 
 use log::debug;
 use p2panda_rs::document::DocumentViewId;
@@ -140,7 +140,7 @@ pub async fn garbage_collection_task(context: Context, input: TaskInput) -> Task
                 for view_id in deleted_views {
                     // Delete this blob view from the filesystem also.
                     let blob_view_path = context.config.blobs_base_path.join(view_id.to_string());
-                    remove_file(blob_view_path.clone())
+                    remove_file(blob_view_path.clone()).await
                         .map_err(|err| TaskError::Critical(err.to_string()))?;
                     debug!("Deleted blob view from filesystem: {}", view_id);
                 }

--- a/aquadoggo/src/materializer/tasks/garbage_collection.rs
+++ b/aquadoggo/src/materializer/tasks/garbage_collection.rs
@@ -193,7 +193,7 @@ mod tests {
     fn e2e_pruning(key_pair: KeyPair) {
         test_runner(|mut node: TestNode| async move {
             // Publish some documents which we will later point relations at.
-            let (child_schema, child_document_view_ids) = add_schema_and_documents(
+            let (child_schema, mut child_document_view_ids) = add_schema_and_documents(
                 &mut node,
                 "schema_for_child",
                 vec![
@@ -203,6 +203,8 @@ mod tests {
                 &key_pair,
             )
             .await;
+
+            child_document_view_ids.sort();
 
             // Create some parent documents which contain a pinned relation list pointing to the
             // children created above.

--- a/aquadoggo/src/materializer/tasks/garbage_collection.rs
+++ b/aquadoggo/src/materializer/tasks/garbage_collection.rs
@@ -350,7 +350,6 @@ mod tests {
                 next_tasks,
                 child_document_view_ids
                     .iter()
-                    .rev()
                     .map(|document_view_id| {
                         let document_id: DocumentId = document_view_id.to_string().parse().unwrap();
                         Task::new("garbage_collection", TaskInput::DocumentId(document_id))

--- a/aquadoggo/src/materializer/tasks/reduce.rs
+++ b/aquadoggo/src/materializer/tasks/reduce.rs
@@ -254,7 +254,7 @@ async fn reduce_document<O: AsOperation + WithId<OperationId> + WithPublicKey>(
 
             if document.is_deleted() || document.is_edited() {
                 debug!(
-                    "Dispatch prune task for document with id: {}",
+                    "Dispatch garbage collection task for document with id: {}",
                     document.id()
                 );
 

--- a/aquadoggo/src/test_utils/mod.rs
+++ b/aquadoggo/src/test_utils/mod.rs
@@ -12,7 +12,7 @@ pub use config::TestConfiguration;
 pub use db::{drop_database, initialize_db, initialize_sqlite_db};
 pub use helpers::{doggo_fields, doggo_schema, generate_key_pairs, schema_from_fields};
 pub use node::{
-    add_blob, add_document, add_schema, add_schema_and_documents, assert_query,
+    add_blob, add_document, add_schema, add_schema_and_documents, assert_query, delete_document,
     populate_and_materialize, populate_store, populate_store_config, update_blob, update_document,
     PopulateStoreConfig, TestNode,
 };


### PR DESCRIPTION
We already garbage collect unused blob views from the database, this PR implements garbage collecting blob views from the file system as well. This occurs both when a blob view is not the current view or pinned from another document, and for the current view as well when the blob document itself is not related to by any other document.

During implementation I did a little general renaming/refactoring in the garbage collection task to help code comprehension. 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
