### PR TITLE
Use `SocketAddr` for all addresses in network config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updates for new hash serialization in p2panda-rs [#569](https://github.com/p2panda/aquadoggo/pull/569)
 - Use `libp2p` `0.5.3` [#570](https://github.com/p2panda/aquadoggo/pull/570)
 - Optimize test data generation methods [#572](https://github.com/p2panda/aquadoggo/pull/572)
+- Use `SocketAddr` in network config instead of `MultiAddr` [#576](https://github.com/p2panda/aquadoggo/pull/576)
 
 ## Fixed
 

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use libp2p::Multiaddr;
-use libp2p::{connection_limits::ConnectionLimits, PeerId};
+use std::net::SocketAddr;
+
+use libp2p::connection_limits::ConnectionLimits;
+use libp2p::PeerId;
 
 use crate::AllowList;
 
@@ -23,7 +25,7 @@ pub struct NetworkConfiguration {
     /// with a static IP Address). If you need to connect to nodes with changing, dynamic IP
     /// addresses or even with nodes behind a firewall or NAT, do not use this field but use at
     /// least one relay.
-    pub direct_node_addresses: Vec<Multiaddr>,
+    pub direct_node_addresses: Vec<SocketAddr>,
 
     /// List of peers which are allowed to connect to your node.
     ///
@@ -62,7 +64,7 @@ pub struct NetworkConfiguration {
     /// WARNING: This will potentially expose your IP address on the network. Do only connect to
     /// trusted relays or make sure your IP address is hidden via a VPN or proxy if you're
     /// concerned about leaking your IP.
-    pub relay_addresses: Vec<Multiaddr>,
+    pub relay_addresses: Vec<SocketAddr>,
 
     /// Enable if node should also function as a relay.
     ///

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -161,7 +161,7 @@ pub async fn network_service(
 
     // Dial all nodes we want to directly connect to.
     for direct_node_address in &network_config.direct_node_addresses {
-        let address = utils::to_multiaddress(&direct_node_address);
+        let address = utils::to_multiaddress(direct_node_address);
         info!("Connecting to node @ {}", address);
 
         let opts = DialOpts::unknown_peer_id().address(address.clone()).build();

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -93,16 +93,15 @@ pub async fn network_service(
         // replication sessions, which could leave the node in a strange state.
         swarm.behaviour_mut().peers.disable();
 
-        for mut relay_address in network_config.relay_addresses.clone() {
-            if let Some(address) = utils::to_quic_address(&relay_address) {
-                info!("Connecting to relay node {}", address);
-            }
+        for relay_address in network_config.relay_addresses.clone() {
+            let mut address = utils::to_multiaddress(&relay_address);
+            info!("Connecting to relay node {}", address);
 
             // Attempt to connect to the relay node, we give this a 5 second timeout so as not to
             // get stuck if one relay is unreachable.
             if let Ok(result) = tokio::time::timeout(
                 RELAY_CONNECT_TIMEOUT,
-                connect_to_relay(&mut swarm, &mut relay_address),
+                connect_to_relay(&mut swarm, &mut address),
             )
             .await
             {
@@ -162,13 +161,10 @@ pub async fn network_service(
 
     // Dial all nodes we want to directly connect to.
     for direct_node_address in &network_config.direct_node_addresses {
-        if let Some(address) = utils::to_quic_address(direct_node_address) {
-            info!("Connecting to node @ {}", address);
-        }
+        let address = utils::to_multiaddress(&direct_node_address);
+        info!("Connecting to node @ {}", address);
 
-        let opts = DialOpts::unknown_peer_id()
-            .address(direct_node_address.clone())
-            .build();
+        let opts = DialOpts::unknown_peer_id().address(address.clone()).build();
 
         match swarm.dial(opts) {
             Ok(_) => (),

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
+use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
 use regex::Regex;
 
@@ -21,4 +22,14 @@ pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
             Some(socket)
         }
     }
+}
+
+pub fn to_multiaddress(socket_address: &SocketAddr) -> Multiaddr {
+    let mut multiaddr = match socket_address.ip() {
+        IpAddr::V4(ip) => Multiaddr::from(Protocol::Ip4(ip)),
+        IpAddr::V6(ip) => Multiaddr::from(Protocol::Ip6(ip)),
+    };
+    multiaddr.push(Protocol::Udp(socket_address.port()));
+    multiaddr.push(Protocol::QuicV1);
+    multiaddr
 }

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::convert::TryFrom;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::OnceLock;
@@ -13,8 +13,7 @@ use colored::Colorize;
 use directories::ProjectDirs;
 use figment::providers::{Env, Format, Serialized, Toml};
 use figment::Figment;
-use libp2p::multiaddr::Protocol;
-use libp2p::{Multiaddr, PeerId};
+use libp2p::PeerId;
 use p2panda_rs::schema::SchemaId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tempfile::TempDir;
@@ -377,33 +376,15 @@ impl TryFrom<Configuration> for NodeConfiguration {
             network: NetworkConfiguration {
                 quic_port: value.quic_port,
                 mdns: value.mdns,
-                direct_node_addresses: value
-                    .direct_node_addresses
-                    .into_iter()
-                    .map(to_multiaddress)
-                    .collect(),
+                direct_node_addresses: value.direct_node_addresses,
                 allow_peer_ids,
                 block_peer_ids: value.block_peer_ids,
-                relay_addresses: value
-                    .relay_addresses
-                    .into_iter()
-                    .map(to_multiaddress)
-                    .collect(),
+                relay_addresses: value.relay_addresses,
                 relay_mode: value.relay_mode,
                 ..Default::default()
             },
         })
     }
-}
-
-fn to_multiaddress(socket_address: SocketAddr) -> Multiaddr {
-    let mut multiaddr = match socket_address.ip() {
-        IpAddr::V4(ip) => Multiaddr::from(Protocol::Ip4(ip)),
-        IpAddr::V6(ip) => Multiaddr::from(Protocol::Ip6(ip)),
-    };
-    multiaddr.push(Protocol::Udp(socket_address.port()));
-    multiaddr.push(Protocol::QuicV1);
-    multiaddr
 }
 
 fn try_determine_config_file_path() -> Option<PathBuf> {


### PR DESCRIPTION
Use `SocketAddr` everywhere in network config rather than `MultiAddr`.

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
