### PR TITLE
Reduce when `blob` task is issued and check for duplicate work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make sure temporary directory does not run out of scope [#557](https://github.com/p2panda/aquadoggo/pull/557)
 - Deduplicate generated schema field by key in proptests [#558](https://github.com/p2panda/aquadoggo/pull/558)
 - Do not panic when blob does not have all pieces yet [#563](https://github.com/p2panda/aquadoggo/pull/563)
+- Fix `blob` tasks being triggered too often [#578](https://github.com/p2panda/aquadoggo/pull/578)
 
 ## [0.5.0]
 

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -14,7 +14,7 @@ use crate::materializer::TaskInput;
 
 /// A blob task assembles and persists blobs to the filesystem.
 ///
-/// Blob tasks are dispatched whenever a blob document has it's dependencies (pieces) available in
+/// Blob tasks are dispatched whenever a blob document has its dependencies (pieces) available in
 /// the store.
 pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInput> {
     debug!("Working on {}", input);
@@ -32,7 +32,7 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
 
     match blob_document {
         Some(blob_document) => {
-            // This document should be a blob document, if it isn't critically fail the task now.
+            // This document should be a blob document. If it isn't, critically fail the task now
             if !matches!(blob_document.schema_id(), SchemaId::Blob(_)) {
                 return Err(TaskError::Critical(format!(
                     "Unexpected system schema id: {}",

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -3,8 +3,6 @@
 use futures::{pin_mut, StreamExt};
 use log::{debug, info};
 use p2panda_rs::document::traits::AsDocument;
-use p2panda_rs::document::DocumentViewId;
-use p2panda_rs::operation::OperationValue;
 use p2panda_rs::schema::SchemaId;
 use p2panda_rs::storage_provider::traits::DocumentStore;
 use tokio::fs::OpenOptions;
@@ -17,8 +15,8 @@ use crate::materializer::TaskInput;
 
 /// A blob task assembles and persists blobs to the filesystem.
 ///
-/// Blob tasks are dispatched whenever a blob or blob piece document has all its immediate
-/// dependencies available in the store.
+/// Blob tasks are dispatched whenever a blob document has it's dependencies (pieces) available in
+/// the store.
 pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInput> {
     debug!("Working on {}", input);
 
@@ -35,131 +33,83 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
         .map_err(|err| TaskError::Critical(err.to_string()))?
         .unwrap();
 
-    let updated_blobs: Vec<StorageDocument> = match schema {
-        // This task is about an updated blob document so we only handle that.
-        SchemaId::Blob(_) => {
-            let document = context
-                .store
-                .get_document_by_view_id(&input_view_id)
-                .await
-                .map_err(|err| TaskError::Failure(err.to_string()))?
-                .unwrap();
-            Ok(vec![document])
-        }
-
-        // This task is about an updated blob piece document that may be used in one or more blob
-        // documents.
-        SchemaId::BlobPiece(_) => get_related_blobs(&input_view_id, &context).await,
-        _ => Err(TaskError::Critical(format!(
-            "Unknown system schema id: {}",
-            schema
-        ))),
-    }?;
-
-    // The related blobs are not known yet to this node so we mark this task failed.
-    if updated_blobs.is_empty() {
-        return Err(TaskError::Failure(
-            "Related blob does not exist (yet)".into(),
-        ));
-    }
-
-    // Materialize all updated blobs to the filesystem.
-    for blob_document in updated_blobs.iter() {
-        // Get a stream of raw blob data
-        let mut blob_stream = context
+    let blob_document: Option<StorageDocument> = match schema {
+        // Check the schema is correct and retrieve the blob document.
+        SchemaId::Blob(_) => context
             .store
-            .get_blob_by_view_id(blob_document.view_id())
+            .get_document_by_view_id(&input_view_id)
             .await
-            // We don't raise a critical error here, as it is possible that this method returns an
-            // error, for example when not all blob pieces are available yet for materialisation
-            .map_err(|err| TaskError::Failure(err.to_string()))?
-            .expect("Blob data exists at this point");
+            .map_err(|err| TaskError::Failure(err.to_string()))?,
+        _ => {
+            return Err(TaskError::Critical(format!(
+                "Unexpected system schema id: {}",
+                schema
+            )))
+        }
+    };
 
-        // Determine a path for this blob file on the file system
-        let blob_view_path = context
-            .config
-            .blobs_base_path
-            .join(blob_document.view_id().to_string());
+    match blob_document {
+        Some(blob_document) => {
+            // Get a stream of raw blob data
+            let mut blob_stream = context
+                .store
+                .get_blob_by_view_id(blob_document.view_id())
+                .await
+                // We don't raise a critical error here, as it is possible that this method returns an
+                // error, for example when not all blob pieces are available yet for materialisation
+                .map_err(|err| TaskError::Failure(err.to_string()))?
+                .expect("Blob data exists at this point");
 
-        // Write the blob to the filesystem
-        info!("Creating blob at path {}", blob_view_path.display());
+            // Determine a path for this blob file on the file system
+            let blob_view_path = context
+                .config
+                .blobs_base_path
+                .join(blob_document.view_id().to_string());
 
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(&blob_view_path)
-            .await
-            .map_err(|err| {
-                TaskError::Critical(format!(
-                    "Could not create blob file @ {}: {}",
-                    blob_view_path.display(),
-                    err
-                ))
-            })?;
+            // Write the blob to the filesystem
+            info!("Creating blob at path {}", blob_view_path.display());
 
-        // Read from the stream, chunk by chunk, and write every part to the file. This should put
-        // less pressure on our systems memory and allow writing large blob files
-        let stream = blob_stream.read_all();
-        pin_mut!(stream);
-
-        while let Some(value) = stream.next().await {
-            match value {
-                Ok(buf) => file.write(&buf).await.map_err(|err| {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .open(&blob_view_path)
+                .await
+                .map_err(|err| {
                     TaskError::Critical(format!(
-                        "Error occurred when writing to blob file @ {}: {}",
+                        "Could not create blob file @ {}: {}",
                         blob_view_path.display(),
                         err
                     ))
-                }),
-                Err(err) => Err(TaskError::Failure(format!(
-                    "Blob data is invalid and can not be materialised: {}",
-                    err
-                ))),
-            }?;
+                })?;
+
+            // Read from the stream, chunk by chunk, and write every part to the file. This should put
+            // less pressure on our systems memory and allow writing large blob files
+            let stream = blob_stream.read_all();
+            pin_mut!(stream);
+
+            while let Some(value) = stream.next().await {
+                match value {
+                    Ok(buf) => file.write(&buf).await.map_err(|err| {
+                        TaskError::Critical(format!(
+                            "Error occurred when writing to blob file @ {}: {}",
+                            blob_view_path.display(),
+                            err
+                        ))
+                    }),
+                    Err(err) => Err(TaskError::Failure(format!(
+                        "Blob data is invalid and can not be materialised: {}",
+                        err
+                    ))),
+                }?;
+            }
+        }
+        // If the blob document did not exist yet in the store we fail this task.
+        None => {
+            return Err(TaskError::Failure("Blob does not exist (yet)".into()));
         }
     }
 
     Ok(None)
-}
-
-/// Retrieve blobs that use the targeted blob piece as one of their fields.
-async fn get_related_blobs(
-    target_blob_piece: &DocumentViewId,
-    context: &Context,
-) -> Result<Vec<StorageDocument>, TaskError> {
-    // Retrieve all blob documents from the store
-    let blobs = context
-        .store
-        .get_documents_by_schema(&SchemaId::Blob(1))
-        .await
-        .map_err(|err| TaskError::Critical(err.to_string()))
-        .unwrap();
-
-    // Collect all blobs that use the targeted blob piece
-    let mut related_blobs = vec![];
-    for blob in blobs {
-        // We can unwrap the value here as all documents returned from the storage method above
-        // have a current view (they are not deleted).
-        let fields_value = blob.get("pieces").unwrap();
-
-        if let OperationValue::PinnedRelationList(fields) = fields_value {
-            if fields
-                .iter()
-                .any(|field_view_id| field_view_id == target_blob_piece)
-            {
-                related_blobs.push(blob)
-            } else {
-                continue;
-            }
-        } else {
-            // It is a critical if there are blobs in the store that don't match the blob schema.
-            Err(TaskError::Critical(
-                "Blob operation does not have a 'pieces' operation field".into(),
-            ))?
-        }
-    }
-
-    Ok(related_blobs)
 }
 
 #[cfg(test)]

--- a/aquadoggo/src/materializer/tasks/dependency.rs
+++ b/aquadoggo/src/materializer/tasks/dependency.rs
@@ -131,9 +131,8 @@ pub async fn dependency_task(context: Context, input: TaskInput) -> TaskResult<T
                     TaskInput::DocumentViewId(document_view.id().clone()),
                 ));
             }
-            // Start `blob` task when a blob or blob_piece view is completed with
-            // dependencies.
-            SchemaId::Blob(_) | SchemaId::BlobPiece(_) => {
+            // Start `blob` task when a blob view is completed with dependencies.
+            SchemaId::Blob(_) => {
                 next_tasks.push(Task::new(
                     "blob",
                     TaskInput::DocumentViewId(document_view.id().clone()),


### PR DESCRIPTION
This PR fixes a couple of logic errors in the issuing of `blob` tasks which meant already materialized blobs were being written to the filesystem multiple times.

- don't dispatch `blob` tasks when a `blob_piece_v1` document being processed in a `dependency` task
- and therefore don't handle `blob_piece_v1` documents in the actual `blob` task
- check if a blob view is already materialized to the file system in case there are other cases causing this to occur

All in all simpler logic :+1: 

I think this may also be an issue in `schema` task. The reason being (actually for both cases, cos I copied the logic from there :rofl: ) that we used to _not_ check and issue tasks for reverse relations, so to account for that we had to handle cases when a "child" of a system schema dependency came in and completed the dependency tree. Now that we _do_ issue check for and issue reverse relation tasks we are in effect handling this case twice, which causes extra work.

closes: #574 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
