### PR TITLE
Use `p2panda-rs` `0.8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `libp2p` `0.5.3` [#570](https://github.com/p2panda/aquadoggo/pull/570)
 - Optimize test data generation methods [#572](https://github.com/p2panda/aquadoggo/pull/572)
 - Use `SocketAddr` in network config instead of `MultiAddr` [#576](https://github.com/p2panda/aquadoggo/pull/576)
+- Use `p2panda-rs` `0.8.0` [#585](https://github.com/p2panda/aquadoggo/pull/585)
 
 ## Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 [[package]]
 name = "p2panda-rs"
 version = "0.7.1"
-source = "git+https://github.com/p2panda/p2panda?rev=06b2fee74b40c779d85a0ef3b37bab8386b164ca#06b2fee74b40c779d85a0ef3b37bab8386b164ca"
+source = "git+https://github.com/p2panda/p2panda?rev=53c9cce6269bae4ba7f414340ee3017fa5311953#53c9cce6269bae4ba7f414340ee3017fa5311953"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,8 +3171,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "p2panda-rs"
-version = "0.7.1"
-source = "git+https://github.com/p2panda/p2panda?rev=53c9cce6269bae4ba7f414340ee3017fa5311953#53c9cce6269bae4ba7f414340ee3017fa5311953"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cacd81a36e7fb04d4b6fcea3023885f65fc9f97cfb1739b7e5c9d1c183a83d44"
 dependencies = [
  "arrayvec 0.5.2",
  "async-trait",

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -58,7 +58,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "06b2fee74b40c779d85a0ef3b37bab8386b164ca", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "53c9cce6269bae4ba7f414340ee3017fa5311953", features = [
     "storage-provider",
 ] }
 rand = "0.8.5"
@@ -99,7 +99,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "06b2fee74b40c779d85a0ef3b37bab8386b164ca", features = [
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "53c9cce6269bae4ba7f414340ee3017fa5311953", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -50,7 +50,7 @@ libp2p = { version = "0.52.3", features = [
     "tokio",
     "yamux",
     "tcp",
-    "quic"
+    "quic",
 ] }
 libp2p-allow-block-list = "0.2.0"
 # libp2p-quic = { version = "0.9.2", features = ["tokio"] }
@@ -58,9 +58,7 @@ lipmaa-link = "0.2.2"
 log = "0.4.19"
 once_cell = "1.18.0"
 openssl-probe = "0.1.5"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "53c9cce6269bae4ba7f414340ee3017fa5311953", features = [
-    "storage-provider",
-] }
+p2panda-rs = { version = "0.8.0", features = ["storage-provider"] }
 rand = "0.8.5"
 regex = "1.9.3"
 serde = { version = "1.0.152", features = ["derive"] }
@@ -99,7 +97,7 @@ http = "0.2.9"
 hyper = "0.14.19"
 libp2p-swarm-test = "0.2.0"
 once_cell = "1.17.0"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "53c9cce6269bae4ba7f414340ee3017fa5311953", features = [
+p2panda-rs = { version = "0.8.0", features = [
     "test-utils",
     "storage-provider",
 ] }

--- a/aquadoggo/src/db/stores/document.rs
+++ b/aquadoggo/src/db/stores/document.rs
@@ -783,7 +783,6 @@ async fn insert_document(
 #[cfg(test)]
 mod tests {
     use p2panda_rs::api::next_args;
-    use p2panda_rs::document::materialization::build_graph;
     use p2panda_rs::document::traits::AsDocument;
     use p2panda_rs::document::{DocumentBuilder, DocumentId, DocumentViewFields, DocumentViewId};
     use p2panda_rs::entry::{LogId, SeqNum};
@@ -827,7 +826,7 @@ mod tests {
 
             // Build the document from the operations.
             let document_builder = DocumentBuilder::from(&operations);
-            let document = document_builder.build().unwrap();
+            let (document, _) = document_builder.build().unwrap();
 
             // Insert the document into the store
             let result = node.context.store.insert_document(&document).await;
@@ -843,8 +842,8 @@ mod tests {
             .to_owned();
 
             // Build the document with just the first operation.
-            let document_at_view_1 = document_builder
-                .build_to_view_id(Some(create_operation.into()))
+            let (document_at_view_1, _) = document_builder
+                .build_to_view_id(create_operation.into())
                 .unwrap();
 
             // Insert it into the store as well.
@@ -1097,11 +1096,7 @@ mod tests {
                 .await
                 .unwrap();
             let document_builder = DocumentBuilder::from(&operations);
-            let sorted_operations = build_graph(&document_builder.operations())
-                .unwrap()
-                .sort()
-                .unwrap()
-                .sorted();
+            let (_, sorted_operations) = document_builder.build().unwrap();
 
             // We want to test that a document is updated.
             let mut current_operations = Vec::new();
@@ -1112,7 +1107,7 @@ mod tests {
                 current_operations.push(operation.clone());
 
                 // We build each document.
-                let document = DocumentBuilder::new(current_operations.clone())
+                let (document, _) = DocumentBuilder::new(current_operations.clone())
                     .build()
                     .expect("Build document");
 

--- a/aquadoggo/src/db/stores/operation.rs
+++ b/aquadoggo/src/db/stores/operation.rs
@@ -410,7 +410,6 @@ impl From<&DocumentViewFieldRow> for OperationCursor {
 
 #[cfg(test)]
 mod tests {
-    use p2panda_rs::document::materialization::build_graph;
     use p2panda_rs::document::traits::AsDocument;
     use p2panda_rs::document::{DocumentBuilder, DocumentId};
     use p2panda_rs::identity::{KeyPair, PublicKey};
@@ -602,11 +601,17 @@ mod tests {
             assert_eq!(operations_by_document_id.len(), 10);
 
             // The operations should be in their topologically sorted order.
-            let operations = DocumentBuilder::from(&operations_by_document_id).operations();
-            let expected_operation_order =
-                build_graph(&operations).unwrap().sort().unwrap().sorted();
+            let document_builder = DocumentBuilder::from(&operations_by_document_id);
+            let (_, expected_operation_order) = document_builder.build().unwrap();
 
-            assert_eq!(operations, expected_operation_order);
+            assert_eq!(
+                operations_by_document_id.len(),
+                expected_operation_order.len()
+            );
+            for i in 0..operations_by_document_id.len() {
+                let operation_id: &OperationId = operations_by_document_id[i].id();
+                assert_eq!(operation_id, &expected_operation_order[i].0)
+            }
         });
     }
 

--- a/aquadoggo/src/test_utils/node.rs
+++ b/aquadoggo/src/test_utils/node.rs
@@ -563,15 +563,15 @@ pub async fn populate_store(store: &SqlStore, config: &PopulateStoreConfig) -> V
                 // Conditionally create or update the document.
                 if let Some(mut document) = current_document {
                     document
-                        .commit(&published_operation)
+                        .commit(&published_operation.0, &published_operation)
                         .expect("Failed updating document");
                     current_document = Some(document);
                 } else {
-                    current_document = Some(
-                        DocumentBuilder::from(&vec![published_operation])
-                            .build()
-                            .expect("Failed to build document"),
-                    );
+                    let (document, _) = DocumentBuilder::from(&vec![published_operation])
+                        .build()
+                        .expect("Failed to build document");
+
+                    current_document = Some(document);
                 }
 
                 // Set values used in the next iteration.

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -29,7 +29,7 @@ figment = { version = "0.10.10", features = ["toml", "env"] }
 hex = "0.4.3"
 libp2p = "0.52.0"
 log = "0.4.20"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "06b2fee74b40c779d85a0ef3b37bab8386b164ca" }
+p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "53c9cce6269bae4ba7f414340ee3017fa5311953" }
 path-clean = "1.0.1"
 serde = { version = "1.0.185", features = ["serde_derive"] }
 tempfile = "3.7.0"

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -29,7 +29,7 @@ figment = { version = "0.10.10", features = ["toml", "env"] }
 hex = "0.4.3"
 libp2p = "0.52.0"
 log = "0.4.20"
-p2panda-rs = { git = "https://github.com/p2panda/p2panda", rev = "53c9cce6269bae4ba7f414340ee3017fa5311953" }
+p2panda-rs = "0.8.0"
 path-clean = "1.0.1"
 serde = { version = "1.0.185", features = ["serde_derive"] }
 tempfile = "3.7.0"


### PR DESCRIPTION
API updates required for bumping p2panda-rs to version `0.8.0`
 
## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
