### PR TITLE
Use `write_all`  when writing blob data to file system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not panic when blob does not have all pieces yet [#563](https://github.com/p2panda/aquadoggo/pull/563)
 - Fix `blob` tasks being triggered too often [#578](https://github.com/p2panda/aquadoggo/pull/578)
 - Fix `schema` tasks being triggered too often [#581](https://github.com/p2panda/aquadoggo/pull/581)
+- Fix blobs getting corrupted when written to the file system [#587](https://github.com/p2panda/aquadoggo/pull/587)
 
 ## [0.5.0]
 

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -93,7 +93,7 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
 
             while let Some(value) = stream.next().await {
                 match value {
-                    Ok(buf) => file.write(&buf).await.map_err(|err| {
+                    Ok(buf) => file.write_all(&buf).await.map_err(|err| {
                         TaskError::Critical(format!(
                             "Error occurred when writing to blob file @ {}: {}",
                             blob_view_path.display(),
@@ -169,6 +169,46 @@ mod tests {
             .await;
 
             assert!(result.is_err(), "{:?}", result,);
+        })
+    }
+
+    #[rstest]
+    fn materializes_larger_blob_to_filesystem(key_pair: KeyPair) {
+        test_runner(|mut node: TestNode| async move {
+            // Publish blob
+            let length = 10e6 as u32; // 5MB
+            let blob_data: Vec<u8> = (0..length).map(|_| rand::random::<u8>()).collect();
+            let blob_view_id = add_blob(
+                &mut node,
+                &blob_data,
+                256 * 1000,
+                "application/octet-stream",
+                &key_pair,
+            )
+            .await;
+
+            // Run blob task
+            let result = blob_task(
+                node.context.clone(),
+                TaskInput::DocumentViewId(blob_view_id.clone()),
+            )
+            .await;
+
+            // It shouldn't fail
+            assert!(result.is_ok());
+            // It should return no extra tasks
+            assert!(result.unwrap().is_none());
+
+            // Construct the expected path to the blob view file
+            let base_path = &node.context.config.blobs_base_path;
+            let blob_path = base_path.join(blob_view_id.to_string());
+
+            // Read from this file
+            let retrieved_blob_data = fs::read(blob_path).await;
+
+            // Number of bytes for the publish and materialized blob should be the same
+            assert!(retrieved_blob_data.is_ok());
+            assert_eq!(blob_data.len(), retrieved_blob_data.unwrap().len());
         })
     }
 


### PR DESCRIPTION
We should use `write_all` instead of `write` when writing blob data to the filesystem as the latter only represents a "single attempt" to write a buffer to a file, whereas the former "continuously calls [write] until there is no more data to be written"  or an error occurs. In using the later we were sometimes silently failing to write all data to the file system. 

Closes #586 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
