### PR TITLE
Fix pagination bug when only one field is selected and sorted at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `blob` tasks being triggered too often [#578](https://github.com/p2panda/aquadoggo/pull/578)
 - Fix `schema` tasks being triggered too often [#581](https://github.com/p2panda/aquadoggo/pull/581)
 - Fix blobs getting corrupted when written to the file system [#587](https://github.com/p2panda/aquadoggo/pull/587)
+- Fix pagination bug when only one field is selected and sorted at the same time [#593](https://github.com/p2panda/aquadoggo/pull/593)
 
 ## [0.5.0]
 

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -926,8 +926,15 @@ fn order_sql(
                 _ => Some("documents.document_view_id ASC".to_string()),
             }
         } else {
-            // Skip this step when none or only one field was selected for this query to not mess
-            // with the order as soon as there are duplicate ordered fields
+            // Skip this step when only _one_ field was selected for this query to not mess with
+            // pagination.
+            //
+            // We're relying on the "cursor" being the tie-breaker for duplicates. If we would
+            // still order by document view id, this would become undesirably our tie-breaker
+            // instead - as every field is automatically another unique document when only one was
+            // selected hence we will never order by cursor on top of that.
+            //
+            // When no field was selected we just skip this ordering to simplify the query.
             None
         }
     };

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -249,6 +249,7 @@ fn typecast_field_sql(
 }
 
 /// Values to bind to SQL query.
+#[derive(Debug)]
 enum BindArgument {
     String(String),
     Integer(i64),
@@ -864,7 +865,12 @@ async fn where_pagination_sql(
     }
 }
 
-fn order_sql(order: &Order, schema: &Schema, list: Option<&RelationList>) -> String {
+fn order_sql(
+    order: &Order,
+    schema: &Schema,
+    list: Option<&RelationList>,
+    fields: &ApplicationFields,
+) -> String {
     // Create custom ordering if query set one
     let custom = order
         .field
@@ -911,11 +917,19 @@ fn order_sql(order: &Order, schema: &Schema, list: Option<&RelationList>) -> Str
         _ => None,
     };
 
-    // Always order by document view id, except of if it was selected manually. We need this to
-    // assemble the rows to documents correctly at the end
-    let id_sql = match order.field {
-        Some(Field::Meta(MetaField::DocumentViewId)) => None,
-        _ => Some("documents.document_view_id ASC".to_string()),
+    // Order by document view id, except of if it was selected manually. We need this to assemble
+    // the rows to documents correctly at the end
+    let id_sql = {
+        // Skip this step when only one field was selected for this query to not mess with the
+        // order as soon as there are duplicate ordered fields
+        if fields.len() == 1 {
+            None
+        } else {
+            match order.field {
+                Some(Field::Meta(MetaField::DocumentViewId)) => None,
+                _ => Some("documents.document_view_id ASC".to_string()),
+            }
+        }
     };
 
     // On top we sort always by the unique operation cursor in case the previous order value is
@@ -1169,7 +1183,7 @@ impl SqlStore {
         )
         .await?;
 
-        let order = order_sql(&args.order, schema, list);
+        let order = order_sql(&args.order, schema, list, &application_fields);
         let (page_size, limit) = limit_sql(&args.pagination, &application_fields);
 
         let sea_quel = format!(

--- a/aquadoggo/src/db/stores/query.rs
+++ b/aquadoggo/src/db/stores/query.rs
@@ -920,15 +920,15 @@ fn order_sql(
     // Order by document view id, except of if it was selected manually. We need this to assemble
     // the rows to documents correctly at the end
     let id_sql = {
-        // Skip this step when only one field was selected for this query to not mess with the
-        // order as soon as there are duplicate ordered fields
-        if fields.len() == 1 {
-            None
-        } else {
+        if fields.len() > 1 {
             match order.field {
                 Some(Field::Meta(MetaField::DocumentViewId)) => None,
                 _ => Some("documents.document_view_id ASC".to_string()),
             }
+        } else {
+            // Skip this step when none or only one field was selected for this query to not mess
+            // with the order as soon as there are duplicate ordered fields
+            None
         }
     };
 

--- a/aquadoggo/src/graphql/queries/collection.rs
+++ b/aquadoggo/src/graphql/queries/collection.rs
@@ -274,7 +274,7 @@ mod tests {
                 vec![
                     ("font", "comic-sans".into(), None),
                     ("index", 9.into(), None),
-                    ("line", "I wanna be a slave to you all        ".into(), None),
+                    ("line", "I wanna be a slave to you all".into(), None),
                 ],
                 vec![
                     ("font", "comic-sans".into(), None),
@@ -559,7 +559,7 @@ mod tests {
                 "documents": [
                     {
                         "cursor": "27ECgmQpeuQwMKtCZxkbJUtCvkZDLuayQKv9zkV5uKx1xMHBeeSBasdhvoZwcgXLC5mnv7QR9HW11gjhH57D1mjs",
-                        "fields": { 
+                        "fields": {
                             "bool": false,
                             "data": "04050607",
                         },
@@ -571,7 +571,7 @@ mod tests {
                     },
                     {
                         "cursor": "32Zn29gCkVQfdCBqnau1WWu4xVKYjmU5F1SPgoZ3sW6GALcbY22EGxEL2K8aNRPQaxppPGfUjSR41Xg9NyayD613",
-                        "fields": { 
+                        "fields": {
                             "bool": true,
                             "data": "00010203"
                         },
@@ -627,7 +627,7 @@ mod tests {
                 "documents": [
                     {
                         "cursor": "32Zn29gCkVQfdCBqnau1WWu4xVKYjmU5F1SPgoZ3sW6GALcbY22EGxEL2K8aNRPQaxppPGfUjSR41Xg9NyayD613",
-                        "fields": { 
+                        "fields": {
                             "bool": true,
                             "data": "00010203",
                         },
@@ -1348,15 +1348,30 @@ mod tests {
                 let data = query_lyrics(
                     client,
                     schema.id(),
-                    &format!("(first: {first}, {after} orderBy: line, orderDirection: DESC, filter: {{ line: {{ contains: \"{filter_value}\" }} }})"),
+                    &format!(
+                        "(
+                            first: {first},
+                            {after}
+                            orderBy: line,
+                            orderDirection: DESC,
+                            filter: {{
+                                line: {{ contains: \"{filter_value}\" }}
+                            }}
+                        )"
+                    ),
                 )
                 .await;
 
-                let documents = data["query"]["documents"].as_array().unwrap().len();
+                let documents_len = data["query"]["documents"].as_array().unwrap().len();
                 let total_count = data["query"]["totalCount"].clone().as_i64().unwrap();
                 let end_cursor = data["query"]["endCursor"].clone().to_string();
                 let has_next_page = data["query"]["hasNextPage"].clone().as_bool().unwrap();
-                return (documents, total_count as usize, end_cursor, has_next_page);
+                return (
+                    documents_len,
+                    total_count as usize,
+                    end_cursor,
+                    has_next_page,
+                );
             }
 
             // Publish some lyrics to the node.

--- a/aquadoggo/src/graphql/queries/collection.rs
+++ b/aquadoggo/src/graphql/queries/collection.rs
@@ -214,56 +214,204 @@ mod tests {
             "lyrics",
             vec![
                 // X-ray Spex : Oh Bondage Up Yours!
-                vec![("line", "Bind me, tie me, chain me to the wall".into(), None)],
-                vec![("line", "I wanna be a slave to you all".into(), None)],
-                vec![("line", "Oh bondage, up yours".into(), None)],
-                vec![("line", "Oh bondage, no more".into(), None)],
-                vec![(
-                    "line",
-                    "Chain-store chainsmoke, I consume you all".into(),
-                    None,
-                )],
-                vec![(
-                    "line",
-                    "Chain-gang chainmail, I don't think at all".into(),
-                    None,
-                )],
-                vec![(
-                    "line",
-                    "Thrash, me crush me, beat me till I fall".into(),
-                    None,
-                )],
-                vec![("line", "I wanna be a victim for you all".into(), None)],
-                vec![("line", "Bind me, tie me, chain me to the wall".into(), None)],
-                vec![("line", "I wanna be a slave to you all        ".into(), None)],
-                vec![("line", "Oh bondage, no more!".into(), None)],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 0.into(), None),
+                    ("line", "Bind me, tie me, chain me to the wall".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 1.into(), None),
+                    ("line", "I wanna be a slave to you all".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 2.into(), None),
+                    ("line", "Oh bondage, up yours".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 3.into(), None),
+                    ("line", "Oh bondage, no more".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 4.into(), None),
+                    (
+                        "line",
+                        "Chain-store chainsmoke, I consume you all".into(),
+                        None,
+                    ),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 5.into(), None),
+                    (
+                        "line",
+                        "Chain-gang chainmail, I don't think at all".into(),
+                        None,
+                    ),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 6.into(), None),
+                    (
+                        "line",
+                        "Thrash, me crush me, beat me till I fall".into(),
+                        None,
+                    ),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 7.into(), None),
+                    ("line", "I wanna be a victim for you all".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 8.into(), None),
+                    ("line", "Bind me, tie me, chain me to the wall".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 9.into(), None),
+                    ("line", "I wanna be a slave to you all        ".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 10.into(), None),
+                    ("line", "Oh bondage, no more!".into(), None),
+                ],
                 // Gang of Four : Natural's Not In
-                vec![("line", "The problem of leisure".into(), None)],
-                vec![("line", "What to do for pleasure".into(), None)],
-                vec![("line", "Ideal love, a new purchase".into(), None)],
-                vec![("line", "A market of the senses".into(), None)],
-                vec![("line", "Dream of the perfect life".into(), None)],
-                vec![("line", "Economic circumstances".into(), None)],
-                vec![("line", "The body is good business".into(), None)],
-                vec![("line", "Sell out, maintain the interest".into(), None)],
-                vec![("line", "Remember Lot's wife".into(), None)],
-                vec![("line", "Renounce all sin and vice".into(), None)],
-                vec![("line", "Dream of the perfect life".into(), None)],
-                vec![("line", "This heaven gives me migraine".into(), None)],
-                vec![("line", "The problem of leisure".into(), None)],
-                vec![("line", "What to do for pleasure".into(), None)],
-                vec![("line", "Coercion of the senses".into(), None)],
-                vec![("line", "We're not so gullible".into(), None)],
-                vec![("line", "Our great expectations".into(), None)],
-                vec![("line", "A future for the good".into(), None)],
-                vec![("line", "Fornication makes you happy".into(), None)],
-                vec![("line", "No escape from society".into(), None)],
-                vec![("line", "Natural is not in it".into(), None)],
-                vec![("line", "Your relations are of power".into(), None)],
-                vec![("line", "We all have good intentions".into(), None)],
-                vec![("line", "But all with strings attached".into(), None)],
-                vec![("line", "Repackaged sex (keeps) your interest".into(), None)],
-                vec![("line", "This heaven gives me migraine".into(), None)],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 11.into(), None),
+                    ("line", "The problem of leisure".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 12.into(), None),
+                    ("line", "What to do for pleasure".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 13.into(), None),
+                    ("line", "Ideal love, a new purchase".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 14.into(), None),
+                    ("line", "A market of the senses".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 15.into(), None),
+                    ("line", "Dream of the perfect life".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 16.into(), None),
+                    ("line", "Economic circumstances".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 17.into(), None),
+                    ("line", "The body is good business".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 18.into(), None),
+                    ("line", "Sell out, maintain the interest".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 19.into(), None),
+                    ("line", "Remember Lot's wife".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 20.into(), None),
+                    ("line", "Renounce all sin and vice".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 21.into(), None),
+                    ("line", "Dream of the perfect life".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 22.into(), None),
+                    ("line", "This heaven gives me migraine".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 23.into(), None),
+                    ("line", "The problem of leisure".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 24.into(), None),
+                    ("line", "What to do for pleasure".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 25.into(), None),
+                    ("line", "Coercion of the senses".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 26.into(), None),
+                    ("line", "We're not so gullible".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 27.into(), None),
+                    ("line", "Our great expectations".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 28.into(), None),
+                    ("line", "A future for the good".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 29.into(), None),
+                    ("line", "Fornication makes you happy".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 30.into(), None),
+                    ("line", "No escape from society".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 31.into(), None),
+                    ("line", "Natural is not in it".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 32.into(), None),
+                    ("line", "Your relations are of power".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 33.into(), None),
+                    ("line", "We all have good intentions".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 34.into(), None),
+                    ("line", "But all with strings attached".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 35.into(), None),
+                    ("line", "Repackaged sex (keeps) your interest".into(), None),
+                ],
+                vec![
+                    ("font", "comic-sans".into(), None),
+                    ("index", 36.into(), None),
+                    ("line", "This heaven gives me migraine".into(), None),
+                ],
             ],
             key_pair,
         )
@@ -1178,6 +1326,74 @@ mod tests {
             )
             .await;
             assert_eq!(data["query"]["documents"].as_array().unwrap().len(), 0);
+        })
+    }
+
+    #[rstest]
+    fn paginated_query_with_ordering_and_filtering(key_pair: KeyPair) {
+        test_runner(|mut node: TestNode| async move {
+            async fn next_page(
+                client: &TestClient,
+                schema: &Schema,
+                first: usize,
+                end_cursor: Option<&String>,
+                filter_value: &String,
+            ) -> (usize, usize, String, bool) {
+                let after = if let Some(end_cursor) = end_cursor {
+                    format!("after: {end_cursor}, ")
+                } else {
+                    String::new()
+                };
+
+                let data = query_lyrics(
+                    client,
+                    schema.id(),
+                    &format!("(first: {first}, {after} orderBy: line, orderDirection: DESC, filter: {{ line: {{ contains: \"{filter_value}\" }} }})"),
+                )
+                .await;
+
+                let documents = data["query"]["documents"].as_array().unwrap().len();
+                let total_count = data["query"]["totalCount"].clone().as_i64().unwrap();
+                let end_cursor = data["query"]["endCursor"].clone().to_string();
+                let has_next_page = data["query"]["hasNextPage"].clone().as_bool().unwrap();
+                return (documents, total_count as usize, end_cursor, has_next_page);
+            }
+
+            // Publish some lyrics to the node.
+            let (lyric_schema, _) = here_be_some_lyrics(&mut node, &key_pair).await;
+
+            // Init a GraphQL client we'll use to query the node.
+            let client = http_test_client(&node).await;
+
+            // We're making paginated queries and filtering by a string value.
+            let page_size = 3;
+            let filter_value = String::from("m");
+            let mut acc = 0;
+
+            // Make the initial paginated request.
+            let (mut page_count, mut total_count, mut end_cursor, mut has_next_page) =
+                next_page(&client, &lyric_schema, page_size, None, &filter_value).await;
+
+            // Add the page count to the accumulator.
+            acc += page_count;
+
+            // Now while there is a next page we keep querying.
+            while has_next_page {
+                (page_count, total_count, end_cursor, has_next_page) = next_page(
+                    &client,
+                    &lyric_schema,
+                    page_size,
+                    Some(&end_cursor),
+                    &filter_value,
+                )
+                .await;
+
+                // Add the page count to the accumulator.
+                acc += page_count;
+            }
+
+            // We should have received the same number of documents as the total count.
+            assert_eq!(acc, total_count);
         })
     }
 


### PR DESCRIPTION
This PR fixes the issue we had when pagination suddenly broke for a query over one single sorted field.

We usually order by:

1. The field which was selected by the user to-be-ordered
2. document view id (except of when it was previously selected)
3. Cursor

Two things are important in this context:

- In SQL the ordering is _only_ applied when the previous ordering stumbled upon duplicates
- The pagination logic needs to follow the same ordering to correctly paginate over it

When multiple fields have been selected by the user and we have duplicate values:

- We sort by documents (since we have 2 or more fields per document and we need to group them)
- .. And use the cursor finally as a tie-breaker for the duplicates

When _one_ field has been selected and we have duplicate values there's an issue:

- We sort by documents, no duplicates are given here anymore because at this stage document view id's will be unique (when only one field is selected we _always_ have a document per field)
- .. still we go by cursor to paginate even though this one became insignificant for the order

To fix this we simply just don't order by document id when sorting over one field!

Closes https://github.com/p2panda/aquadoggo/issues/583

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
