### PR TITLE
Generate a random name for in-memory database and set cache to shared by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `schema` tasks being triggered too often [#581](https://github.com/p2panda/aquadoggo/pull/581)
 - Fix blobs getting corrupted when written to the file system [#587](https://github.com/p2panda/aquadoggo/pull/587)
 - Fix pagination bug when only one field is selected and sorted at the same time [#593](https://github.com/p2panda/aquadoggo/pull/593)
+- Fix SQLite in-memory database overwrite by giving them each a random name [#595](https://github.com/p2panda/aquadoggo/pull/595)
 
 ## [0.5.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "log",
  "p2panda-rs",
  "path-clean",
+ "rand 0.8.5",
  "serde",
  "tempfile",
  "tokio",

--- a/aquadoggo_cli/Cargo.toml
+++ b/aquadoggo_cli/Cargo.toml
@@ -31,6 +31,7 @@ libp2p = "0.52.0"
 log = "0.4.20"
 p2panda-rs = "0.8.0"
 path-clean = "1.0.1"
+rand = "0.8.5"
 serde = { version = "1.0.185", features = ["serde_derive"] }
 tempfile = "3.7.0"
 tokio = { version = "1.28.2", features = ["full"] }

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -301,8 +301,9 @@ impl Default for Configuration {
             let db_name = format!("dbmem{}", rand::random::<u32>());
 
             // Set "mode=memory" to enable SQLite running in-memory and set "cache=shared", as
-            // setting it to "private" would break SQLite in a multi-thread runtime (for unknown
-            // reasons so far, it seems to work in Rust tests which are single-threaded).
+            // setting it to "private" would break sqlx / SQLite.
+            //
+            // See related issue: https://github.com/launchbadge/sqlx/issues/2510
             format!("sqlite://file:{db_name}?mode=memory&cache=shared")
         };
 

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -292,10 +292,17 @@ pub struct Configuration {
 
 impl Default for Configuration {
     fn default() -> Self {
+        // Give each in-memory SQLite database an unique name as we're observing funny issues with
+        // SQLite sharing data between processes (!) and breaking each others databases
+        // potentially.
+        //
+        // See related issue: https://github.com/p2panda/aquadoggo/issues/568
+        let db_name = format!("dbmem{}", rand::random::<u32>());
+
         Self {
             log_level: "off".into(),
             allow_schema_ids: UncheckedAllowList::Wildcard,
-            database_url: "sqlite::memory:".into(),
+            database_url: format!("sqlite://{db_name}?mode=memory&cache=private"),
             database_max_connections: 32,
             http_port: 2020,
             quic_port: 2022,


### PR DESCRIPTION
This is a fix around an issue with SQLite / sqlx https://github.com/launchbadge/sqlx/issues/2510 which corrupts our in-memory databases sometimes.

Closes https://github.com/p2panda/aquadoggo/issues/568

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
