### PR TITLE
GraphQL subscription support

### DIFF
--- a/aquadoggo/src/graphql/mod.rs
+++ b/aquadoggo/src/graphql/mod.rs
@@ -13,4 +13,4 @@ mod schema;
 mod tests;
 pub mod utils;
 
-pub use schema::{build_root_schema, GraphQLSchemaManager};
+pub use schema::GraphQLSchemaManager;

--- a/aquadoggo/src/graphql/queries/mod.rs
+++ b/aquadoggo/src/graphql/queries/mod.rs
@@ -5,5 +5,5 @@ mod document;
 mod next_args;
 
 pub use collection::build_collection_query;
-pub use document::build_document_query;
+pub use document::{build_document_query, build_document_subscription_query};
 pub use next_args::build_next_args_query;

--- a/aquadoggo/src/graphql/scalars/document_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/document_id_scalar.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use dynamic_graphql::{Error, Result, Scalar, ScalarValue, Value};
 use p2panda_rs::document::DocumentId;
+use p2panda_rs::Human;
 
 /// The id of a p2panda document.
 #[derive(Scalar, Clone, Debug, Eq, PartialEq)]
@@ -47,6 +48,12 @@ impl From<&DocumentIdScalar> for DocumentId {
 impl Display for DocumentIdScalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0.as_str())
+    }
+}
+
+impl Human for DocumentIdScalar {
+    fn display(&self) -> String {
+        self.0.display()
     }
 }
 

--- a/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
+++ b/aquadoggo/src/graphql/scalars/document_view_id_scalar.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 
 use dynamic_graphql::{Error, Result, Scalar, ScalarValue, Value};
 use p2panda_rs::document::DocumentViewId;
+use p2panda_rs::Human;
 
 /// The document view id of a p2panda document. Refers to a specific point in a documents history
 /// and can be used to deterministically reconstruct its state at that time.
@@ -48,6 +49,12 @@ impl From<DocumentViewIdScalar> for DocumentViewId {
 impl Display for DocumentViewIdScalar {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl Human for DocumentViewIdScalar {
+    fn display(&self) -> String {
+        self.0.display()
     }
 }
 

--- a/aquadoggo/src/graphql/schema.rs
+++ b/aquadoggo/src/graphql/schema.rs
@@ -3,9 +3,11 @@
 //! Dynamically create and manage GraphQL schemas.
 use std::sync::Arc;
 
-use async_graphql::dynamic::{Field, FieldFuture, Object, Schema, TypeRef};
+use async_graphql::dynamic::{Field, FieldFuture, Object, Schema, Subscription, TypeRef};
 use async_graphql::{Request, Response, Value};
 use dynamic_graphql::internal::Registry;
+use futures::stream::BoxStream;
+use futures::{FutureExt, Stream, StreamExt};
 use log::{debug, info, warn};
 use p2panda_rs::Human;
 use tokio::sync::Mutex;
@@ -23,7 +25,8 @@ use crate::graphql::objects::{
     build_paginated_document_object, DocumentMeta,
 };
 use crate::graphql::queries::{
-    build_collection_query, build_document_query, build_next_args_query,
+    build_collection_query, build_document_query, build_document_subscription_query,
+    build_next_args_query,
 };
 use crate::graphql::responses::NextArguments;
 use crate::graphql::scalars::{
@@ -75,14 +78,22 @@ pub async fn build_root_schema(
         .register::<PublicKeyScalar>()
         .register::<SeqNumScalar>();
 
-    let mut schema_builder = Schema::build("Query", Some("MutationRoot"), None);
+    // Construct the root query object
+    let mut root_query = Object::new("Query");
+
+    // Construct the root subscription object
+    let mut root_subscription = Subscription::new("Subscription");
+
+    // Start a schema builder with the root objects
+    let mut schema_builder = Schema::build(
+        root_query.type_name(),
+        Some("MutationRoot"),
+        Some(root_subscription.type_name()),
+    );
 
     // Populate it with the registered types. We can now use these in any following dynamically
     // created query object fields.
     schema_builder = registry.apply_into_schema_builder(schema_builder);
-
-    // Construct the root query object
-    let mut root_query = Object::new("Query");
 
     // Loop through all schema retrieved from the schema store, dynamically create GraphQL objects,
     // input values and a query for the documents they describe
@@ -120,6 +131,9 @@ pub async fn build_root_schema(
 
         // Add a query for retrieving all documents of a certain schema
         root_query = build_collection_query(root_query, &schema);
+
+        // Add a field for subscribing to changes on a single document
+        root_subscription = build_document_subscription_query(root_subscription, &schema);
     }
 
     // Add next args to the query object
@@ -128,6 +142,7 @@ pub async fn build_root_schema(
     // Build the GraphQL schema
     schema_builder
         .register(root_query)
+        .register(root_subscription)
         .data(store)
         .data(schema_provider)
         .data(tx)
@@ -262,6 +277,41 @@ impl GraphQLSchemaManager {
             .expect("No schema given yet")
             .execute(request)
             .await
+    }
+
+    /// Executes an incoming GraphQL query.
+    ///
+    /// This method makes sure the GraphQL query will be executed by the latest given schema the
+    /// manager knows about.
+    pub async fn stream(
+        self,
+        request: impl Into<Request>,
+        session_data: Arc<async_graphql::Data>,
+    ) -> impl Stream<Item = Response> {
+        self.schemas
+            .lock()
+            .await
+            .last()
+            .expect("No schema given yet")
+            .execute_stream_with_session_data(request, session_data)
+    }
+}
+
+#[async_trait::async_trait]
+impl async_graphql::Executor for GraphQLSchemaManager {
+    async fn execute(&self, request: Request) -> Response {
+        self.execute(request).await
+    }
+
+    fn execute_stream(
+        &self,
+        request: Request,
+        session_data: Option<Arc<async_graphql::Data>>,
+    ) -> BoxStream<'static, Response> {
+        self.clone()
+            .stream(request, session_data.unwrap_or_default())
+            .flatten_stream()
+            .boxed()
     }
 }
 

--- a/aquadoggo/src/http/api.rs
+++ b/aquadoggo/src/http/api.rs
@@ -25,8 +25,12 @@ use tokio_util::io::ReaderStream;
 use crate::http::context::HttpServiceContext;
 
 /// Handle GraphQL playground requests at the given path.
-pub async fn handle_graphql_playground(path: &str) -> impl IntoResponse {
-    response::Html(playground_source(GraphQLPlaygroundConfig::new(path)))
+pub async fn handle_graphql_playground(path: &str, subscription_path: &str) -> impl IntoResponse {
+    response::Html(playground_source(
+        GraphQLPlaygroundConfig::new(path)
+            .subscription_endpoint(subscription_path)
+            .title("p2panda GraphQL Playground"),
+    ))
 }
 
 /// Handle GraphQL requests.


### PR DESCRIPTION
Prototype for GraphQL subscriptions that lets you stream the value of a single document, yields an update once a second.

- Adds a WebSocket subscription endpoint in a way that is 
- Adds a GraphQL query and resolver for streaming changes to a document
- Shows an error message when the initial schema fails to build

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
