### PR TITLE
Let document subscription stream updates from materializer

### DIFF
--- a/aquadoggo/src/bus.rs
+++ b/aquadoggo/src/bus.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use p2panda_rs::document::DocumentId;
 use p2panda_rs::operation::OperationId;
 use tokio::sync::broadcast;
 
@@ -20,6 +21,8 @@ pub fn create_service_sender(capacity: usize) -> ServiceSender {
 pub enum ServiceMessage {
     /// A new operation arrived at the node.
     NewOperation(OperationId),
+
+    DocumentUpdated(DocumentId),
 
     /// Node established a bi-directional connection to another node.
     PeerConnected(Peer),

--- a/aquadoggo/src/bus.rs
+++ b/aquadoggo/src/bus.rs
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use p2panda_rs::operation::OperationId;
+use tokio::sync::broadcast;
 
 use crate::manager::Sender;
 use crate::network::{Peer, PeerMessage};
 
 /// Sender for cross-service communication bus.
 pub type ServiceSender = Sender<ServiceMessage>;
+
+/// Creates a broadcast channel for use as a service bus.
+pub fn create_service_sender(capacity: usize) -> ServiceSender {
+    let (tx, _) = broadcast::channel(capacity);
+    tx
+}
 
 /// Messages which can be sent on the communication bus.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/aquadoggo/src/context.rs
+++ b/aquadoggo/src/context.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use p2panda_rs::identity::KeyPair;
 use p2panda_rs::storage_provider::traits::{DocumentStore, EntryStore, LogStore, OperationStore};
 
+use crate::bus::ServiceSender;
 use crate::config::Configuration;
 use crate::db::SqlStore;
 use crate::schema::SchemaProvider;
@@ -27,6 +28,9 @@ where
 
     /// Schema provider gives access to system and application schemas.
     pub schema_provider: SchemaProvider,
+
+    /// Service bus sender.
+    pub service_bus: ServiceSender,
 }
 
 impl<S> Data<S>
@@ -38,12 +42,14 @@ where
         key_pair: KeyPair,
         config: Configuration,
         schema_provider: SchemaProvider,
+        service_bus: ServiceSender,
     ) -> Self {
         Self {
             key_pair,
             config,
             store,
             schema_provider,
+            service_bus,
         }
     }
 }
@@ -64,12 +70,14 @@ where
         key_pair: KeyPair,
         config: Configuration,
         schema_provider: SchemaProvider,
+        tx: ServiceSender,
     ) -> Self {
         Self(Arc::new(Data::new(
             store,
             key_pair,
             config,
             schema_provider,
+            tx,
         )))
     }
 }

--- a/aquadoggo/src/materializer/service.rs
+++ b/aquadoggo/src/materializer/service.rs
@@ -156,6 +156,7 @@ mod tests {
     use tokio::sync::{broadcast, oneshot};
     use tokio::task;
 
+    use crate::bus::create_service_sender;
     use crate::context::Context;
     use crate::materializer::{Task, TaskInput};
     use crate::schema::SchemaProvider;
@@ -197,6 +198,7 @@ mod tests {
                 KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
+                create_service_sender(128),
             );
             let shutdown = task::spawn(async {
                 loop {
@@ -273,6 +275,7 @@ mod tests {
                 KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
+                create_service_sender(128),
             );
             let shutdown = task::spawn(async {
                 loop {
@@ -339,6 +342,7 @@ mod tests {
                 KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
+                create_service_sender(128),
             );
             let shutdown = task::spawn(async {
                 loop {
@@ -434,6 +438,7 @@ mod tests {
                 KeyPair::new(),
                 Configuration::default(),
                 SchemaProvider::default(),
+                create_service_sender(128),
             );
             let shutdown = task::spawn(async {
                 loop {

--- a/aquadoggo/src/test_utils/runner.rs
+++ b/aquadoggo/src/test_utils/runner.rs
@@ -7,6 +7,7 @@ use p2panda_rs::identity::KeyPair;
 use tokio::runtime::Builder;
 use tokio::sync::Mutex;
 
+use crate::bus::create_service_sender;
 use crate::context::Context;
 use crate::db::Pool;
 use crate::db::SqlStore;
@@ -74,6 +75,7 @@ impl TestNodeManager {
                 KeyPair::new(),
                 cfg,
                 SchemaProvider::default(),
+                create_service_sender(512_000),
             ),
         };
 
@@ -115,6 +117,7 @@ pub fn test_runner<F: AsyncTestFn + Send + Sync + 'static>(test: F) {
                 KeyPair::new(),
                 config,
                 SchemaProvider::default(),
+                create_service_sender(512_000),
             ),
         };
 


### PR DESCRIPTION
The subscription field for receiving updates about a specific document is updated to trigger sending a new update whenever the materializer finishes a new version of it.

This required changing up the message bus and service manager a bit to allow receiving updates about newly updated documents from within the `http` service. `Context` receives a new field containing the service sender, which is now constructed outside the service manager and passed in to it as a parameter.

Then, a new message type `DocumentUpdated` is added, which is emitted in the reducer task whenever documents are created or updated. This lets use then connect any running subscription stream to the service bus and listen for updates of their queried document.

## 📋 Checklist

- [ ] Add tests that cover your changes
- [ ] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [ ] Link this PR to any issues it closes
- [ ] New files contain a SPDX license header
