### PR TITLE
Accept domain name and ip addresses for peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Accept domain name and ip addresses for peers in configuration file and cli [#612](https://github.com/p2panda/aquadoggo/pull/612)
+
 ## [0.7.1]
 
 ### Added

--- a/aquadoggo/src/api/config_file.rs
+++ b/aquadoggo/src/api/config_file.rs
@@ -11,8 +11,8 @@ use p2panda_rs::schema::SchemaId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tempfile::TempDir;
 
-use crate::{AllowList, Configuration, NetworkConfiguration};
 use crate::network::utils::to_multiaddress;
+use crate::{AllowList, Configuration, NetworkConfiguration};
 
 const WILDCARD: &str = "*";
 

--- a/aquadoggo/src/api/config_file.rs
+++ b/aquadoggo/src/api/config_file.rs
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use std::convert::TryFrom;
-use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::OnceLock;
 
 use anyhow::{anyhow, Result};
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId};
 use p2panda_rs::schema::SchemaId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tempfile::TempDir;
 
 use crate::{AllowList, Configuration, NetworkConfiguration};
+use crate::network::utils::to_multiaddress;
 
 const WILDCARD: &str = "*";
 
@@ -154,7 +154,7 @@ pub struct ConfigFile {
     /// addresses or even with nodes behind a firewall or NAT, do not use this field but use at
     /// least one relay.
     #[serde(default)]
-    pub direct_node_addresses: Vec<SocketAddr>,
+    pub direct_node_addresses: Vec<String>,
 
     /// List of peers which are allowed to connect to your node.
     ///
@@ -196,7 +196,7 @@ pub struct ConfigFile {
     /// trusted relays or make sure your IP address is hidden via a VPN or proxy if you're
     /// concerned about leaking your IP.
     #[serde(default)]
-    pub relay_addresses: Vec<SocketAddr>,
+    pub relay_addresses: Vec<String>,
 
     /// Enable if node should also function as a relay. Disabled by default.
     ///
@@ -287,6 +287,18 @@ impl TryFrom<ConfigFile> for Configuration {
                 .to_path_buf(),
         };
 
+        let direct_node_addresses = value
+            .direct_node_addresses
+            .iter()
+            .map(to_multiaddress)
+            .collect::<Result<Vec<Multiaddr>, _>>()?;
+
+        let relay_addresses = value
+            .relay_addresses
+            .iter()
+            .map(to_multiaddress)
+            .collect::<Result<Vec<Multiaddr>, _>>()?;
+
         Ok(Configuration {
             allow_schema_ids,
             database_url: value.database_url,
@@ -297,10 +309,10 @@ impl TryFrom<ConfigFile> for Configuration {
             network: NetworkConfiguration {
                 quic_port: value.quic_port,
                 mdns: value.mdns,
-                direct_node_addresses: value.direct_node_addresses,
+                direct_node_addresses,
                 allow_peer_ids,
                 block_peer_ids: value.block_peer_ids,
-                relay_addresses: value.relay_addresses,
+                relay_addresses,
                 relay_mode: value.relay_mode,
                 ..Default::default()
             },

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::net::SocketAddr;
-
 use libp2p::connection_limits::ConnectionLimits;
-use libp2p::PeerId;
+use libp2p::{Multiaddr, PeerId};
 
 use crate::AllowList;
 
@@ -25,7 +23,7 @@ pub struct NetworkConfiguration {
     /// with a static IP Address). If you need to connect to nodes with changing, dynamic IP
     /// addresses or even with nodes behind a firewall or NAT, do not use this field but use at
     /// least one relay.
-    pub direct_node_addresses: Vec<SocketAddr>,
+    pub direct_node_addresses: Vec<Multiaddr>,
 
     /// List of peers which are allowed to connect to your node.
     ///
@@ -64,7 +62,7 @@ pub struct NetworkConfiguration {
     /// WARNING: This will potentially expose your IP address on the network. Do only connect to
     /// trusted relays or make sure your IP address is hidden via a VPN or proxy if you're
     /// concerned about leaking your IP.
-    pub relay_addresses: Vec<SocketAddr>,
+    pub relay_addresses: Vec<Multiaddr>,
 
     /// Enable if node should also function as a relay.
     ///

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -93,15 +93,14 @@ pub async fn network_service(
         // replication sessions, which could leave the node in a strange state.
         swarm.behaviour_mut().peers.disable();
 
-        for relay_address in network_config.relay_addresses.clone() {
-            let mut address = utils::to_multiaddress(&relay_address);
-            info!("Connecting to relay node {}", address);
+        for mut relay_address in network_config.relay_addresses.clone() {
+            info!("Connecting to relay node {}", relay_address);
 
             // Attempt to connect to the relay node, we give this a 5 second timeout so as not to
             // get stuck if one relay is unreachable.
             if let Ok(result) = tokio::time::timeout(
                 RELAY_CONNECT_TIMEOUT,
-                connect_to_relay(&mut swarm, &mut address),
+                connect_to_relay(&mut swarm, &mut relay_address),
             )
             .await
             {
@@ -161,10 +160,11 @@ pub async fn network_service(
 
     // Dial all nodes we want to directly connect to.
     for direct_node_address in &network_config.direct_node_addresses {
-        let address = utils::to_multiaddress(direct_node_address);
-        info!("Connecting to node @ {}", address);
+        info!("Connecting to node @ {}", direct_node_address);
 
-        let opts = DialOpts::unknown_peer_id().address(address.clone()).build();
+        let opts = DialOpts::unknown_peer_id()
+            .address(direct_node_address.clone())
+            .build();
 
         match swarm.dial(opts) {
             Ok(_) => (),

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 
+use anyhow::Result;
 use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
 use regex::Regex;
@@ -24,12 +25,17 @@ pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
     }
 }
 
-pub fn to_multiaddress(socket_address: &SocketAddr) -> Multiaddr {
+pub fn to_multiaddress(address: &String) -> Result<Multiaddr> {
+    let socket_address = address
+        .to_socket_addrs()?
+        .next()
+        .expect(&format!("Could not resolve socket address for: {address}"));
+
     let mut multiaddr = match socket_address.ip() {
         IpAddr::V4(ip) => Multiaddr::from(Protocol::Ip4(ip)),
         IpAddr::V6(ip) => Multiaddr::from(Protocol::Ip6(ip)),
     };
     multiaddr.push(Protocol::Udp(socket_address.port()));
     multiaddr.push(Protocol::QuicV1);
-    multiaddr
+    Ok(multiaddr)
 }

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -29,7 +29,7 @@ pub fn to_multiaddress(address: &String) -> Result<Multiaddr> {
     let socket_address = address
         .to_socket_addrs()?
         .next()
-        .expect(&format!("Could not resolve socket address for: {address}"));
+        .unwrap_or_else(|| panic!("Could not resolve socket address for: {}", address));
 
     let mut multiaddr = match socket_address.ip() {
         IpAddr::V4(ip) => Multiaddr::from(Protocol::Ip4(ip)),

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -142,7 +142,8 @@ mdns = true
 # NODES
 # ﾟ･｡+☆
 
-# List of known node addresses (IP + port) we want to connect to directly.
+# List of known node addresses we want to connect to direct. Addresses can be 
+# domain names or IP addresses and must include a port number.
 #
 # NOTE: Make sure that nodes mentioned in this list are directly reachable
 # (they need to be hosted with a static IP Address). If you need to connect to
@@ -151,7 +152,7 @@ mdns = true
 #
 direct_node_addresses = [
     # "192.0.2.0:2022",
-    # "192.0.2.2:3000",
+    # "my.domain.name:2022",
 ]
 
 # List of peers which are allowed to connect to your node.
@@ -189,7 +190,8 @@ block_peer_ids = []
 # RELAYS
 # ﾟ･｡+☆+
 
-# List of relay addresses.
+# List of relay addresses. Addresses can be domain names or IP addresses 
+# and must include a port number.
 #
 # A relay helps discover other nodes on the internet (also known as
 # "rendesvouz" or "bootstrap" server) and helps establishing direct p2p
@@ -210,7 +212,7 @@ block_peer_ids = []
 #
 relay_addresses = [
     # "192.0.2.16:2022",
-    # "192.0.2.17:2022",
+    # "my.domain.me:2022",
 ]
 
 # Set to true if node should also function as a relay. Defaults to false.

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::net::SocketAddr;
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
@@ -160,7 +159,7 @@ struct Cli {
     /// least one relay.
     #[arg(short = 'n', long, value_name = "IP:PORT", num_args = 0..)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    direct_node_addresses: Option<Vec<SocketAddr>>,
+    direct_node_addresses: Option<Vec<String>>,
 
     /// List of peers which are allowed to connect to your node.
     ///
@@ -208,7 +207,7 @@ struct Cli {
     /// concerned about leaking your IP.
     #[arg(short = 'r', long, value_name = "IP:PORT", num_args = 0..)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    relay_addresses: Option<Vec<SocketAddr>>,
+    relay_addresses: Option<Vec<String>>,
 
     /// Enable if node should also function as a relay. Disabled by default.
     ///


### PR DESCRIPTION
We want to be able to pass addresses for direct peers and relay peers into aquadoggo as both ip addresses and domain names. This PR implements parsing either addresses in string format to a `SocketAddr` using `ToSocketAddrs` and then constructs a `Multiaddr` in the format libp2p expects.

Addresses for relay and direct peers are now accepted in the following formats:
- ip address: `123.123.123:2022`
- domain name: `welle.liebechaos.org:2022`

I was under the impression that libp2p would do this lookup for us under the hood, but even after many attempts I couldn't get it to work, so I switched to this method which is preferable in my opinion anyway.

closes: #610 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
