### PR TITLE
Re-run tasks for partially materialized blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-materialize blobs which were only partially written to disc due to node crash [#618](https://github.com/p2panda/aquadoggo/pull/618)
+
 ## [0.7.3]
 
 ### Fixed

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -62,11 +62,7 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
                             _ => unreachable!(),
                         };
 
-                        if metadata.len() < *expected_blob_length as u64 {
-                            false
-                        } else {
-                            true
-                        }
+                        metadata.len() < *expected_blob_length as u64
                     }
                     Err(_) => false,
                 };

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -62,7 +62,7 @@ pub async fn blob_task(context: Context, input: TaskInput) -> TaskResult<TaskInp
                             _ => unreachable!(),
                         };
 
-                        metadata.len() < *expected_blob_length as u64
+                        metadata.len() == *expected_blob_length as u64
                     }
                     Err(_) => false,
                 };

--- a/aquadoggo/src/materializer/tasks/blob.rs
+++ b/aquadoggo/src/materializer/tasks/blob.rs
@@ -267,7 +267,6 @@ mod tests {
     fn re_materialize_blob_after_previous_task_did_not_complete(key_pair: KeyPair) {
         test_runner(|mut node: TestNode| async move {
             // Publish blob
-            // Publish blob
             let blob_data = "Hello, World!";
             let blob_view_id =
                 add_blob(&mut node, blob_data.as_bytes(), 5, "plain/text", &key_pair).await;

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -27,7 +27,7 @@ type ConfigFilePath = Option<PathBuf>;
 /// Returns a partly unchecked configuration object which results from all of these sources. It
 /// still needs to be converted for aquadoggo as it might still contain invalid values.
 pub fn load_config() -> Result<(ConfigFilePath, ConfigFile)> {
-    // Parse command line arguments and CONFIG environment variable first to get optional config 
+    // Parse command line arguments and CONFIG environment variable first to get optional config
     // file path
     let cli = Cli::parse();
 


### PR DESCRIPTION
Before materializing a blob to the file system the blob task checks if a file already exists at the expected path. If there is one then it aborts the task without completing. This check is there as blob tasks can be triggered multiple times and we only want it to complete once. 

This is fine except for in the case where a node is shutdown or crashes while a blob task is running. In this case the file is only partially written to disc and even when the task is picked up again on next restart the blob task will not be retried because of the previously described check.

This PR fixes this issue by introducing a check which ensures the file existing at the blob path is the expected length. If not the task continues to materialize the blob at that path as it assumes it didn't complete last time.
 
closes: #617 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
