### PR TITLE
Introduce `PeerAddress` struct for improved address resolution patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Re-materialize blobs which were only partially written to disc due to node crash [#618](https://github.com/p2panda/aquadoggo/pull/618)
 
+### Added
+
+- Introduce `PeerAddress` struct to help resolve `String` to internal address types [#621](https://github.com/p2panda/aquadoggo/pull/621)
+
 ## [0.7.3]
 
 ### Fixed

--- a/aquadoggo/src/api/config_file.rs
+++ b/aquadoggo/src/api/config_file.rs
@@ -11,7 +11,7 @@ use p2panda_rs::schema::SchemaId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tempfile::TempDir;
 
-use crate::{network::PeerAddress, AllowList, Configuration, NetworkConfiguration};
+use crate::{AllowList, Configuration, NetworkConfiguration};
 
 const WILDCARD: &str = "*";
 
@@ -153,7 +153,7 @@ pub struct ConfigFile {
     /// addresses or even with nodes behind a firewall or NAT, do not use this field but use at
     /// least one relay.
     #[serde(default)]
-    pub direct_node_addresses: Vec<PeerAddress>,
+    pub direct_node_addresses: Vec<String>,
 
     /// List of peers which are allowed to connect to your node.
     ///
@@ -195,7 +195,7 @@ pub struct ConfigFile {
     /// trusted relays or make sure your IP address is hidden via a VPN or proxy if you're
     /// concerned about leaking your IP.
     #[serde(default)]
-    pub relay_addresses: Vec<PeerAddress>,
+    pub relay_addresses: Vec<String>,
 
     /// Enable if node should also function as a relay. Disabled by default.
     ///
@@ -286,6 +286,13 @@ impl TryFrom<ConfigFile> for Configuration {
                 .to_path_buf(),
         };
 
+        let relay_addresses = value.relay_addresses.into_iter().map(From::from).collect();
+        let direct_node_addresses = value
+            .direct_node_addresses
+            .into_iter()
+            .map(From::from)
+            .collect();
+
         Ok(Configuration {
             allow_schema_ids,
             database_url: value.database_url,
@@ -296,10 +303,10 @@ impl TryFrom<ConfigFile> for Configuration {
             network: NetworkConfiguration {
                 quic_port: value.quic_port,
                 mdns: value.mdns,
-                direct_node_addresses: value.direct_node_addresses,
+                direct_node_addresses,
                 allow_peer_ids,
                 block_peer_ids: value.block_peer_ids,
-                relay_addresses: value.relay_addresses,
+                relay_addresses,
                 relay_mode: value.relay_mode,
                 ..Default::default()
             },

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -6,7 +6,6 @@ use anyhow::Error;
 use libp2p::connection_limits::ConnectionLimits;
 use libp2p::multiaddr::Protocol;
 use libp2p::{Multiaddr, PeerId};
-use serde::{Deserialize, Serialize};
 
 use crate::AllowList;
 
@@ -152,7 +151,7 @@ impl NetworkConfiguration {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct PeerAddress {
     addr_str: String,
     socket_addr: Option<SocketAddr>,

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -155,9 +155,9 @@ impl NetworkConfiguration {
 /// a DNS lookup. The [ToSocketAddrs](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html)
 /// implementation is used to attempt converting a `String`` to a `SocketAddrs` and then from
 /// here to a `Multiaddr`.
-/// 
+///
 /// When `to_socket` is first called it's successful result is cached internally and this value
-/// is used directly from this point on. This is an optimization which avoids unnecessary DNS 
+/// is used directly from this point on. This is an optimization which avoids unnecessary DNS
 /// lookups.
 #[derive(Debug, Clone)]
 pub struct PeerAddress {
@@ -173,7 +173,7 @@ impl PeerAddress {
         }
     }
 
-    pub fn to_socket(&mut self) -> Result<SocketAddr, Error> {
+    pub fn socket(&mut self) -> Result<SocketAddr, Error> {
         if let Some(socket_addr) = self.socket_addr {
             return Ok(socket_addr);
         }
@@ -190,8 +190,8 @@ impl PeerAddress {
         Ok(socket_addr)
     }
 
-    pub fn to_quic_multiaddr(&mut self) -> Result<Multiaddr, Error> {
-        match self.to_socket() {
+    pub fn quic_multiaddr(&mut self) -> Result<Multiaddr, Error> {
+        match self.socket() {
             Ok(socket_address) => {
                 let mut multiaddr = match socket_address.ip() {
                     IpAddr::V4(ip) => Multiaddr::from(Protocol::Ip4(ip)),

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -156,7 +156,6 @@ impl NetworkConfiguration {
 pub struct PeerAddress {
     addr_str: String,
     socket_addr: Option<SocketAddr>,
-    multi_addr: Option<Multiaddr>,
 }
 
 impl PeerAddress {
@@ -164,7 +163,6 @@ impl PeerAddress {
         PeerAddress {
             addr_str,
             socket_addr: None,
-            multi_addr: None,
         }
     }
 

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -151,6 +151,14 @@ impl NetworkConfiguration {
     }
 }
 
+/// Helper struct for handling ambiguous string addresses which may need resolving via
+/// a DNS lookup. The [ToSocketAddrs](https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html)
+/// implementation is used to attempt converting a `String`` to a `SocketAddrs` and then from
+/// here to a `Multiaddr`.
+/// 
+/// When `to_socket` is first called it's successful result is cached internally and this value
+/// is used directly from this point on. This is an optimization which avoids unnecessary DNS 
+/// lookups.
 #[derive(Debug, Clone)]
 pub struct PeerAddress {
     addr_str: String,

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -10,7 +10,7 @@ mod swarm;
 mod transport;
 pub mod utils;
 
-pub use config::NetworkConfiguration;
+pub use config::{PeerAddress, NetworkConfiguration};
 pub use peers::{Peer, PeerMessage};
 pub use service::network_service;
 pub use shutdown::ShutdownHandler;

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -10,7 +10,7 @@ mod swarm;
 mod transport;
 pub mod utils;
 
-pub use config::{NetworkConfiguration, PeerAddress};
+pub use config::NetworkConfiguration;
 pub use peers::{Peer, PeerMessage};
 pub use service::network_service;
 pub use shutdown::ShutdownHandler;

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -10,7 +10,7 @@ mod swarm;
 mod transport;
 pub mod utils;
 
-pub use config::{PeerAddress, NetworkConfiguration};
+pub use config::{NetworkConfiguration, PeerAddress};
 pub use peers::{Peer, PeerMessage};
 pub use service::network_service;
 pub use shutdown::ShutdownHandler;

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -96,7 +96,7 @@ pub async fn network_service(
         for relay_address in network_config.relay_addresses.iter_mut() {
             info!("Connecting to relay node {}", relay_address);
 
-            let mut relay_address = match relay_address.to_quic_multiaddr() {
+            let mut relay_address = match relay_address.quic_multiaddr() {
                 Ok(relay_address) => relay_address,
                 Err(e) => {
                     debug!("Failed to resolve relay multiaddr: {}", e.to_string());
@@ -170,7 +170,7 @@ pub async fn network_service(
     for direct_node_address in network_config.direct_node_addresses.iter_mut() {
         info!("Connecting to node @ {}", direct_node_address);
 
-        let direct_node_address = match direct_node_address.to_quic_multiaddr() {
+        let direct_node_address = match direct_node_address.quic_multiaddr() {
             Ok(address) => address,
             Err(e) => {
                 debug!("Failed to resolve direct node multiaddr: {}", e.to_string());

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -235,11 +235,6 @@ pub async fn connect_to_relay(
 
                 // Now that we have a reply from the relay node we can add their peer id to the
                 // relay address.
-
-                // Pop off the "p2p" protocol.
-                let _ = relay_address.pop();
-
-                // Add it back on again with the relay nodes peer id included.
                 relay_address.push(Protocol::P2p(peer_id));
 
                 // Update values on the config.

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 
-use anyhow::Result;
-use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
 use regex::Regex;
 
@@ -23,19 +21,4 @@ pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
             Some(socket)
         }
     }
-}
-
-pub fn to_multiaddress(address: &String) -> Result<Multiaddr> {
-    let socket_address = address
-        .to_socket_addrs()?
-        .next()
-        .unwrap_or_else(|| panic!("Could not resolve socket address for: {}", address));
-
-    let mut multiaddr = match socket_address.ip() {
-        IpAddr::V4(ip) => Multiaddr::from(Protocol::Ip4(ip)),
-        IpAddr::V6(ip) => Multiaddr::from(Protocol::Ip6(ip)),
-    };
-    multiaddr.push(Protocol::Udp(socket_address.port()));
-    multiaddr.push(Protocol::QuicV1);
-    Ok(multiaddr)
 }


### PR DESCRIPTION
In all public aquadoggo configuration APIs peers can be addressed by IP address or domain name, in the case of the later, before making a connection attempt we need to do a DNS lookup to get the correct socket address. When the node is offline then we want to silently ignore failed lookups, just log the attempt and continue. Currently we only perform lookup when a node starts and we parse the configuration file, but later we want to introduce redials of relays and direct nodes, this will require us to perform the DNS lookup later (it may have failed on startup). 

This PR just introduces a new struct `PeerAddress` with two methods `socket` and `quic_multiaddr` which help us handle still unresolved peer addresses. When `socket` is called and successfully resolves the peer address string to a `SocketAddr` the result is cached and directly used on later calls in order to avoid unnecessary DNS lookups.

closes: #613 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
