### PR TITLE
Dial all configured known relay and direct node addresses on schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduce `PeerAddress` struct to help resolve `String` to internal address types [#621](https://github.com/p2panda/aquadoggo/pull/621)
+- Re-dial all configured known peers on schedule [#622](https://github.com/p2panda/aquadoggo/pull/622)
 
 ### Changed
 

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -428,7 +428,7 @@ impl EventLoop {
     /// if we are currently not connected to the target peer.
     async fn attempt_dial_known_addresses(&mut self) {
         fn try_dial_peer(swarm: &mut Swarm<P2pandaBehaviour>, address: &mut PeerAddress) {
-            let address = match address.to_quic_multiaddr() {
+            let address = match address.quic_multiaddr() {
                 Ok(address) => address,
                 Err(e) => {
                     debug!("Failed to resolve relay multiaddr: {}", e.to_string());

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -316,8 +316,8 @@ struct EventLoop {
     /// - listening on a circuit relay address for relayed connections
     relay_addresses: HashMap<PeerId, Multiaddr>,
 
-    /// Addresses of configured relay or direct peers with their corresponding PeerId. 
-    /// Is only populated once we have made the first connection to the addressed peer 
+    /// Addresses of configured relay or direct peers with their corresponding PeerId.
+    /// Is only populated once we have made the first connection to the addressed peer
     /// and received an identify message back containing the PeerId.
     known_peers: HashMap<Multiaddr, PeerId>,
 
@@ -576,7 +576,7 @@ impl EventLoop {
 
                 // Check if the identified peer is one of our configured relay addresses.
                 for address in self.network_config.relay_addresses.iter_mut() {
-                    if let Some(addr) = address.quic_multiaddr().ok() {
+                    if let Ok(addr) = address.quic_multiaddr() {
                         if listen_addrs.contains(&addr) {
                             debug!("Relay identified: {peer_id} {addr}");
                             self.known_peers.insert(addr, *peer_id);
@@ -586,7 +586,7 @@ impl EventLoop {
 
                 // Check if the identified peer is one of our direct node addresses.
                 for address in self.network_config.direct_node_addresses.iter_mut() {
-                    if let Some(addr) = address.quic_multiaddr().ok() {
+                    if let Ok(addr) = address.quic_multiaddr() {
                         if listen_addrs.contains(&addr) {
                             debug!("Direct node identified: {peer_id} {addr}");
                             self.known_peers.insert(addr, *peer_id);

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -413,7 +413,7 @@ impl EventLoop {
             address: &mut PeerAddress,
         ) {
             // Get the peers quic multiaddress, this can error if the address was provided in the form
-            // of a domain name and we are not able to resolve it to a valid multiaddress (for example, 
+            // of a domain name and we are not able to resolve it to a valid multiaddress (for example,
             // if we are offline).
             let address = match address.quic_multiaddr() {
                 Ok(address) => address,

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use libp2p::multiaddr::Protocol;
-use libp2p::swarm::behaviour::ConnectionEstablished;
 use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
 use libp2p::swarm::SwarmEvent;
 use libp2p::{identify, mdns, relay, rendezvous, Multiaddr, PeerId, Swarm};

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -167,29 +167,6 @@ pub async fn network_service(
                 );
         }
     }
-
-    // Dial all nodes we want to directly connect to.
-    for direct_node_address in network_config.direct_node_addresses.iter_mut() {
-        info!("Connecting to node @ {}", direct_node_address);
-
-        let direct_node_address = match direct_node_address.quic_multiaddr() {
-            Ok(address) => address,
-            Err(e) => {
-                debug!("Failed to resolve direct node multiaddr: {}", e.to_string());
-                continue;
-            }
-        };
-
-        let opts = DialOpts::unknown_peer_id()
-            .address(direct_node_address.clone())
-            .build();
-
-        match swarm.dial(opts) {
-            Ok(_) => (),
-            Err(err) => debug!("Error dialing node: {:?}", err),
-        };
-    }
-
     info!("Network service ready!");
 
     // Spawn main event loop handling all p2panda and libp2p network events.


### PR DESCRIPTION
When a node is first launched it attempts to connect to any configured relay or direct node addresses, the steps are as follows:

1) register at all relay/rendezvous nodes for peer discovery and connections
2) connect to and initiate a replication sessions with all relay/rendezvous nodes
3) connect to and initiate a replication sessions with all direct nodes

If the device where a node is running is offline when the app starts, all of these steps will fail and no further connection attempts are made. Similarly, if the node loses connectivity after it started, connections will be dropped for good. 

This PR implements a modest solution for points `2)` an `3)` above by adding a polling service to the `EventLoop` which attempts to (re)connect to all known peer addresses (relay or otherwise) every x seconds. A connection is only established if none already exist to the address in question. Replication sessions will be initiated with any peers that we successfully (re)connect to.

Finding a solution in the same situation for point `1)` above is a little more involved, these changes seemed like easy low hanging fruit which brings greatly improved UX to node users, especially in situations where nodes run for long periods and connections may drop.

## 📋 Checklist

- [x] ~~Add tests that cover your changes~~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
