### PR TITLE
Move relay connection logic into main event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upate `libp2p` to version `0.53.2` and apply API changes [#631](https://github.com/p2panda/aquadoggo/pull/631)
+- Update `libp2p` to version `0.53.2` and apply API changes [#631](https://github.com/p2panda/aquadoggo/pull/631)
+- Move relay registration into main network service event loop [#632](https://github.com/p2panda/aquadoggo/pull/632)
 
 ### Fixed
 

--- a/aquadoggo/src/http/service.rs
+++ b/aquadoggo/src/http/service.rs
@@ -18,6 +18,7 @@ use crate::http::api::{
     handle_blob_document, handle_blob_view, handle_graphql_playground, handle_graphql_query,
 };
 use crate::http::context::HttpServiceContext;
+use crate::info_or_print;
 use crate::manager::{ServiceReadySender, Shutdown};
 
 /// Route to the GraphQL playground
@@ -74,17 +75,19 @@ pub async fn http_service(
     let builder = if let Ok(builder) = axum::Server::try_bind(&http_address) {
         builder
     } else {
-        println!("HTTP port {http_port} was already taken, try random port instead ..");
+        info_or_print(&format!(
+            "HTTP port {http_port} was already taken, try random port instead .."
+        ));
         axum::Server::try_bind(&SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))?
     };
 
     let builder = builder.serve(build_server(http_context).into_make_service());
 
     let local_address = builder.local_addr();
-    println!(
+    info_or_print(&format!(
         "Go to http://{}/graphql to use GraphQL playground",
         local_address
-    );
+    ));
 
     builder
         .with_graceful_shutdown(async {

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -61,6 +61,9 @@ fn init() {
     }
 }
 
+/// Helper method for logging a message directly to standard out or via the `log` crate when any
+/// logging level is enabled. We need this as some messages should be always printed, but when any
+/// logging level is selected, we want the message to be printed with consistent formatting.
 fn info_or_print(message: &str) {
     if log_enabled!(Level::Info) || log_enabled!(Level::Debug) || log_enabled!(Level::Trace) {
         info!("{message}");

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -35,6 +35,7 @@ mod tests;
 pub use crate::api::{ConfigFile, LockFile};
 pub use crate::config::{AllowList, Configuration};
 pub use crate::network::NetworkConfiguration;
+use log::{info, log_enabled, Level};
 pub use node::Node;
 
 /// Init env_logger before the test suite runs to handle logging outputs.
@@ -57,5 +58,13 @@ fn init() {
     // to see any logs.
     if std::env::var("RUST_LOG").is_ok() {
         let _ = env_logger::builder().is_test(true).try_init();
+    }
+}
+
+fn info_or_print(message: &str) {
+    if log_enabled!(Level::Info) || log_enabled!(Level::Debug) || log_enabled!(Level::Trace) {
+        info!("{message}");
+    } else {
+        println!("{message}");
     }
 }

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -32,10 +32,11 @@ mod test_utils;
 #[cfg(test)]
 mod tests;
 
+use log::{info, log_enabled, Level};
+
 pub use crate::api::{ConfigFile, LockFile};
 pub use crate::config::{AllowList, Configuration};
 pub use crate::network::NetworkConfiguration;
-use log::{info, log_enabled, Level};
 pub use node::Node;
 
 /// Init env_logger before the test suite runs to handle logging outputs.

--- a/aquadoggo/src/network/behaviour.rs
+++ b/aquadoggo/src/network/behaviour.rs
@@ -223,7 +223,6 @@ pub enum Event {
     RendezvousClient(rendezvous::client::Event),
     #[allow(dead_code)]
     RendezvousServer(rendezvous::server::Event),
-    #[allow(dead_code)]
     Dcutr(dcutr::Event),
     Peers(peers::Event),
     Void,

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -132,9 +132,9 @@ impl Default for NetworkConfiguration {
             dial_concurrency_factor: 8,
             max_connections_in: 16,
             max_connections_out: 16,
-            max_connections_pending_in: 16,
-            max_connections_pending_out: 16,
-            max_connections_per_peer: 8,
+            max_connections_pending_in: 8,
+            max_connections_pending_out: 8,
+            max_connections_per_peer: 2,
         }
     }
 }

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -4,6 +4,7 @@ mod behaviour;
 mod config;
 pub mod identity;
 mod peers;
+mod relay;
 mod service;
 mod shutdown;
 mod swarm;

--- a/aquadoggo/src/network/peers/behaviour.rs
+++ b/aquadoggo/src/network/peers/behaviour.rs
@@ -120,15 +120,6 @@ impl Behaviour {
         false
     }
 
-    /// Disable the behaviour, it won't handle any connection events or received messages.
-    pub fn disable(&mut self) {
-        self.enabled = false
-    }
-
-    pub fn enable(&mut self) {
-        self.enabled = true
-    }
-
     pub fn send_message(&mut self, peer: Peer, message: PeerMessage) {
         self.push_event(ToSwarm::NotifyHandler {
             peer_id: peer.id(),

--- a/aquadoggo/src/network/relay.rs
+++ b/aquadoggo/src/network/relay.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use libp2p::multiaddr::Protocol;
+use libp2p::{rendezvous, Multiaddr, PeerId, Swarm};
+
+use crate::network::behaviour::P2pandaBehaviour;
+use crate::network::config::NODE_NAMESPACE;
+
+/// A relay node.
+pub struct Relay {
+    /// PeerId of the relay node.
+    pub(crate) peer_id: PeerId,
+
+    /// A single Multiaddr which we know the relay node to be accessible at.
+    pub(crate) addr: Multiaddr,
+
+    /// The namespace we discover peers at on this relay.
+    pub(crate) namespace: String,
+
+    /// Did we tell the relay it's observed address yet.
+    pub(crate) told_addr: bool,
+
+    /// Are we currently discovering peers.
+    pub(crate) discovering: bool,
+
+    /// Are we in the process of registering at this relay.
+    pub(crate) registering: bool,
+
+    /// Have we successfully registered.
+    pub(crate) registered: bool,
+
+    /// Was our relay circuit reservation accepted.
+    pub(crate) reservation_accepted: bool,
+}
+
+impl Relay {
+    pub fn new(peer_id: PeerId, addr: Multiaddr) -> Self {
+        Relay {
+            peer_id,
+            addr,
+            namespace: NODE_NAMESPACE.to_string(),
+            told_addr: false,
+            discovering: false,
+            registering: false,
+            registered: false,
+            reservation_accepted: false,
+        }
+    }
+
+    /// The circuit address we should listen at for this relay.
+    pub fn circuit_addr(&self) -> Multiaddr {
+        self.addr
+            .clone()
+            .with(Protocol::P2p(self.peer_id))
+            .with(Protocol::P2pCircuit)
+    }
+
+    /// Start listening on the relay circuit address and register on our discovery namespace.
+    pub fn register(&mut self, swarm: &mut Swarm<P2pandaBehaviour>) -> Result<bool, anyhow::Error> {
+        if self.registered || self.registering {
+            return Ok(false);
+        }
+
+        self.registering = true;
+
+        // Start listening on the circuit relay address.
+        let circuit_address = self.circuit_addr();
+        swarm.listen_on(circuit_address.clone())?;
+
+        // Register in the `NODE_NAMESPACE` using the rendezvous network behaviour.
+        swarm
+            .behaviour_mut()
+            .rendezvous_client
+            .as_mut()
+            .unwrap()
+            .register(
+                rendezvous::Namespace::from_static(NODE_NAMESPACE),
+                self.peer_id.clone(),
+                None, // Default ttl is 7200s
+            )?;
+
+        Ok(true)
+    }
+
+    /// Start discovering peers also registered at the same namespace.
+    pub fn discover(&mut self, swarm: &mut Swarm<P2pandaBehaviour>) -> bool {
+        if self.reservation_accepted && self.registered && !self.discovering {
+            self.discovering = true;
+
+            swarm
+                .behaviour_mut()
+                .rendezvous_client
+                .as_mut()
+                .expect("Relay client behaviour exists")
+                .discover(
+                    Some(
+                        rendezvous::Namespace::new(NODE_NAMESPACE.to_string())
+                            .expect("Valid namespace"),
+                    ),
+                    None,
+                    None,
+                    self.peer_id,
+                );
+
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/aquadoggo/src/network/relay.rs
+++ b/aquadoggo/src/network/relay.rs
@@ -75,7 +75,7 @@ impl Relay {
             .unwrap()
             .register(
                 rendezvous::Namespace::from_static(NODE_NAMESPACE),
-                self.peer_id.clone(),
+                self.peer_id,
                 None, // Default ttl is 7200s
             )?;
 

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -10,7 +10,7 @@ use libp2p::multiaddr::Protocol;
 use libp2p::rendezvous::Registration;
 use libp2p::swarm::dial_opts::DialOpts;
 use libp2p::swarm::SwarmEvent;
-use libp2p::{identify, mdns, relay, rendezvous, Multiaddr, PeerId, Swarm};
+use libp2p::{dcutr, identify, mdns, relay, rendezvous, Multiaddr, PeerId, Swarm};
 use log::{debug, info, trace, warn};
 use tokio::task;
 use tokio::time::interval;
@@ -196,6 +196,7 @@ impl EventLoop {
                         SwarmEvent::Behaviour(Event::RendezvousClient(event)) => self.handle_rendezvous_client_events(&event).await,
                         SwarmEvent::Behaviour(Event::Peers(event)) => self.handle_peers_events(&event).await,
                         SwarmEvent::Behaviour(Event::RelayClient(event)) => self.handle_relay_client_events(&event).await,
+                        SwarmEvent::Behaviour(Event::Dcutr(event)) => self.handle_dcutr_events(&event).await,
                         event => self.handle_swarm_events(event).await,
 
                     }
@@ -459,6 +460,18 @@ impl EventLoop {
                 }
             }
             event => trace!("{event:?}"),
+        }
+    }
+
+    async fn handle_dcutr_events(&mut self, event: &dcutr::Event) {
+        match &event.result {
+            Ok(connection_id) => {
+                info!(
+                    "{}({}) upgraded to direct connection",
+                    event.remote_peer_id, connection_id
+                );
+            }
+            Err(e) => debug!("Direct connection upgrade error: {}", e),
         }
     }
 

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -467,7 +467,7 @@ impl EventLoop {
         match &event.result {
             Ok(connection_id) => {
                 info!(
-                    "{}({}) upgraded to direct connection",
+                    "Connection with {}({}) upgraded to direct connection",
                     event.remote_peer_id, connection_id
                 );
             }

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -324,7 +324,7 @@ impl EventLoop {
                 rendezvous_node,
                 ..
             } => {
-                if let Some(relay) = self.relays.get_mut(&rendezvous_node) {
+                if let Some(relay) = self.relays.get_mut(rendezvous_node) {
                     if !relay.registered {
                         debug!("Registered on rendezvous {rendezvous_node} in namespace \"{namespace}\"");
                         relay.registered = true;
@@ -376,7 +376,7 @@ impl EventLoop {
                 if let Some(addr) =
                     is_known_peer_address(&mut self.network_config.relay_addresses, listen_addrs)
                 {
-                    if self.relays.get(peer_id).is_some() {
+                    if self.relays.contains_key(peer_id) {
                         return;
                     }
 
@@ -447,7 +447,7 @@ impl EventLoop {
             relay::client::Event::ReservationReqAccepted { relay_peer_id, .. } => {
                 debug!("Relay {relay_peer_id} accepted circuit reservation request");
 
-                if let Some(relay) = self.relays.get_mut(&relay_peer_id) {
+                if let Some(relay) = self.relays.get_mut(relay_peer_id) {
                     relay.reservation_accepted = true;
                     // Attempt to start discovering peers at the configured namespace.
                     if relay.discover(&mut self.swarm) {
@@ -497,7 +497,7 @@ impl EventLoop {
                 );
 
                 // Remove this peer address from our known peers.
-                self.known_peers.remove(&endpoint.get_remote_address());
+                self.known_peers.remove(endpoint.get_remote_address());
             }
             event => trace!("{event:?}"),
         }

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::num::NonZeroU8;
 
-use libp2p::Multiaddr;
+use libp2p::swarm::dial_opts::DialOpts;
+use libp2p::{Multiaddr, PeerId, Swarm};
+use log::debug;
 use regex::Regex;
+
+use crate::network::behaviour::P2pandaBehaviour;
+use crate::network::config::PeerAddress;
 
 pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
     let hay = address.to_string();
@@ -21,4 +28,55 @@ pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
             Some(socket)
         }
     }
+}
+
+pub fn is_known_peer_address(
+    known_addresses: &mut Vec<PeerAddress>,
+    peer_addresses: &Vec<Multiaddr>,
+) -> Option<Multiaddr> {
+    for address in known_addresses.iter_mut() {
+        if let Ok(addr) = address.quic_multiaddr() {
+            if peer_addresses.contains(&addr) {
+                return Some(addr.clone());
+            }
+        }
+    }
+    None
+}
+
+pub fn dial_known_peer(
+    swarm: &mut Swarm<P2pandaBehaviour>,
+    known_peers: &mut HashMap<Multiaddr, PeerId>,
+    address: &mut PeerAddress,
+) {
+    // Get the peers quic multiaddress, this can error if the address was provided in the form
+    // of a domain name and we are not able to resolve it to a valid multiaddress (for example,
+    // if we are offline).
+    let address = match address.quic_multiaddr() {
+        Ok(address) => address,
+        Err(e) => {
+            debug!("Failed to resolve relay multiaddr: {}", e.to_string());
+            return;
+        }
+    };
+
+    // Construct dial opts depending on if we know the peer id of the peer we are dialing.
+    // We know the peer id if we have connected once to the peer in the current session.
+    let opts = match known_peers.get(&address) {
+        Some(peer_id) => DialOpts::peer_id(*peer_id)
+            .addresses(vec![address.to_owned()])
+            .override_dial_concurrency_factor(NonZeroU8::new(1).expect("Is nonzero u8"))
+            .build(),
+        None => DialOpts::unknown_peer_id()
+            .address(address.to_owned())
+            .build(),
+    };
+
+    // Dial the known peer. When dialing a peer by it's peer id this method will attempt a
+    // new connections if we are already connected to the peer or we are already dialing
+    // them.
+    match swarm.dial(opts) {
+        Ok(_) => (),
+        Err(err) => debug!("Error dialing node: {:?}", err),
+    };
 }

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -31,8 +31,8 @@ pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
 }
 
 pub fn is_known_peer_address(
-    known_addresses: &mut Vec<PeerAddress>,
-    peer_addresses: &Vec<Multiaddr>,
+    known_addresses: &mut [PeerAddress],
+    peer_addresses: &[Multiaddr],
 ) -> Option<Multiaddr> {
     for address in known_addresses.iter_mut() {
         if let Ok(addr) = address.quic_multiaddr() {

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -75,8 +75,5 @@ pub fn dial_known_peer(
     // Dial the known peer. When dialing a peer by it's peer id this method will attempt a
     // new connections if we are already connected to the peer or we are already dialing
     // them.
-    match swarm.dial(opts) {
-        Ok(_) => (),
-        Err(err) => debug!("Error dialing node: {:?}", err),
-    };
+    let _ = swarm.dial(opts);
 }


### PR DESCRIPTION
Before this PR a peer only registered on any configured relay nodes on startup in an initiation phase before the main networking event loop started. The main reason for this is that listening on the circuit relay would sometimes (quite often) fail and so we needed a retry loop which would timeout after x seconds. This pattern was clunky and not possible to fit into the event loop. It also meant that we had to disable the `Peers` behaviour, enable it, and then force connect again to the relay in order to trigger replication... ugh...

Since https://github.com/p2panda/aquadoggo/pull/631 listening on the circuit relay never seems to fail, and so moving all of the relay connection and registration logic into the main event loop is now possible (yay!). This unlocks some nicer patterns around handling relays and means we can dynamically register on relays during runtime. No disabling peers behaviour and secondary force connecting required.

- [x] introduce `Relay` struct for holding current state relating to relays and a node's registration on it
- [x] move relay dialing, namespace registration, circuit relay listening and initiating peer discovery into main event loop
- [x] revise connection limits now that things are more stable and observable
- [x] improve logging messages
- [x] bonus: depending on logging level either `println!(..)` or `info!(..)` startup info    

_check out these beautiful logs!!_

```
[2024-06-22T15:45:36Z INFO  aquadoggo::manager] Start materializer service
[2024-06-22T15:45:36Z INFO  aquadoggo::materializer::worker] Register reduce worker with pool size 16
[2024-06-22T15:45:36Z INFO  aquadoggo::materializer::worker] Register dependency worker with pool size 16
[2024-06-22T15:45:36Z INFO  aquadoggo::materializer::worker] Register schema worker with pool size 16
[2024-06-22T15:45:36Z INFO  aquadoggo::materializer::worker] Register blob worker with pool size 16
[2024-06-22T15:45:36Z INFO  aquadoggo::materializer::worker] Register garbage_collection worker with pool size 16
[2024-06-22T15:45:36Z DEBUG aquadoggo::materializer::service] Dispatch 0 pending tasks from last runtime
[2024-06-22T15:45:36Z DEBUG aquadoggo::materializer::service] Materialiser service is ready
[2024-06-22T15:45:36Z INFO  aquadoggo::manager] Start http service
[2024-06-22T15:45:36Z DEBUG aquadoggo::graphql::schema] Subscribing GraphQL manager to schema provider
[2024-06-22T15:45:36Z DEBUG aquadoggo::graphql::schema] Finished building initial GraphQL schema
[2024-06-22T15:45:36Z INFO  aquadoggo] HTTP port 2020 was already taken, try random port instead ..
[2024-06-22T15:45:36Z INFO  aquadoggo] Go to http://0.0.0.0:40723/graphql to use GraphQL playground
[2024-06-22T15:45:36Z DEBUG aquadoggo::http::service] HTTP service is ready
[2024-06-22T15:45:36Z INFO  aquadoggo::manager] Start network service
[2024-06-22T15:45:36Z INFO  aquadoggo] Peer id: 12D3KooWHNwGZBRLBQqiJsQD8xLy9JmPfJiSptRX8d15ftiVxLrJ
[2024-06-22T15:45:36Z INFO  aquadoggo::network::service] Networking service initializing...
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::behaviour] Identify network behaviour enabled
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::behaviour] Rendezvous client network behaviour enabled
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::behaviour] Relay client network behaviour enabled
[2024-06-22T15:45:36Z INFO  aquadoggo] QUIC port 2022 was already taken, try random port instead ..
[2024-06-22T15:45:36Z INFO  aquadoggo::network::service] Network service ready!
[2024-06-22T15:45:36Z INFO  aquadoggo::manager] Start replication service
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Dial relay at address 127.0.0.1:2022
[2024-06-22T15:45:36Z INFO  aquadoggo] Node is listening on 0.0.0.0:59137
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Connected to /ip4/127.0.0.1/udp/2022/quic-v1 (1/1)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::service] Established connection with peer: 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm (1)
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Relay identified 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm /ip4/127.0.0.1/udp/2022/quic-v1
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Told relay 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm its public address
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Registration request sent to relay 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Registered on rendezvous 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm in namespace "aquadoggo"
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Relay 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm accepted circuit reservation request
[2024-06-22T15:45:36Z INFO  aquadoggo::network::service] Discovering peers in namespace "aquadoggo" on relay 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Discovered 2 addresses for peer 12D3KooWHNwGZBRLBQqiJsQD8xLy9JmPfJiSptRX8d15ftiVxLrJ
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Discovered 2 addresses for peer 12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Dialed peer 12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Connected to /ip4/127.0.0.1/udp/2022/quic-v1/p2p/12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm/p2p-circuit/p2p/12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba (1/1)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::service] Established connection with peer: 12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba (2)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::manager] Initiate outbound replication session with peer 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm (1)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::service] Finished replication with peer 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm (1)
[2024-06-22T15:45:36Z DEBUG aquadoggo::network::service] Connected to /ip4/127.0.0.1/udp/55554/quic-v1/p2p/12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba (1/2)
[2024-06-22T15:45:36Z INFO  aquadoggo::network::service] Connection with 12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba(3) upgraded to direct connection
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::service] Established connection with peer: 12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba (3)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::manager] Initiate outbound replication session with peer 12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba (2)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::manager] Initiate outbound replication session with peer 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm (1)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::service] Finished replication with peer 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm (1)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::service] Finished replication with peer 12D3KooWJ5veLXRZ1zibpzMHFDfoPuFCMjKAUUHxWEsgQuyaFgba (2)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::manager] Accept inbound replication session with peer 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm (1)
[2024-06-22T15:45:36Z INFO  aquadoggo::replication::service] Finished replication with peer 12D3KooWK2KQ1BQHzsQDEsHdGfhndDTDJqdFjFgwTSjCQZRNJ3Jm (1)
```

## 📋 Checklist

- [x] ~Add tests that cover your changes~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
