### PR TITLE
Fix: handle connection ids greater than 9 in `Peer` impl of `Human` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed 
+
+- Handle connection ids greater than 9 in `Peer` impl of `Human` trait [#634](https://github.com/p2panda/aquadoggo/pull/634)
+
 ## [0.7.4]
 
 ### Added

--- a/aquadoggo/src/network/peers/peer.rs
+++ b/aquadoggo/src/network/peers/peer.rs
@@ -61,7 +61,7 @@ impl Human for Peer {
         // Trick to nicely display `ConnectionId` struct
         let connection_id = format!("{:?}", self.1);
         let connection_id = connection_id[13..]
-            .strip_suffix(")")
+            .strip_suffix(')')
             .expect("ConnectionId format is as expected");
         format!("{} ({})", self.0, connection_id)
     }
@@ -82,7 +82,10 @@ mod tests {
         assert_eq!(peer_connection_2.display(), format!("{} ({})", peer_id, 2));
 
         let peer_connection_23 = Peer::new(peer_id, ConnectionId::new_unchecked(23));
-        assert_eq!(peer_connection_23.display(), format!("{} ({})", peer_id, 23));
+        assert_eq!(
+            peer_connection_23.display(),
+            format!("{} ({})", peer_id, 23)
+        );
 
         let peer_connection_999 = Peer::new(peer_id, ConnectionId::new_unchecked(999));
         assert_eq!(

--- a/aquadoggo/src/network/peers/peer.rs
+++ b/aquadoggo/src/network/peers/peer.rs
@@ -59,7 +59,35 @@ impl PartialOrd for Peer {
 impl Human for Peer {
     fn display(&self) -> String {
         // Trick to nicely display `ConnectionId` struct
-        let connection_id = &format!("{:?}", self.1)[13..][..1];
+        let connection_id = format!("{:?}", self.1);
+        let connection_id = connection_id[13..]
+            .strip_suffix(")")
+            .expect("ConnectionId format is as expected");
         format!("{} ({})", self.0, connection_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::identity::Keypair;
+    use libp2p::swarm::ConnectionId;
+    use p2panda_rs::Human;
+
+    use super::Peer;
+
+    #[test]
+    fn peers_display() {
+        let peer_id = Keypair::generate_ed25519().public().to_peer_id();
+        let peer_connection_2 = Peer::new(peer_id, ConnectionId::new_unchecked(2));
+        assert_eq!(peer_connection_2.display(), format!("{} ({})", peer_id, 2));
+
+        let peer_connection_23 = Peer::new(peer_id, ConnectionId::new_unchecked(23));
+        assert_eq!(peer_connection_23.display(), format!("{} ({})", peer_id, 23));
+
+        let peer_connection_999 = Peer::new(peer_id, ConnectionId::new_unchecked(999));
+        assert_eq!(
+            peer_connection_999.display(),
+            format!("{} ({})", peer_id, 999)
+        );
     }
 }


### PR DESCRIPTION
closes: #633 

## 📋 Checklist

- [x] Add tests that cover your changes
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
