### PR TITLE
Support private net with pre-shared key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support private network secured by pre-shared key [#635](https://github.com/p2panda/aquadoggo/pull/635) 
+
 ### Changed
 
 - Update `libp2p` to version `0.53.2` and apply API changes [#631](https://github.com/p2panda/aquadoggo/pull/631)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
 ]
@@ -56,7 +56,7 @@ checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
 dependencies = [
  "aead",
  "aes",
- "cipher",
+ "cipher 0.3.0",
  "ctr",
  "ghash",
  "subtle",
@@ -173,6 +173,7 @@ dependencies = [
  "ctor",
  "deadqueue",
  "dynamic-graphql",
+ "either",
  "env_logger",
  "envy",
  "futures",
@@ -952,7 +953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
 ]
@@ -965,7 +966,7 @@ checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
  "aead",
  "chacha20",
- "cipher",
+ "cipher 0.3.0",
  "poly1305",
  "zeroize",
 ]
@@ -1004,6 +1005,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1236,7 +1247,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
@@ -1543,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encoding_rs"
@@ -2306,6 +2317,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2481,7 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-pnet",
  "libp2p-quic",
  "libp2p-relay",
  "libp2p-rendezvous",
@@ -2800,6 +2821,20 @@ dependencies = [
  "libp2p-identity",
  "quick-protobuf",
  "quick-protobuf-codec 0.2.0",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-pnet"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2dcb82113064b0baf0a3b92d30ad61211ff66fff02f2973b569b77b2d1811a"
+dependencies = [
+ "futures",
+ "pin-project",
+ "rand 0.8.5",
+ "salsa20",
+ "sha3",
  "tracing",
 ]
 
@@ -4414,6 +4449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4560,6 +4604,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -42,12 +42,13 @@ libp2p = { version = "0.53.2", features = [
     "macros",
     "mdns",
     "noise",
+    "quic",
     "relay",
     "rendezvous",
     "serde",
+    "tcp",
     "tokio",
     "yamux",
-    "quic",
 ] }
 lipmaa-link = "0.2.2"
 log = "0.4.19"

--- a/aquadoggo/Cargo.toml
+++ b/aquadoggo/Cargo.toml
@@ -33,6 +33,7 @@ deadqueue = { version = "0.2.3", default-features = false, features = [
     "unlimited",
 ] }
 dynamic-graphql = "0.7.3"
+either = "1.12.0"
 futures = "0.3.23"
 hex = "0.4.3"
 http = "0.2.9"
@@ -42,6 +43,7 @@ libp2p = { version = "0.53.2", features = [
     "macros",
     "mdns",
     "noise",
+    "pnet",
     "quic",
     "relay",
     "rendezvous",

--- a/aquadoggo/src/api/config_file.rs
+++ b/aquadoggo/src/api/config_file.rs
@@ -116,7 +116,7 @@ pub struct ConfigFile {
     #[serde(default = "default_http_port")]
     pub http_port: u16,
 
-    /// protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC.
+    /// Protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC.
     #[serde(default)]
     pub transport: Transport,
 

--- a/aquadoggo/src/api/config_file.rs
+++ b/aquadoggo/src/api/config_file.rs
@@ -21,7 +21,7 @@ const DEFAULT_MAX_DATABASE_CONNECTIONS: u32 = 32;
 
 const DEFAULT_HTTP_PORT: u16 = 2020;
 
-const DEFAULT_QUIC_PORT: u16 = 2022;
+const DEFAULT_NODE_PORT: u16 = 2022;
 
 const DEFAULT_WORKER_POOL_SIZE: u32 = 16;
 
@@ -41,8 +41,8 @@ fn default_http_port() -> u16 {
     DEFAULT_HTTP_PORT
 }
 
-fn default_quic_port() -> u16 {
-    DEFAULT_QUIC_PORT
+fn default_node_port() -> u16 {
+    DEFAULT_NODE_PORT
 }
 
 fn default_database_url() -> String {
@@ -116,9 +116,9 @@ pub struct ConfigFile {
     #[serde(default = "default_http_port")]
     pub http_port: u16,
 
-    /// QUIC port for node-node communication and data replication. Defaults to 2022.
-    #[serde(default = "default_quic_port")]
-    pub quic_port: u16,
+    /// TCP / QUIC port for node-node communication and data replication. Defaults to 2022.
+    #[serde(default = "default_node_port")]
+    pub node_port: u16,
 
     /// Path to folder where blobs (large binary files) are persisted. Defaults to a temporary
     /// directory.
@@ -219,7 +219,7 @@ impl Default for ConfigFile {
             database_url: default_database_url(),
             database_max_connections: default_max_database_connections(),
             http_port: default_http_port(),
-            quic_port: default_quic_port(),
+            node_port: default_node_port(),
             blobs_base_path: None,
             mdns: default_mdns(),
             private_key: None,
@@ -301,7 +301,7 @@ impl TryFrom<ConfigFile> for Configuration {
             blobs_base_path,
             worker_pool_size: value.worker_pool_size,
             network: NetworkConfiguration {
-                quic_port: value.quic_port,
+                port: value.node_port,
                 mdns: value.mdns,
                 direct_node_addresses,
                 allow_peer_ids,

--- a/aquadoggo/src/api/config_file.rs
+++ b/aquadoggo/src/api/config_file.rs
@@ -11,7 +11,7 @@ use p2panda_rs::schema::SchemaId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tempfile::TempDir;
 
-use crate::{AllowList, Configuration, NetworkConfiguration};
+use crate::{AllowList, Configuration, NetworkConfiguration, Transport};
 
 const WILDCARD: &str = "*";
 
@@ -116,6 +116,10 @@ pub struct ConfigFile {
     #[serde(default = "default_http_port")]
     pub http_port: u16,
 
+    /// protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC. 
+    #[serde(default)]
+    pub transport: Transport,
+
     /// TCP / QUIC port for node-node communication and data replication. Defaults to 2022.
     #[serde(default = "default_node_port")]
     pub node_port: u16,
@@ -214,6 +218,7 @@ pub struct ConfigFile {
 impl Default for ConfigFile {
     fn default() -> Self {
         Self {
+            transport: Transport::default(),
             log_level: default_log_level(),
             allow_schema_ids: UncheckedAllowList::default(),
             database_url: default_database_url(),
@@ -301,6 +306,7 @@ impl TryFrom<ConfigFile> for Configuration {
             blobs_base_path,
             worker_pool_size: value.worker_pool_size,
             network: NetworkConfiguration {
+                transport: value.transport,
                 port: value.node_port,
                 mdns: value.mdns,
                 direct_node_addresses,

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -36,7 +36,7 @@ use log::{info, log_enabled, Level};
 
 pub use crate::api::{ConfigFile, LockFile};
 pub use crate::config::{AllowList, Configuration};
-pub use crate::network::NetworkConfiguration;
+pub use crate::network::{NetworkConfiguration, Transport};
 pub use node::Node;
 
 /// Init env_logger before the test suite runs to handle logging outputs.

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use anyhow::Error;
 use libp2p::connection_limits::ConnectionLimits;
 use libp2p::multiaddr::Protocol;
+use libp2p::pnet::PreSharedKey;
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -17,8 +18,11 @@ pub const NODE_NAMESPACE: &str = "aquadoggo";
 /// Network config for the node.
 #[derive(Debug, Clone)]
 pub struct NetworkConfiguration {
-    /// protocol (TCP/QUIC) used for node-node communication and data replication. 
+    /// protocol (TCP/QUIC) used for node-node communication and data replication.
     pub transport: Transport,
+
+    /// Establish a private net secured by this pre-shared key.
+    pub psk: Option<PreSharedKey>,
 
     /// QUIC or TCP port for node-node communication and data replication.
     pub port: u16,
@@ -126,6 +130,7 @@ impl Default for NetworkConfiguration {
     fn default() -> Self {
         Self {
             transport: Transport::QUIC,
+            psk: None,
             port: 2022,
             mdns: true,
             direct_node_addresses: Vec::new(),
@@ -239,7 +244,7 @@ impl std::fmt::Display for PeerAddress {
 }
 
 /// Enum representing transport protocol types.
-#[derive(Debug, Clone, Copy, Default, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 pub enum Transport {
     #[default]
     /// UDP/QUIC transport protocol

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -18,7 +18,7 @@ pub const NODE_NAMESPACE: &str = "aquadoggo";
 /// Network config for the node.
 #[derive(Debug, Clone)]
 pub struct NetworkConfiguration {
-    /// protocol (TCP/QUIC) used for node-node communication and data replication.
+    /// Protocol (TCP/QUIC) used for node-node communication and data replication.
     pub transport: Transport,
 
     /// Pre-shared key formatted as a 64 digit hexadecimal string.

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -21,7 +21,12 @@ pub struct NetworkConfiguration {
     /// protocol (TCP/QUIC) used for node-node communication and data replication.
     pub transport: Transport,
 
-    /// Establish a private net secured by this pre-shared key.
+    /// Pre-shared key formatted as a 64 digit hexadecimal string.
+    ///
+    /// When provided a private network will be made with only peers knowing the psk being able
+    /// to form connections.
+    ///
+    /// WARNING: Private networks are only supported when using TCP for the transport layer.
     pub psk: Option<PreSharedKey>,
 
     /// QUIC or TCP port for node-node communication and data replication.

--- a/aquadoggo/src/network/config.rs
+++ b/aquadoggo/src/network/config.rs
@@ -15,8 +15,8 @@ pub const NODE_NAMESPACE: &str = "aquadoggo";
 /// Network config for the node.
 #[derive(Debug, Clone)]
 pub struct NetworkConfiguration {
-    /// QUIC port for node-node communication and data replication.
-    pub quic_port: u16,
+    /// QUIC or TCP port for node-node communication and data replication.
+    pub port: u16,
 
     /// Discover peers on the local network via mDNS (over IPv4 only, using port 5353).
     pub mdns: bool,
@@ -120,7 +120,7 @@ pub struct NetworkConfiguration {
 impl Default for NetworkConfiguration {
     fn default() -> Self {
         Self {
-            quic_port: 2022,
+            port: 2022,
             mdns: true,
             direct_node_addresses: Vec::new(),
             allow_peer_ids: AllowList::<PeerId>::Wildcard,

--- a/aquadoggo/src/network/mod.rs
+++ b/aquadoggo/src/network/mod.rs
@@ -10,7 +10,7 @@ mod shutdown;
 mod swarm;
 pub mod utils;
 
-pub use config::NetworkConfiguration;
+pub use config::{NetworkConfiguration, Transport};
 pub use peers::{Peer, PeerMessage};
 pub use service::network_service;
 pub use shutdown::ShutdownHandler;

--- a/aquadoggo/src/network/relay.rs
+++ b/aquadoggo/src/network/relay.rs
@@ -61,14 +61,12 @@ impl Relay {
             return Ok(false);
         }
 
-        self.registering = true;
-
         // Start listening on the circuit relay address.
         let circuit_address = self.circuit_addr();
         swarm.listen_on(circuit_address.clone())?;
 
         // Register in the `NODE_NAMESPACE` using the rendezvous network behaviour.
-        swarm
+        let result = swarm
             .behaviour_mut()
             .rendezvous_client
             .as_mut()
@@ -77,7 +75,11 @@ impl Relay {
                 rendezvous::Namespace::from_static(NODE_NAMESPACE),
                 self.peer_id,
                 None, // Default ttl is 7200s
-            )?;
+            );
+
+        // If register attempt failed switch registering flag back to false.
+        self.registering = result.is_ok();
+        result?;
 
         Ok(true)
     }

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -147,11 +147,8 @@ struct EventLoop {
     /// Shutdown handler.
     shutdown_handler: ShutdownHandler,
 
-    /// Did we learn our own QUIC port yet.
-    learned_quic_port: bool,
-
-    /// Did we learn our own TCP port yet.
-    learned_tcp_port: bool,
+    /// Did we learn our own port yet.
+    learned_port: bool,
 
     /// Did we learn our observed address yet.
     learned_observed_addr: bool,
@@ -175,8 +172,7 @@ impl EventLoop {
             known_peers: HashMap::new(),
             relays: HashMap::new(),
             shutdown_handler,
-            learned_quic_port: false,
-            learned_tcp_port: false,
+            learned_port: false,
             learned_observed_addr: false,
         }
     }
@@ -208,21 +204,21 @@ impl EventLoop {
                     let event = event.expect("Swarm stream to be infinite");
                     match event {
                         SwarmEvent::NewListenAddr { address, .. } => {
-                            if !self.learned_quic_port {
+                            if !self.learned_port {
                                 // Show only one QUIC address during the runtime of the node, otherwise
                                 // it might get too spammy
                                 if let Some(address) = utils::to_quic_address(&address) {
                                     info_or_print(&format!("Node is listening on 0.0.0.0:{} (QUIC)", address.port()));
-                                    self.learned_quic_port = true;
+                                    self.learned_port = true;
                                 }
                             }
 
-                            if !self.learned_tcp_port {
+                            if !self.learned_port {
                                 // Show only one TCP address during the runtime of the node, otherwise
                                 // it might get too spammy
                                 if let Some(address) = utils::to_tcp_address(&address) {
                                     info_or_print(&format!("Node is listening on 0.0.0.0:{} (TCP)", address.port()));
-                                    self.learned_tcp_port = true;
+                                    self.learned_port = true;
                                 }
                             }
                         }

--- a/aquadoggo/src/network/service.rs
+++ b/aquadoggo/src/network/service.rs
@@ -21,6 +21,7 @@ use crate::bus::{ServiceMessage, ServiceSender};
 use crate::context::Context;
 use crate::manager::{ServiceReadySender, Shutdown};
 use crate::network::behaviour::{Event, P2pandaBehaviour};
+use crate::network::config::Transport;
 use crate::network::relay::Relay;
 use crate::network::utils::{dial_known_peer, is_known_peer_address};
 use crate::network::{identity, peers, swarm, utils, ShutdownHandler};
@@ -60,40 +61,45 @@ pub async fn network_service(
         swarm::build_client_swarm(&network_config, key_pair).await?
     };
 
-    // Start listening on QUIC address. Pick a random one if the given is taken already.
-    let mut listen_addr_quic = Multiaddr::empty()
-        .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
-        .with(Protocol::Udp(network_config.port))
-        .with(Protocol::QuicV1);
-    if swarm.listen_on(listen_addr_quic.clone()).is_err() {
-        listen_addr_quic = Multiaddr::empty()
-            .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
-            .with(Protocol::Udp(0))
-            .with(Protocol::QuicV1);
+    match network_config.transport {
+        Transport::QUIC => {
+            // Start listening on QUIC address. Pick a random one if the given is taken already.
+            let mut listen_addr_quic = Multiaddr::empty()
+                .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
+                .with(Protocol::Udp(network_config.port))
+                .with(Protocol::QuicV1);
+            if swarm.listen_on(listen_addr_quic.clone()).is_err() {
+                info_or_print(&format!(
+                    "QUIC port {} was already taken, try random port instead ..",
+                    network_config.port
+                ));
 
-        info_or_print(&format!(
-            "QUIC port {} was already taken, try random port instead ..",
-            network_config.port
-        ));
+                listen_addr_quic = Multiaddr::empty()
+                    .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
+                    .with(Protocol::Udp(0))
+                    .with(Protocol::QuicV1);
 
-        swarm.listen_on(listen_addr_quic.clone())?;
-    }
+                swarm.listen_on(listen_addr_quic.clone())?;
+            }
+        }
+        Transport::TCP => {
+            // Start listening on TCP address. Pick a random one if the given is taken already.
+            let mut listen_address_tcp = Multiaddr::empty()
+                .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
+                .with(Protocol::Tcp(network_config.port));
+            if swarm.listen_on(listen_address_tcp.clone()).is_err() {
+                info_or_print(&format!(
+                    "TCP port {} was already taken, try random port instead ..",
+                    network_config.port
+                ));
 
-    // Start listening on TCP address. Pick a random one if the given is taken already.
-    let mut listen_address_tcp = Multiaddr::empty()
-        .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
-        .with(Protocol::Tcp(network_config.port));
-    if swarm.listen_on(listen_address_tcp.clone()).is_err() {
-        listen_address_tcp = Multiaddr::empty()
-            .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
-            .with(Protocol::Tcp(0));
+                listen_address_tcp = Multiaddr::empty()
+                    .with(Protocol::from(Ipv4Addr::UNSPECIFIED))
+                    .with(Protocol::Tcp(0));
 
-        info_or_print(&format!(
-            "TCP port {} was already taken, try random port instead ..",
-            network_config.port
-        ));
-
-        swarm.listen_on(listen_address_tcp.clone())?;
+                swarm.listen_on(listen_address_tcp.clone())?;
+            }
+        }
     }
 
     info!("Network service ready!");
@@ -255,13 +261,23 @@ impl EventLoop {
         // Attempt to dial all relay addresses.
         for relay_address in self.network_config.relay_addresses.iter_mut() {
             debug!("Dial relay at address {}", relay_address);
-            dial_known_peer(&mut self.swarm, &mut self.known_peers, relay_address);
+            dial_known_peer(
+                &mut self.swarm,
+                &mut self.known_peers,
+                relay_address,
+                self.network_config.transport,
+            );
         }
 
         // Attempt to dial all direct peer addresses.
         for direct_node_address in self.network_config.direct_node_addresses.iter_mut() {
             debug!("Dial direct peer at address {}", direct_node_address);
-            dial_known_peer(&mut self.swarm, &mut self.known_peers, direct_node_address);
+            dial_known_peer(
+                &mut self.swarm,
+                &mut self.known_peers,
+                direct_node_address,
+                self.network_config.transport,
+            );
         }
     }
 
@@ -372,12 +388,7 @@ impl EventLoop {
     async fn handle_identify_events(&mut self, event: &identify::Event) {
         match event {
             identify::Event::Received {
-                info:
-                    identify::Info {
-                        observed_addr,
-                        listen_addrs,
-                        ..
-                    },
+                info: identify::Info { observed_addr, .. },
                 peer_id,
             } => {
                 // We now learned at least one of our observed addr.
@@ -401,32 +412,22 @@ impl EventLoop {
                 // to avoid multiple connections being established to the same peer.
 
                 // Check if the identified peer is one of our configured relay addresses.
-                if let Some(addr) =
-                    is_known_peer_address(&mut self.network_config.relay_addresses, listen_addrs)
-                {
-                    if self.relays.contains_key(peer_id) {
+                if let Some(relay) = self.relays.get_mut(peer_id) {
+                    if !self.learned_observed_addr || !relay.told_addr {
                         return;
                     }
 
-                    // Add the relay to our known peers.
-                    debug!("Relay identified {peer_id} {addr}");
-                    self.known_peers.insert(addr.clone(), *peer_id);
-
-                    // Also add it to our map of identified relays.
-                    self.relays.insert(*peer_id, Relay::new(*peer_id, addr));
-                }
-
-                // Check if the identified peer is one of our direct node addresses.
-                if let Some(addr) = is_known_peer_address(
-                    &mut self.network_config.direct_node_addresses,
-                    listen_addrs,
-                ) {
-                    // Add the direct node to our known peers.
-                    debug!("Direct node identified {peer_id} {addr}");
-                    self.known_peers.insert(addr, *peer_id);
+                    // Attempt to register with the relay.
+                    match relay.register(&mut self.swarm) {
+                        Ok(registered) => {
+                            if registered {
+                                debug!("Registration request sent to relay {}", relay.peer_id)
+                            }
+                        }
+                        Err(e) => debug!("Error registering on relay: {}", e),
+                    };
                 }
             }
-
             identify::Event::Sent { peer_id } => {
                 if let Some(relay) = self.relays.get_mut(peer_id) {
                     if !relay.told_addr {
@@ -434,7 +435,12 @@ impl EventLoop {
                         relay.told_addr = true;
                     }
 
+                    if !self.learned_observed_addr || !relay.told_addr {
+                        return;
+                    }
+
                     // Attempt to register with the relay.
+                    debug!("Register on relay {}", relay.peer_id);
                     match relay.register(&mut self.swarm) {
                         Ok(registered) => {
                             if registered {
@@ -507,6 +513,7 @@ impl EventLoop {
             SwarmEvent::ConnectionEstablished {
                 endpoint,
                 num_established,
+                peer_id,
                 ..
             } => {
                 debug!(
@@ -514,6 +521,33 @@ impl EventLoop {
                     endpoint.get_remote_address(),
                     num_established
                 );
+
+                // Check if the connected peer is one of our relay addresses.
+                if let Some(addr) = is_known_peer_address(
+                    &mut self.network_config.relay_addresses,
+                    &[endpoint.get_remote_address().to_owned()],
+                    self.network_config.transport,
+                ) {
+                    if self.relays.contains_key(&peer_id) {
+                        return;
+                    }
+
+                    // Add the relay to our known peers.
+                    debug!("Relay identified {peer_id} {addr}");
+                    self.known_peers.insert(addr.clone(), peer_id);
+                    self.relays.insert(peer_id, Relay::new(peer_id, addr));
+                }
+
+                // Check if the connected peer is one of our direct node addresses.
+                if let Some(addr) = is_known_peer_address(
+                    &mut self.network_config.direct_node_addresses,
+                    &[endpoint.get_remote_address().to_owned()],
+                    self.network_config.transport,
+                ) {
+                    // Add the direct node to our known peers.
+                    debug!("Direct node identified {peer_id} {addr}");
+                    self.known_peers.insert(addr, peer_id);
+                }
             }
             SwarmEvent::ConnectionClosed {
                 peer_id,

--- a/aquadoggo/src/network/swarm.rs
+++ b/aquadoggo/src/network/swarm.rs
@@ -31,7 +31,7 @@ pub async fn build_client_swarm(
     let swarm = SwarmBuilder::with_existing_identity(key_pair)
         .with_tokio()
         .with_tcp(
-            tcp::Config::default().port_reuse(true).nodelay(true),
+            tcp::Config::default().nodelay(true),
             noise::Config::new,
             yamux::Config::default,
         )?

--- a/aquadoggo/src/network/swarm.rs
+++ b/aquadoggo/src/network/swarm.rs
@@ -1,45 +1,79 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use anyhow::Result;
+use either::Either;
+use libp2p::core::upgrade::Version;
 use libp2p::identity::Keypair;
-use libp2p::{noise, tcp, yamux, Swarm, SwarmBuilder};
+use libp2p::pnet::PnetConfig;
+use libp2p::{noise, tcp, yamux, Swarm, SwarmBuilder, Transport};
 
 use crate::network::behaviour::P2pandaBehaviour;
 use crate::network::NetworkConfiguration;
 
-pub async fn build_relay_swarm(
+pub fn build_tcp_swarm(
     network_config: &NetworkConfiguration,
     key_pair: Keypair,
 ) -> Result<Swarm<P2pandaBehaviour>> {
     let swarm = SwarmBuilder::with_existing_identity(key_pair)
         .with_tokio()
-        .with_tcp(
-            tcp::Config::default().nodelay(true),
-            noise::Config::new,
-            yamux::Config::default,
-        )?
-        .with_quic()
-        .with_behaviour(|key_pair| P2pandaBehaviour::new(network_config, key_pair, None).unwrap())?
-        .build();
+        .with_other_transport(|key| {
+            let noise_config = noise::Config::new(key).unwrap();
+            let yamux_config = yamux::Config::default();
+
+            let base_transport = tcp::tokio::Transport::new(tcp::Config::default().nodelay(true));
+            let maybe_encrypted = match network_config.psk {
+                Some(psk) => Either::Left(
+                    base_transport
+                        .and_then(move |socket, _| PnetConfig::new(psk).handshake(socket)),
+                ),
+                None => Either::Right(base_transport),
+            };
+            maybe_encrypted
+                .upgrade(Version::V1Lazy)
+                .authenticate(noise_config)
+                .multiplex(yamux_config)
+        })?;
+
+    let swarm = if !network_config.relay_mode && !network_config.relay_addresses.is_empty() {
+        swarm
+            .with_relay_client(noise::Config::new, yamux::Config::default)?
+            .with_behaviour(|key_pair, relay_client| {
+                P2pandaBehaviour::new(network_config, key_pair, Some(relay_client)).unwrap()
+            })?
+            .build()
+    } else {
+        swarm
+            .with_behaviour(|key_pair| {
+                P2pandaBehaviour::new(network_config, key_pair, None).unwrap()
+            })?
+            .build()
+    };
+
     Ok(swarm)
 }
 
-pub async fn build_client_swarm(
+pub fn build_quic_swarm(
     network_config: &NetworkConfiguration,
     key_pair: Keypair,
 ) -> Result<Swarm<P2pandaBehaviour>> {
     let swarm = SwarmBuilder::with_existing_identity(key_pair)
         .with_tokio()
-        .with_tcp(
-            tcp::Config::default().nodelay(true),
-            noise::Config::new,
-            yamux::Config::default,
-        )?
-        .with_quic()
-        .with_relay_client(noise::Config::new, yamux::Config::default)?
-        .with_behaviour(|key_pair, relay_client| {
-            P2pandaBehaviour::new(network_config, key_pair, Some(relay_client)).unwrap()
-        })?
-        .build();
+        .with_quic();
+
+    let swarm = if !network_config.relay_mode && !network_config.relay_addresses.is_empty() {
+        swarm
+            .with_relay_client(noise::Config::new, yamux::Config::default)?
+            .with_behaviour(|key_pair, relay_client| {
+                P2pandaBehaviour::new(network_config, key_pair, Some(relay_client)).unwrap()
+            })?
+            .build()
+    } else {
+        swarm
+            .with_behaviour(|key_pair| {
+                P2pandaBehaviour::new(network_config, key_pair, None).unwrap()
+            })?
+            .build()
+    };
+
     Ok(swarm)
 }

--- a/aquadoggo/src/network/swarm.rs
+++ b/aquadoggo/src/network/swarm.rs
@@ -14,7 +14,7 @@ pub async fn build_relay_swarm(
     let swarm = SwarmBuilder::with_existing_identity(key_pair)
         .with_tokio()
         .with_tcp(
-            tcp::Config::default().port_reuse(true).nodelay(true),
+            tcp::Config::default().nodelay(true),
             noise::Config::new,
             yamux::Config::default,
         )?

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -10,7 +10,7 @@ use log::debug;
 use regex::Regex;
 
 use crate::network::behaviour::P2pandaBehaviour;
-use crate::network::config::PeerAddress;
+use crate::network::config::{PeerAddress, Transport};
 
 pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
     let hay = address.to_string();
@@ -51,9 +51,15 @@ pub fn to_tcp_address(address: &Multiaddr) -> Option<SocketAddr> {
 pub fn is_known_peer_address(
     known_addresses: &mut [PeerAddress],
     peer_addresses: &[Multiaddr],
+    transport: Transport,
 ) -> Option<Multiaddr> {
     for address in known_addresses.iter_mut() {
-        if let Ok(addr) = address.quic_multiaddr() {
+        let address = match transport {
+            Transport::QUIC => address.quic_multiaddr(),
+            Transport::TCP => address.tcp_multiaddr(),
+        };
+
+        if let Ok(addr) = address {
             if peer_addresses.contains(&addr) {
                 return Some(addr.clone());
             }
@@ -66,11 +72,17 @@ pub fn dial_known_peer(
     swarm: &mut Swarm<P2pandaBehaviour>,
     known_peers: &mut HashMap<Multiaddr, PeerId>,
     address: &mut PeerAddress,
+    transport: Transport,
 ) {
-    // Get the peers quic multiaddress, this can error if the address was provided in the form
-    // of a domain name and we are not able to resolve it to a valid multiaddress (for example,
+    // Get the peers multiaddr, this can error if the address was provided in the form
+    // of a domain name and we are not able to resolve it to a valid address (for example,
     // if we are offline).
-    let address = match address.quic_multiaddr() {
+    let address = match transport {
+        Transport::QUIC => address.quic_multiaddr(),
+        Transport::TCP => address.tcp_multiaddr(),
+    };
+
+    let address = match address {
         Ok(address) => address,
         Err(e) => {
             debug!("Failed to resolve relay multiaddr: {}", e.to_string());

--- a/aquadoggo/src/network/utils.rs
+++ b/aquadoggo/src/network/utils.rs
@@ -30,6 +30,24 @@ pub fn to_quic_address(address: &Multiaddr) -> Option<SocketAddr> {
     }
 }
 
+pub fn to_tcp_address(address: &Multiaddr) -> Option<SocketAddr> {
+    let hay = address.to_string();
+    let regex = Regex::new(r"/ip4/(\d+.\d+.\d+.\d+)/tcp/(\d+)").unwrap();
+    let caps = regex.captures(&hay);
+
+    match caps {
+        None => None,
+        Some(caps) => {
+            let ip_address = caps.get(1).unwrap().as_str();
+            let port = caps.get(2).unwrap().as_str();
+            let socket = format!("{ip_address}:{port}")
+                .parse::<SocketAddr>()
+                .expect("Tried to convert invalid address");
+            Some(socket)
+        }
+    }
+}
+
 pub fn is_known_peer_address(
     known_addresses: &mut [PeerAddress],
     peer_addresses: &[Multiaddr],

--- a/aquadoggo_cli/README.md
+++ b/aquadoggo_cli/README.md
@@ -172,7 +172,7 @@ blobs_base_path = "$HOME/.local/share/aquadoggo/blobs"
 
 #### Private Network
 
-> "I want only peers who know a pre-shared key to be able to join my network."
+> "I want only peers who know a pre-shared key to be able to join my network." 
 
 ```sh
 # Generate a 64 digit hexadecimal string, for example on the command line like this
@@ -182,6 +182,8 @@ hexdump -vn64 -e'"%x"' /dev/urandom
 # Pass the pre-shared key to your node via environment variables or config file
 PSK=<PRE_SHARED_KEY> aquadoggo
 ```
+
+
 
 ### Configuration
 
@@ -197,53 +199,78 @@ Options:
   -c, --config <PATH>
           Path to an optional "config.toml" file for further configuration.
 
-          When not set the program will try to find a `config.toml` file in the same folder the program is executed in and otherwise in the regarding operation systems XDG config directory ("$HOME/.config/aquadoggo/config.toml" on Linux).
-
-          [env: CONFIG=]
+          When not set the program will try to find a `config.toml` file in the
+          same folder the program is executed in and otherwise in the regarding
+          operation systems XDG config directory
+          ("$HOME/.config/aquadoggo/config.toml" on Linux).
 
   -s, --allow-schema-ids [<SCHEMA_ID>...]
-          List of schema ids which a node will replicate, persist and expose on the GraphQL API. Separate multiple values with a whitespace. Defaults to allow _any_ schemas ("*").
+          List of schema ids which a node will replicate, persist and expose on
+          the GraphQL API. Separate multiple values with a whitespace. Defaults
+          to allow _any_ schemas ("*").
 
-          When allowing a schema you automatically opt into announcing, replicating and materializing documents connected to it, supporting applications and networks which are dependent on this data.
+          When allowing a schema you automatically opt into announcing,
+          replicating and materializing documents connected to it, supporting
+          applications and networks which are dependent on this data.
 
-          It is recommended to set this list to all schema ids your own application should support, including all important system schemas.
+          It is recommended to set this list to all schema ids your own
+          application should support, including all important system schemas.
 
-          WARNING: When set to wildcard "*", your node will support _any_ schemas it will encounter on the network. This is useful for experimentation and local development but _not_ recommended for production settings.
+          WARNING: When set to wildcard "*", your node will support _any_
+          schemas it will encounter on the network. This is useful for
+          experimentation and local development but _not_ recommended for
+          production settings.
 
   -d, --database-url <CONNECTION_STRING>
-          URL / connection string to PostgreSQL or SQLite database. Defaults to an in-memory SQLite database.
+          URL / connection string to PostgreSQL or SQLite database. Defaults to
+          an in-memory SQLite database.
 
-          WARNING: By default your node will not persist anything after shutdown. Set a database connection url for production settings to not loose data.
+          WARNING: By default your node will not persist anything after
+          shutdown. Set a database connection url for production settings to
+          not loose data.
 
   -p, --http-port <PORT>
-          HTTP port for client-node communication, serving the GraphQL API. Defaults to 2020
+          HTTP port for client-node communication, serving the GraphQL API.
+          Defaults to 2020
 
   -q, --transport <TRANSPORT>
-          Protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC
+          Protocol (TCP/QUIC) used for node-node communication and data 
+          replication. Defaults to QUIC
 
   -t, --node-port <PORT>
-          QUIC port for node-node communication and data replication. Defaults to 2022
+          QUIC port for node-node communication and data replication. Defaults
+          to 2022
 
   -y, --psk <PSK>
           Pre-shared key formatted as a 64 digit hexadecimal string.
+          
+          When provided a private network will be made with only peers knowing 
+          the psk being able to form connections.
+          
+          WARNING: Private networks are only supported when using TCP for the 
+          transport layer.
 
-          When provided a private network will be made with only peers knowing the psk being able to form connections.
-
-          WARNING: Private networks are only supported when using TCP for the transport layer.
 
   -f, --blobs-base-path <PATH>
-          Path to folder where blobs (large binary files) are persisted. Defaults to a temporary directory.
+          Path to folder where blobs (large binary files) are persisted.
+          Defaults to a temporary directory.
 
-          WARNING: By default your node will not persist any blobs after shutdown. Set a path for production settings to not loose data.
+          WARNING: By default your node will not persist any blobs after
+          shutdown. Set a path for production settings to not loose data.
 
   -k, --private-key <PATH>
-          Path to persist your ed25519 private key file. Defaults to an ephemeral key only for this current session.
+          Path to persist your ed25519 private key file. Defaults to an
+          ephemeral key only for this current session.
 
-          The key is used to identify you towards other nodes during network discovery and replication. This key is _not_ used to create and sign data.
+          The key is used to identify you towards other nodes during network
+          discovery and replication. This key is _not_ used to create and sign
+          data.
 
-          If a path is set, a key will be generated newly and stored under this path when node starts for the first time.
+          If a path is set, a key will be generated newly and stored under this
+          path when node starts for the first time.
 
-          When no path is set, your node will generate an ephemeral private key on every start up and _not_ persist it.
+          When no path is set, your node will generate an ephemeral private key
+          on every start up and _not_ persist it.
 
   -m, --mdns [<BOOL>]
           mDNS to discover other peers on the local network. Enabled by default
@@ -253,48 +280,74 @@ Options:
   -n, --direct-node-addresses [<IP:PORT>...]
           List of known node addresses we want to connect to directly.
 
-          Make sure that nodes mentioned in this list are directly reachable (they need to be hosted with a static IP Address). If you need to connect to nodes with changing, dynamic IP addresses or even with nodes behind a firewall or NAT, do not use this field but use at least one relay.
+          Make sure that nodes mentioned in this list are directly reachable
+          (they need to be hosted with a static IP Address). If you need to
+          connect to nodes with changing, dynamic IP addresses or even with
+          nodes behind a firewall or NAT, do not use this field but use at
+          least one relay.
 
   -a, --allow-peer-ids [<PEER_ID>...]
           List of peers which are allowed to connect to your node.
 
-          If set then only nodes (identified by their peer id) contained in this list will be able to connect to your node (via a relay or directly). When not set any other node can connect to yours.
+          If set then only nodes (identified by their peer id) contained in
+          this list will be able to connect to your node (via a relay or
+          directly). When not set any other node can connect to yours.
 
-          Peer IDs identify nodes by using their hashed public keys. They do _not_ represent authored data from clients and are only used to authenticate nodes towards each other during networking.
+          Peer IDs identify nodes by using their hashed public keys. They do
+          _not_ represent authored data from clients and are only used to
+          authenticate nodes towards each other during networking.
 
-          Use this list for example for setups where the identifier of the nodes you want to form a network with is known but you still need to use relays as their IP addresses change dynamically.
+          Use this list for example for setups where the identifier of the
+          nodes you want to form a network with is known but you still need to
+          use relays as their IP addresses change dynamically.
 
   -b, --block-peer-ids [<PEER_ID>...]
           List of peers which will be blocked from connecting to your node.
 
-          If set then any peers (identified by their peer id) contained in this list will be blocked from connecting to your node (via a relay or directly). When an empty list is provided then there are no restrictions on which nodes can connect to yours.
+          If set then any peers (identified by their peer id) contained in this
+          list will be blocked from connecting to your node (via a relay or
+          directly). When an empty list is provided then there are no
+          restrictions on which nodes can connect to yours.
 
-          Block lists and allow lists are exclusive, which means that you should _either_ use a block list _or_ an allow list depending on your setup.
+          Block lists and allow lists are exclusive, which means that you
+          should _either_ use a block list _or_ an allow list depending on your
+          setup.
 
-          Use this list for example if you want to allow _any_ node to connect to yours _except_ of a known number of excluded nodes.
+          Use this list for example if you want to allow _any_ node to connect
+          to yours _except_ of a known number of excluded nodes.
 
   -r, --relay-addresses [<IP:PORT>...]
           List of relay addresses.
 
-          A relay helps discover other nodes on the internet (also known as "rendesvouz" or "bootstrap" server) and helps establishing direct p2p connections when node is behind a firewall or NAT (also known as "holepunching").
+          A relay helps discover other nodes on the internet (also known as
+          "rendesvouz" or "bootstrap" server) and helps establishing direct p2p
+          connections when node is behind a firewall or NAT (also known as
+          "holepunching").
 
-          WARNING: This will potentially expose your IP address on the network. Do only connect to trusted relays or make sure your IP address is hidden via a VPN or proxy if you're concerned about leaking your IP.
+          WARNING: This will potentially expose your IP address on the network.
+          Do only connect to trusted relays or make sure your IP address is
+          hidden via a VPN or proxy if you're concerned about leaking your IP.
 
   -e, --relay-mode [<BOOL>]
           Enable if node should also function as a relay. Disabled by default.
 
           Other nodes can use relays to aid discovery and establishing connectivity.
 
-          Relays _need_ to be hosted in a way where they can be reached directly, for example with a static IP address through an VPS.
+          Relays _need_ to be hosted in a way where they can be reached
+          directly, for example with a static IP address through an VPS.
 
           [possible values: true, false]
 
   -l, --log-level <LEVEL>
-          Set log verbosity. Use this for learning more about how your node behaves or for debugging.
+          Set log verbosity. Use this for learning more about how your node
+          behaves or for debugging.
 
-          Possible log levels are: ERROR, WARN, INFO, DEBUG, TRACE. They are scoped to "aquadoggo" by default.
+          Possible log levels are: ERROR, WARN, INFO, DEBUG, TRACE. They are
+          scoped to "aquadoggo" by default.
 
-          If you want to adjust the scope for deeper inspection use a filter value, for example "=TRACE" for logging _everything_ or "aquadoggo=INFO,libp2p=DEBUG" etc.
+          If you want to adjust the scope for deeper inspection use a filter
+          value, for example "=TRACE" for logging _everything_ or
+          "aquadoggo=INFO,libp2p=DEBUG" etc.
 
   -h, --help
           Print help (see a summary with '-h')
@@ -326,9 +379,9 @@ GNU Affero General Public License v3.0 [`AGPL-3.0-or-later`](LICENSE)
 <img src="https://raw.githubusercontent.com/p2panda/.github/main/assets/nlnet-logo.svg" width="auto" height="80px"><br />
 <img src="https://raw.githubusercontent.com/p2panda/.github/main/assets/eu-flag-logo.png" width="auto" height="80px">
 
-_This project has received funding from the European Union’s Horizon 2020
+*This project has received funding from the European Union’s Horizon 2020
 research and innovation programme within the framework of the NGI-POINTER
-Project funded under grant agreement No 871528 and NGI-ASSURE No 957073_
+Project funded under grant agreement No 871528 and NGI-ASSURE No 957073*
 
 [`config.toml`]: config.toml
 [`p2panda`]: https://p2panda.org

--- a/aquadoggo_cli/README.md
+++ b/aquadoggo_cli/README.md
@@ -170,6 +170,19 @@ database_url = "sqlite:$HOME/.local/share/aquadoggo/db.sqlite3"
 blobs_base_path = "$HOME/.local/share/aquadoggo/blobs"
 ```
 
+#### Private Network
+
+> "I want only peers who know a pre-shared key to be able to join my network."
+
+```sh
+# Generate a 64 digit hexadecimal string, for example on the command line like this
+hexdump -vn64 -e'"%x"' /dev/urandom
+# => <PRE_SHARED_KEY>
+
+# Pass the pre-shared key to your node via environment variables or config file
+PSK=<PRE_SHARED_KEY> aquadoggo
+```
+
 ### Configuration
 
 Check out the [`config.toml`] file for all configurations and documentation or
@@ -184,64 +197,53 @@ Options:
   -c, --config <PATH>
           Path to an optional "config.toml" file for further configuration.
 
-          When not set the program will try to find a `config.toml` file in the
-          same folder the program is executed in and otherwise in the regarding
-          operation systems XDG config directory
-          ("$HOME/.config/aquadoggo/config.toml" on Linux).
+          When not set the program will try to find a `config.toml` file in the same folder the program is executed in and otherwise in the regarding operation systems XDG config directory ("$HOME/.config/aquadoggo/config.toml" on Linux).
+
+          [env: CONFIG=]
 
   -s, --allow-schema-ids [<SCHEMA_ID>...]
-          List of schema ids which a node will replicate, persist and expose on
-          the GraphQL API. Separate multiple values with a whitespace. Defaults
-          to allow _any_ schemas ("*").
+          List of schema ids which a node will replicate, persist and expose on the GraphQL API. Separate multiple values with a whitespace. Defaults to allow _any_ schemas ("*").
 
-          When allowing a schema you automatically opt into announcing,
-          replicating and materializing documents connected to it, supporting
-          applications and networks which are dependent on this data.
+          When allowing a schema you automatically opt into announcing, replicating and materializing documents connected to it, supporting applications and networks which are dependent on this data.
 
-          It is recommended to set this list to all schema ids your own
-          application should support, including all important system schemas.
+          It is recommended to set this list to all schema ids your own application should support, including all important system schemas.
 
-          WARNING: When set to wildcard "*", your node will support _any_
-          schemas it will encounter on the network. This is useful for
-          experimentation and local development but _not_ recommended for
-          production settings.
+          WARNING: When set to wildcard "*", your node will support _any_ schemas it will encounter on the network. This is useful for experimentation and local development but _not_ recommended for production settings.
 
   -d, --database-url <CONNECTION_STRING>
-          URL / connection string to PostgreSQL or SQLite database. Defaults to
-          an in-memory SQLite database.
+          URL / connection string to PostgreSQL or SQLite database. Defaults to an in-memory SQLite database.
 
-          WARNING: By default your node will not persist anything after
-          shutdown. Set a database connection url for production settings to
-          not loose data.
+          WARNING: By default your node will not persist anything after shutdown. Set a database connection url for production settings to not loose data.
 
   -p, --http-port <PORT>
-          HTTP port for client-node communication, serving the GraphQL API.
-          Defaults to 2020
+          HTTP port for client-node communication, serving the GraphQL API. Defaults to 2020
 
-  -q, --quic-port <PORT>
-          QUIC port for node-node communication and data replication. Defaults
-          to 2022
+  -q, --transport <TRANSPORT>
+          Protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC
+
+  -t, --node-port <PORT>
+          QUIC port for node-node communication and data replication. Defaults to 2022
+
+  -y, --psk <PSK>
+          Pre-shared key formatted as a 64 digit hexadecimal string.
+
+          When provided a private network will be made with only peers knowing the psk being able to form connections.
+
+          WARNING: Private networks are only supported when using TCP for the transport layer.
 
   -f, --blobs-base-path <PATH>
-          Path to folder where blobs (large binary files) are persisted.
-          Defaults to a temporary directory.
+          Path to folder where blobs (large binary files) are persisted. Defaults to a temporary directory.
 
-          WARNING: By default your node will not persist any blobs after
-          shutdown. Set a path for production settings to not loose data.
+          WARNING: By default your node will not persist any blobs after shutdown. Set a path for production settings to not loose data.
 
   -k, --private-key <PATH>
-          Path to persist your ed25519 private key file. Defaults to an
-          ephemeral key only for this current session.
+          Path to persist your ed25519 private key file. Defaults to an ephemeral key only for this current session.
 
-          The key is used to identify you towards other nodes during network
-          discovery and replication. This key is _not_ used to create and sign
-          data.
+          The key is used to identify you towards other nodes during network discovery and replication. This key is _not_ used to create and sign data.
 
-          If a path is set, a key will be generated newly and stored under this
-          path when node starts for the first time.
+          If a path is set, a key will be generated newly and stored under this path when node starts for the first time.
 
-          When no path is set, your node will generate an ephemeral private key
-          on every start up and _not_ persist it.
+          When no path is set, your node will generate an ephemeral private key on every start up and _not_ persist it.
 
   -m, --mdns [<BOOL>]
           mDNS to discover other peers on the local network. Enabled by default
@@ -251,74 +253,48 @@ Options:
   -n, --direct-node-addresses [<IP:PORT>...]
           List of known node addresses we want to connect to directly.
 
-          Make sure that nodes mentioned in this list are directly reachable
-          (they need to be hosted with a static IP Address). If you need to
-          connect to nodes with changing, dynamic IP addresses or even with
-          nodes behind a firewall or NAT, do not use this field but use at
-          least one relay.
+          Make sure that nodes mentioned in this list are directly reachable (they need to be hosted with a static IP Address). If you need to connect to nodes with changing, dynamic IP addresses or even with nodes behind a firewall or NAT, do not use this field but use at least one relay.
 
   -a, --allow-peer-ids [<PEER_ID>...]
           List of peers which are allowed to connect to your node.
 
-          If set then only nodes (identified by their peer id) contained in
-          this list will be able to connect to your node (via a relay or
-          directly). When not set any other node can connect to yours.
+          If set then only nodes (identified by their peer id) contained in this list will be able to connect to your node (via a relay or directly). When not set any other node can connect to yours.
 
-          Peer IDs identify nodes by using their hashed public keys. They do
-          _not_ represent authored data from clients and are only used to
-          authenticate nodes towards each other during networking.
+          Peer IDs identify nodes by using their hashed public keys. They do _not_ represent authored data from clients and are only used to authenticate nodes towards each other during networking.
 
-          Use this list for example for setups where the identifier of the
-          nodes you want to form a network with is known but you still need to
-          use relays as their IP addresses change dynamically.
+          Use this list for example for setups where the identifier of the nodes you want to form a network with is known but you still need to use relays as their IP addresses change dynamically.
 
   -b, --block-peer-ids [<PEER_ID>...]
           List of peers which will be blocked from connecting to your node.
 
-          If set then any peers (identified by their peer id) contained in this
-          list will be blocked from connecting to your node (via a relay or
-          directly). When an empty list is provided then there are no
-          restrictions on which nodes can connect to yours.
+          If set then any peers (identified by their peer id) contained in this list will be blocked from connecting to your node (via a relay or directly). When an empty list is provided then there are no restrictions on which nodes can connect to yours.
 
-          Block lists and allow lists are exclusive, which means that you
-          should _either_ use a block list _or_ an allow list depending on your
-          setup.
+          Block lists and allow lists are exclusive, which means that you should _either_ use a block list _or_ an allow list depending on your setup.
 
-          Use this list for example if you want to allow _any_ node to connect
-          to yours _except_ of a known number of excluded nodes.
+          Use this list for example if you want to allow _any_ node to connect to yours _except_ of a known number of excluded nodes.
 
   -r, --relay-addresses [<IP:PORT>...]
           List of relay addresses.
 
-          A relay helps discover other nodes on the internet (also known as
-          "rendesvouz" or "bootstrap" server) and helps establishing direct p2p
-          connections when node is behind a firewall or NAT (also known as
-          "holepunching").
+          A relay helps discover other nodes on the internet (also known as "rendesvouz" or "bootstrap" server) and helps establishing direct p2p connections when node is behind a firewall or NAT (also known as "holepunching").
 
-          WARNING: This will potentially expose your IP address on the network.
-          Do only connect to trusted relays or make sure your IP address is
-          hidden via a VPN or proxy if you're concerned about leaking your IP.
+          WARNING: This will potentially expose your IP address on the network. Do only connect to trusted relays or make sure your IP address is hidden via a VPN or proxy if you're concerned about leaking your IP.
 
   -e, --relay-mode [<BOOL>]
           Enable if node should also function as a relay. Disabled by default.
 
           Other nodes can use relays to aid discovery and establishing connectivity.
 
-          Relays _need_ to be hosted in a way where they can be reached
-          directly, for example with a static IP address through an VPS.
+          Relays _need_ to be hosted in a way where they can be reached directly, for example with a static IP address through an VPS.
 
           [possible values: true, false]
 
   -l, --log-level <LEVEL>
-          Set log verbosity. Use this for learning more about how your node
-          behaves or for debugging.
+          Set log verbosity. Use this for learning more about how your node behaves or for debugging.
 
-          Possible log levels are: ERROR, WARN, INFO, DEBUG, TRACE. They are
-          scoped to "aquadoggo" by default.
+          Possible log levels are: ERROR, WARN, INFO, DEBUG, TRACE. They are scoped to "aquadoggo" by default.
 
-          If you want to adjust the scope for deeper inspection use a filter
-          value, for example "=TRACE" for logging _everything_ or
-          "aquadoggo=INFO,libp2p=DEBUG" etc.
+          If you want to adjust the scope for deeper inspection use a filter value, for example "=TRACE" for logging _everything_ or "aquadoggo=INFO,libp2p=DEBUG" etc.
 
   -h, --help
           Print help (see a summary with '-h')
@@ -350,9 +326,9 @@ GNU Affero General Public License v3.0 [`AGPL-3.0-or-later`](LICENSE)
 <img src="https://raw.githubusercontent.com/p2panda/.github/main/assets/nlnet-logo.svg" width="auto" height="80px"><br />
 <img src="https://raw.githubusercontent.com/p2panda/.github/main/assets/eu-flag-logo.png" width="auto" height="80px">
 
-*This project has received funding from the European Union’s Horizon 2020
+_This project has received funding from the European Union’s Horizon 2020
 research and innovation programme within the framework of the NGI-POINTER
-Project funded under grant agreement No 871528 and NGI-ASSURE No 957073*
+Project funded under grant agreement No 871528 and NGI-ASSURE No 957073_
 
 [`config.toml`]: config.toml
 [`p2panda`]: https://p2panda.org

--- a/aquadoggo_cli/config.toml
+++ b/aquadoggo_cli/config.toml
@@ -92,11 +92,11 @@ database_max_connections = 32
 #
 http_port = 2020
 
-# QUIC port for node-node communication and data replication. Defaults to 2022.
+# Port for node-node communication and data replication. Defaults to 2022.
 #
 # When port is taken the node will automatically pick a random, free port.
 #
-quic_port = 2022
+node_port = 2022
 
 # ﾟ･｡+☆
 # BLOBS

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -112,10 +112,15 @@ struct Cli {
     #[serde(skip_serializing_if = "Option::is_none")]
     http_port: Option<u16>,
 
-    /// QUIC port for node-node communication and data replication. Defaults to 2022.
-    #[arg(short = 'q', long, value_name = "PORT")]
+    /// protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC. 
+    #[arg(short = 'q', long, value_name = "TRANSPORT")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    quic_port: Option<u16>,
+    pub transport: Option<String>,
+
+    /// QUIC port for node-node communication and data replication. Defaults to 2022.
+    #[arg(short = 't', long, value_name = "PORT")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    node_port: Option<u16>,
 
     /// Path to folder where blobs (large binary files) are persisted. Defaults to a temporary
     /// directory.

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -112,7 +112,7 @@ struct Cli {
     #[serde(skip_serializing_if = "Option::is_none")]
     http_port: Option<u16>,
 
-    /// protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC.
+    /// Protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC.
     #[arg(short = 'q', long, value_name = "TRANSPORT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transport: Option<String>,

--- a/aquadoggo_cli/src/config.rs
+++ b/aquadoggo_cli/src/config.rs
@@ -112,7 +112,7 @@ struct Cli {
     #[serde(skip_serializing_if = "Option::is_none")]
     http_port: Option<u16>,
 
-    /// protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC. 
+    /// protocol (TCP/QUIC) used for node-node communication and data replication. Defaults to QUIC.
     #[arg(short = 'q', long, value_name = "TRANSPORT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transport: Option<String>,
@@ -121,6 +121,16 @@ struct Cli {
     #[arg(short = 't', long, value_name = "PORT")]
     #[serde(skip_serializing_if = "Option::is_none")]
     node_port: Option<u16>,
+
+    /// Pre-shared key formatted as a 64 digit hexadecimal string.
+    ///
+    /// When provided a private network will be made with only peers knowing the psk being able
+    /// to form connections.
+    ///
+    /// WARNING: Private networks are only supported when using TCP for the transport layer.
+    #[arg(short = 'y', long, value_name = "PSK")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub psk: Option<String>,
 
     /// Path to folder where blobs (large binary files) are persisted. Defaults to a temporary
     /// directory.
@@ -381,12 +391,19 @@ pub fn print_config(
         "disabled"
     };
 
+    let pnet = if config.network.psk.is_some() {
+        "enabled"
+    } else {
+        "disabled"
+    };
+
     format!(
         r"Allow schema IDs: {}
 Database URL: {}
 mDNS: {}
 Private key: {}
 Relay mode: {}
+Private Net: {}
 
 Node is ready!
 ",
@@ -395,5 +412,6 @@ Node is ready!
         mdns.blue(),
         private_key.blue(),
         relay_mode.blue(),
+        pnet.blue()
     )
 }

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -8,7 +8,7 @@ use std::convert::TryInto;
 use std::str::FromStr;
 
 use anyhow::Context;
-use aquadoggo::{AllowList, Configuration, Node};
+use aquadoggo::{AllowList, Configuration, Node, Transport};
 use env_logger::WriteStyle;
 use log::{warn, LevelFilter};
 
@@ -73,6 +73,13 @@ async fn main() -> anyhow::Result<()> {
 
 /// Show some hopefully helpful warnings around common configuration issues.
 fn show_warnings(config: &Configuration, is_temporary_blobs_path: bool) {
+    if config.network.psk.is_some() && config.network.transport == Transport::QUIC {
+        warn!(
+            "Your node is configured with a pre-shared key and uses QUIC transport. Private 
+            nets are not supported when using QUIC therefore TCP will be enforced. "
+        );
+    }
+
     match &config.allow_schema_ids {
         AllowList::Set(values) => {
             if values.is_empty() && !config.network.relay_mode {


### PR DESCRIPTION
Implement private network secured via a pre-shared key using libp2p [pnet](https://github.com/libp2p/rust-libp2p/tree/master/transports/pnet]. When in "private net" mode a node will only accept connections with peers after verifying they know the same pre-shared key. `pnet` itself is a transport through which a connection is (in libp2p terms) "upgraded". 

It is only possible to run a private net when using TLC as the base transport (QUIC not supported) and so if a pre-shared key is provided the node is forced into using TLC regardless of other configurations.

- [x] introduce `pnet` network behaviour
- [x] accept pre-shared key in configuration file and via cli
- [x] force TLC when pre-shared key provided
- [x] log warnings if QUIC transport was requested  
- [ ] network tests: _i tried to write some simple network tests but it doesn't seem possible without introducing a new swarm just for testing, I believe "memory" multiaddr would need to be supported in our core `P2pandaBehaviour`. This would require some additional exploration and as we're using pnet in it's basic setup (which is tested on the libp2p side) it seems ok to me that there are no tests in this place_   

## 📋 Checklist

- [x] ~Add tests that cover your changes~ (see above)
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
