### PR TITLE
Safely handle missing document when retrieving document view from store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle connection ids greater than 9 in `Peer` impl of `Human` trait [#634](https://github.com/p2panda/aquadoggo/pull/634)
 - Check if blob file exists before deleting it from fs [#636](https://github.com/p2panda/aquadoggo/pull/636)
 - Inconsistent blob storage warning was wrongly shown [#638](https://github.com/p2panda/aquadoggo/pull/638)
+- Safely handle missing document when retrieving document view from store [#637](https://github.com/p2panda/aquadoggo/pull/637)
 
 ## [0.7.4]
 


### PR DESCRIPTION
This should account for a race-condition where a document view id was requested while the document itself was already deleted.

Closes: https://github.com/p2panda/aquadoggo/issues/630

## 📋 Checklist

- ~~Add tests that cover your changes~~
- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] Link this PR to any issues it closes
- [x] New files contain a SPDX license header
