### PR TITLE
Inconsistent blob storage warning was wrongly shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Handle connection ids greater than 9 in `Peer` impl of `Human` trait [#634](https://github.com/p2panda/aquadoggo/pull/634)
 - Check if blob file exists before deleting it from fs [#636](https://github.com/p2panda/aquadoggo/pull/636)
+- Inconsistent blob storage warning was wrongly shown [#638](https://github.com/p2panda/aquadoggo/pull/638)
 
 ## [0.7.4]
 

--- a/aquadoggo_cli/src/main.rs
+++ b/aquadoggo_cli/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> anyhow::Result<()> {
 fn show_warnings(config: &Configuration, is_temporary_blobs_path: bool) {
     if config.network.psk.is_some() && config.network.transport == Transport::QUIC {
         warn!(
-            "Your node is configured with a pre-shared key and uses QUIC transport. Private 
+            "Your node is configured with a pre-shared key and uses QUIC transport. Private
             nets are not supported when using QUIC therefore TCP will be enforced. "
         );
     }
@@ -103,7 +103,10 @@ fn show_warnings(config: &Configuration, is_temporary_blobs_path: bool) {
         warn!("Will not connect to given relay addresses when relay mode is enabled.");
     }
 
-    if config.database_url != "sqlite::memory:" && is_temporary_blobs_path {
+    let is_temporary_database =
+        config.database_url == "sqlite::memory:" || config.database_url.contains("mode=memory");
+
+    if !is_temporary_database && is_temporary_blobs_path {
         warn!(
             "Your database is persisted but blobs _are not_ which might result in unrecoverable
         data inconsistency (blob operations are stored but the files themselves are _not_). It is


### PR DESCRIPTION
Minor fix where this warning was shown even though the database _was_ temporary (stored in memory):

> [2024-06-26T09:39:24Z WARN  aquadoggo] Your database is persisted but blobs _are not_ which might result in unrecoverable data inconsistency (blob operations are stored but the files themselves are _not_). It is recommended to either set both values (`database_url` and `blobs_base_path`) to an temporary value or set both to persist all data.