### PR TITLE
Expose NodeEvent to public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Expose NodeEvent to public API [#643](https://github.com/p2panda/aquadoggo/pull/643)
+
 ## [0.8.0]
 
 ### Added

--- a/aquadoggo/src/api/api.rs
+++ b/aquadoggo/src/api/api.rs
@@ -7,9 +7,13 @@ use crate::api::{migrate, LockFile};
 use crate::bus::{ServiceMessage, ServiceSender};
 use crate::context::Context;
 
+/// Node events which can be interesting for clients, for example when peers connect or disconnect.
 #[derive(Debug, Clone)]
 pub enum NodeEvent {
+    /// A peer connected to our node. This can be a direct or relayed connection.
     PeerConnected,
+
+    /// A peer disconnected from our node.
     PeerDisconnected,
 }
 

--- a/aquadoggo/src/lib.rs
+++ b/aquadoggo/src/lib.rs
@@ -34,7 +34,7 @@ mod tests;
 
 use log::{info, log_enabled, Level};
 
-pub use crate::api::{ConfigFile, LockFile};
+pub use crate::api::{ConfigFile, LockFile, NodeEvent};
 pub use crate::config::{AllowList, Configuration};
 pub use crate::network::{NetworkConfiguration, Transport};
 pub use node::Node;


### PR DESCRIPTION
Last step required to actually make the new node event subscription API useful.

## 📋 Checklist

- [x] Add this PR to the _Unreleased_ section in `CHANGELOG.md`
- [x] New files contain a SPDX license header
